### PR TITLE
give operators - and + same precedence

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -195,10 +195,12 @@ parenBrackets  = parens . brackets
 
 expr2P = buildExpressionParser bops lexprP
 
-bops = [ [Infix  (reservedOp "*"   >> return (EBin Times)) AssocLeft]
-       , [Infix  (reservedOp "/"   >> return (EBin Div  )) AssocLeft]
-       , [Infix  (reservedOp "+"   >> return (EBin Plus )) AssocLeft]
-       , [Infix  (reservedOp "-"   >> return (EBin Minus)) AssocLeft]
+bops = [ [ Infix  (reservedOp "*"   >> return (EBin Times)) AssocLeft
+         , Infix  (reservedOp "/"   >> return (EBin Div  )) AssocLeft
+         ]
+       , [ Infix  (reservedOp "-"   >> return (EBin Minus)) AssocLeft
+         , Infix  (reservedOp "+"   >> return (EBin Plus )) AssocLeft
+         ]
        , [Infix  (reservedOp "mod" >> return (EBin Mod  )) AssocLeft]
        ]
 


### PR DESCRIPTION
This is a fix for ucsd-progsys/liquidhaskell#155.

`+` used to have higher precedence than `-`, so `(x - y + 1)` was parsed as `(x - (y + 1))`, 
BUT, in haskell `+` and `-` have the same precedence, so the haskell expressions `(x - y + 1) :: {v: a | v = ((x - y) + 1)}`
causing the below constraint to fail 

```
tmp1 = x - y, tmp2 = 1 |- tmp1 + tmp2 => x - (y + 1)
```

"All operators in one list have the same precedence" 
according to http://hackage.haskell.org/package/parsec-3.0.0/docs/Text-Parsec-Expr.html
