### PR TITLE
Implemented maxPartSize option

### DIFF
--- a/src/Language/Fixpoint/Config.hs
+++ b/src/Language/Fixpoint/Config.hs
@@ -33,6 +33,9 @@ defaultCores = 1
 defaultMinPartSize :: Int
 defaultMinPartSize = 500
 
+defaultMaxPartSize :: Int
+defaultMaxPartSize = 700
+
 data Config
   = Config {
       inFile      :: FilePath         -- ^ target fq-file
@@ -40,6 +43,7 @@ data Config
     , srcFile     :: FilePath         -- ^ src file (*.hs, *.ts, *.c)
     , cores       :: Int              -- ^ number of cores used to solve constraints
     , minPartSize :: Int              -- ^ Minimum size of a partition
+    , maxPartSize :: Int              -- ^ Maximum size of a partition. Overrides minPartSize
     , solver      :: SMTSolver        -- ^ which SMT solver to use
     , genSorts    :: GenQualifierSort -- ^ generalize qualifier sorts
     , ueqAllSorts :: UeqAllSorts      -- ^ use UEq on all sorts
@@ -58,6 +62,7 @@ instance Default Config where
                , srcFile     = def
                , cores       = defaultCores
                , minPartSize = defaultMinPartSize
+               , maxPartSize = defaultMaxPartSize
                , solver      = def
                , genSorts    = def
                , ueqAllSorts = def
@@ -147,6 +152,7 @@ config = Config {
   , parts       = False &= help "Partition constraints into indepdendent .fq files"
   , cores       = defaultCores &= help "(numeric) Number of threads to use"
   , minPartSize = defaultMinPartSize &= help "(numeric) Minimum partition size when solving in parallel"
+  , maxPartSize = defaultMaxPartSize &= help "(numeric) Maximum partiton size when solving in parallel."
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -126,10 +126,11 @@ solveExt cfg fi =   {-# SCC "Solve"  #-} execFq cfg fn fi
 --   calls solveExt on each in parallel
 solvePar :: (Fixpoint a) => Config -> FInfo a -> IO (Result a)
 solvePar c fi = do
-   let (_, fis) = partition' (Just (cores c, minPartSize c)) fi
+   let (_, fis) = partition' (Just (mcInfo c)) fi
    writeLoud $ "Number of partitions: " ++ show (length fis)
    writeLoud $ "number of cores: " ++ show (cores c)
    writeLoud $ "minimum part size: " ++ show (minPartSize c)
+   writeLoud $ "maximum part size: " ++ show (maxPartSize c)
    case fis of
       [] -> errorstar "partiton' returned empty list!"
       [onePart] -> solveExt c onePart

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -166,6 +166,8 @@ module Language.Fixpoint.Types (
 
   -- * Partitions
   , CPart (..)
+  , MCInfo (..)
+  , mcInfo
   ) where
 
 import           Debug.Trace               (trace)
@@ -1830,3 +1832,18 @@ instance Monoid (CPart a) where
                        , pcm = pcm l `mappend` pcm r
                        , cFileName = cFileName l
                        }
+
+-------------------------------------------------------------------------
+-- | Multicore info -----------------------------------------------------
+-------------------------------------------------------------------------
+
+data MCInfo = MCInfo { mcCores :: Int
+                     , mcMinPartSize :: Int
+                     , mcMaxPartSize :: Int
+                     } deriving (Show)
+
+mcInfo :: Config -> MCInfo
+mcInfo c = MCInfo { mcCores = cores c
+                  , mcMinPartSize = minPartSize c
+                  , mcMaxPartSize = maxPartSize c
+                  }


### PR DESCRIPTION
Implements a maximum partition size threshold for multicore solving. If combining the two smallest partitions will create a partition that exceeds this threshold, then the merge will not happen even if the smallest is smaller than the minPartSize threshold.

Depends on Liquid Haskell pull request [#440](https://github.com/ucsd-progsys/liquidhaskell/pull/440)