### PR TITLE
Remove gs from GInfo

### DIFF
--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -46,7 +46,7 @@ import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Statistics     (statistics)
 import           Language.Fixpoint.Partition      (partition, partition')
 import           Language.Fixpoint.Parse          (rr, rr')
-import           Language.Fixpoint.Types          hiding (kuts, lits)
+import           Language.Fixpoint.Types
 import           Language.Fixpoint.Errors (exit)
 import           Language.Fixpoint.PrettyPrint (showpp, pprintKVs)
 import           Language.Fixpoint.Parallel
@@ -212,4 +212,4 @@ parseFI f = do
   str   <- readFile f
   let fi = rr' f str :: FInfo ()
   return $ mempty { quals = quals  fi
-                  , gs    = gs     fi }
+                  , lits  = lits   fi }

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -573,17 +573,15 @@ intP :: Parser Int
 intP = fromInteger <$> integer
 
 defsFInfo :: [Def a] -> FInfo a
-defsFInfo defs = FI cm ws bs gs lts kts qs mempty mempty
+defsFInfo defs = FI cm ws bs lts kts qs mempty mempty
   where
     cm     = M.fromList       [(cid c, c)       | Cst c       <- defs]
     ws     =                  [w                | Wfc w       <- defs]
     bs     = bindEnvFromList  [(n, x, r)        | IBind n x r <- defs]
-    gs     = fromListSEnv     [(x, RR t mempty) | Con x t     <- defs]
-    lts    =                  [(x, t)           | Con x t     <- defs, notFun t]
+    lts    = fromListSEnv     [(x, t)           | Con x t     <- defs]
     kts    = KS $ S.fromList  [k                | Kut k       <- defs]
     qs     =                  [q                | Qul q       <- defs]
     cid    = fromJust . sid
-    notFun = not . isFunctionSortedReft . (`RR` trueReft)
 ---------------------------------------------------------------------
 -- | Interacting with Fixpoint --------------------------------------
 ---------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -110,7 +110,8 @@ declare fi  = withContext $ \me -> do
 declLiterals :: F.GInfo c a -> [[F.Expr]]
 declLiterals fi = [es | (_, es) <- tess ]
   where
-    tess        = groupList [(t, F.expr x) | (x, t) <- F.lits fi]
+    notFun      = not . F.isFunctionSortedReft . (`F.RR` F.trueReft)
+    tess        = groupList [(t, F.expr x) | (x, t) <- F.toListSEnv $ F.lits fi, notFun t]
 
 declSymbols :: F.GInfo c a -> Either E.Error [(F.Symbol, F.Sort)]
 declSymbols = fmap dropThy . symbolSorts

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -116,7 +116,7 @@ refine fi qs s w = refineK env qs s (wfKvar w)
   where
     env          = wenv <> genv
     wenv         = F.fromListSEnv $ F.envCs (F.bs fi) (F.wenv w)
-    genv         = F.gs fi
+    genv         = (`F.RR` mempty) <$> F.lits fi
 
 refineK :: F.SEnv F.SortedReft
         -> [F.Qualifier]

--- a/src/Language/Fixpoint/Solver/TrivialSort.hs
+++ b/src/Language/Fixpoint/Solver/TrivialSort.hs
@@ -142,14 +142,10 @@ simplifyFInfo tm fi = fi {
      cm   = simplifySubCs   tm $ cm fi
    , ws   = simplifyWfCs    tm $ ws fi
    , bs   = simplifyBindEnv tm $ bs fi
-   , gs   = simplifyFEnv    tm $ gs fi
 }
 
 simplifyBindEnv :: NonTrivSorts -> BindEnv -> BindEnv
 simplifyBindEnv = mapBindEnv . second . simplifySortedReft
-
-simplifyFEnv :: NonTrivSorts -> FEnv -> FEnv
-simplifyFEnv = fmap . simplifySortedReft
 
 simplifyWfCs :: NonTrivSorts -> [WfC a] -> [WfC a]
 simplifyWfCs tm = filter (isNonTrivialSort tm . sr_sort . wrft)

--- a/src/Language/Fixpoint/Solver/Uniqify.hs
+++ b/src/Language/Fixpoint/Solver/Uniqify.hs
@@ -6,7 +6,6 @@ import           Language.Fixpoint.Types
 import           Language.Fixpoint.Names (renameSymbol)
 import           Language.Fixpoint.Solver.Eliminate (elimKVar, findWfC)
 import           Language.Fixpoint.Misc  (fst3)
-import           Language.Fixpoint.Solver.Validate (finfoDefs)
 import qualified Data.HashMap.Strict     as M
 import qualified Data.HashSet            as S
 import           Data.List               ((\\), sort)
@@ -79,8 +78,8 @@ renameVarIfSeen fi x@(id, _) = state (\m ->
 ----TODO: only valid if the binding has no kvars and is of the same sort
 ---- as the constant. Should that be checked here, or in Validate?
 --insertIfNotConstant :: SInfo a -> Symbol -> Sort -> M.HashMap Symbol Sort -> M.HashMap Symbol Sort
---insertIfNotConstant fi sym srt m | sym `elem` (fst <$> finfoDefs fi) = m
---                                 | otherwise                         = M.insert sym srt m
+--insertIfNotConstant fi sym srt m | sym `elem` (fst <$> lits fi) = m
+--                                 | otherwise                    = M.insert sym srt m
 
 handleSeenVar :: SInfo a -> (BindId, S.HashSet Ref) -> Symbol -> Sort -> (M.HashMap Symbol Sort) -> (SInfo a, (M.HashMap Symbol Sort))
 handleSeenVar fi x sym srt m | M.lookup sym m == Just srt = (fi, m)


### PR DESCRIPTION
Condenses 'gs' and 'lits' fields into a single field containing all fq 'constants'.