### PR TITLE
Add type to handle negation of expressions

### DIFF
--- a/external/fixpoint/fixParse.mly
+++ b/external/fixpoint/fixParse.mly
@@ -276,10 +276,8 @@ expr:
   | con                                   { A.eCon $1  }
   | exprs                                 { A.eMExp $1 } 
   | LPAREN expr MOD expr RPAREN           { A.eMod ($2, $4) }
-  | expr PLUS expr                        { A.eBin ($1, A.Plus, $3) }
-  | expr MINUS expr                       { A.eBin ($1, A.Minus, $3) }
-  | expr TIMES expr                       { A.eBin ($1, A.Times, $3) }
-  | expr DIV expr                         { A.eBin ($1, A.Div, $3) }
+  | MINUS expr                            { A.eBin (A.zero, A.Minus, $3) }
+  | expr op expr                          { A.eBin ($1, $2, $3) }
   | expr ops expr                         { A.eMBin ($1, $2, $3) }
   | Id LPAREN exprs RPAREN                { A.eApp ((Sy.of_string $1), $3) }
   | Id Id                                 { A.eApp ((Sy.of_string $1), [A.eVar (Sy.of_string $2)]) }

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -254,14 +254,14 @@ parenBrackets  = parens . brackets
 
 -- ORIG expr2P = buildExpressionParser bops lexprP
 
-bops = [ [ Prefix (reservedOp "-"   >> return eMinus)]
+bops = [ [ Prefix (reservedOp "-"   >> return ENeg)]
        , [ Infix  (reservedOp "*"   >> return (EBin Times)) AssocLeft
          , Infix  (reservedOp "/"   >> return (EBin Div  )) AssocLeft
          ]
        , [ Infix  (reservedOp "-"   >> return (EBin Minus)) AssocLeft
          , Infix  (reservedOp "+"   >> return (EBin Plus )) AssocLeft
          ]
-       , [Infix  (reservedOp "mod"  >> return (EBin Mod  )) AssocLeft]
+       , [ Infix  (reservedOp "mod"  >> return (EBin Mod  )) AssocLeft]
        ]
 
 eMinus = EBin Minus (expr (0 :: Integer)) 

--- a/src/Language/Fixpoint/PrettyPrint.hs
+++ b/src/Language/Fixpoint/PrettyPrint.hs
@@ -71,6 +71,7 @@ instance PPrint Expr where
   pprint (ECon c)        = pprint c 
   pprint (EVar s)        = pprint s
   pprint (ELit s _)      = pprint s
+  pprint (ENeg e)        = parens $ text "-" <+> parens (pprint e)
   pprint (EBin o e1 e2)  = parens $ pprint e1 <+> pprint o <+> pprint e2
   pprint (EIte p e1 e2)  = parens $ text "if" <+> pprint p <+> text "then" <+> pprint e1 <+> text "else" <+> pprint e2 
   pprint (ECst e so)     = parens $ pprint e <+> text " : " <+> pprint so 

--- a/src/Language/Fixpoint/SmtLib2.hs
+++ b/src/Language/Fixpoint/SmtLib2.hs
@@ -424,6 +424,7 @@ instance SMTLIB2 Expr where
   smt2 (EApp f [e])     | val f == "Set_sng"
                         = format "({} {} {})"     (add, emp, smt2 e)
   smt2 (EApp f es)      = format "({} {})"        (smt2 f, smt2s es)
+  smt2 (ENeg e)         = format "(- {})"         (Only $ smt2 e)
   smt2 (EBin o e1 e2)   = format "({} {} {})"     (smt2 o, smt2 e1, smt2 e2)
   smt2 (EIte e1 e2 e3)  = format "(ite {} {} {})" (smt2 e1, smt2 e2, smt2 e3)
   smt2 _                = error "TODO: SMTLIB2 Expr"

--- a/src/Language/Fixpoint/Sort.hs
+++ b/src/Language/Fixpoint/Sort.hs
@@ -127,6 +127,7 @@ checkExpr _ EBot           = throwError "Type Error: Bot"
 checkExpr _ (ECon (I _))   = return FInt 
 checkExpr _ (ECon (R _))   = return FReal 
 checkExpr f (EVar x)       = checkSym f x
+checkExpr f (ENeg e)       = checkNeg f e
 checkExpr f (EBin o e1 e2) = checkOp f e1 o e2
 checkExpr f (EIte p e1 e2) = checkIte f p e1 e2
 checkExpr f (ECst e t)     = checkCst f t e
@@ -177,6 +178,15 @@ checkApp' f to g es
 
 
 -- | Helper for checking binary (numeric) operations
+
+checkNeg f e = do
+  t <- checkExpr f e
+  case t of
+   FReal    -> return FReal
+   FInt     -> return FInt
+   (FObj l) -> checkNumeric f l >> return t
+   _        -> throwError $ printf "Operand has non-numeric type %s in %s"
+                            (showFix t) (showFix e)
 
 checkOp f e1 o e2 
   = do t1 <- checkExpr f e1

--- a/src/Language/Fixpoint/Visitor.hs
+++ b/src/Language/Fixpoint/Visitor.hs
@@ -102,6 +102,7 @@ visitExpr v = vE
     step c e@(ELit _ _)   = return e 
     step c e@(EVar _)     = return e
     step c (EApp f es)    = EApp f     <$> (vE c <$$> es)  
+    step c (ENeg e)       = ENeg       <$> vE c e
     step c (EBin o e1 e2) = EBin o     <$> vE c e1 <*> vE c e2
     step c (EIte p e1 e2) = EIte       <$> vP c p  <*> vE c e1 <*> vE c e2
     step c (ECst e t)     = (`ECst` t) <$> vE c e


### PR DESCRIPTION
Liquid Haskell was having trouble lifting functions with expressions like `-1` to measures. It seemed cleaner to add a real type like `PNot`, called `ENeg`, than to always convert to `0 - 1`.

I'll also make a pull request for the corresponding change in liquidhaskell. 
I can also add the type to the OCaml side of things if this seems like a good idea.

This change requires a rebuild of the `fixpoint` executable.