### PR TITLE
factored `defaultFoo` functions out of liquid

### DIFF
--- a/src/Language/Fixpoint/Config.hs
+++ b/src/Language/Fixpoint/Config.hs
@@ -11,6 +11,9 @@ module Language.Fixpoint.Config (
   , GenQualifierSort (..)
   , UeqAllSorts (..)
   , withTarget
+  , defaultCores
+  , defaultMinPartSize
+  , defaultMaxPartSize
 ) where
 
 import           System.Console.CmdArgs


### PR DESCRIPTION
Clearing PR backlog by merging my pull requests into make-par-default

Adding defaultCores, defaultMinPartSize, and defaultMaxPartSize to the export list, to be consumed by liquidhaskell.

Previously liquidhaskell had duplicate versions of these, and the two required synchronization.
