### PR TITLE
fix in sortcheck_app

### DIFF
--- a/external/fixpoint/ast.ml
+++ b/external/fixpoint/ast.ml
@@ -1116,7 +1116,7 @@ and sortcheck_app_sub g f so_expected uf es =
                 if List.length e_ts <> List.length i_ts then 
                   None 
                 else
-                  match Sort.unify i_ts e_ts with
+                  match Sort.unify e_ts i_ts with
                     | None   -> None
                     | Some s ->
                         let t = Sort.apply s o_t in


### PR DESCRIPTION
This edit addresses the issue ucsd-progsys/liquidhaskell#66
where

``` haskell
{-@ listElem :: y:a -> zs:[a] -> {v:Bool | (Prop(v) <=> Set_mem(y, (listElts(zs))))} @-}
listElem ::  a -> [a] -> Bool
listElem = undefined
```

produces a sortcheck error
