### PR TITLE
Binary

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -100,6 +100,7 @@ Executable fixpoint.native
                , cmdargs
                , ansi-terminal
                , bifunctors
+               , binary
                , bytestring
                , containers
                , deepseq
@@ -127,6 +128,7 @@ Executable fixpoint
                , cmdargs
                , ansi-terminal
                , bifunctors
+               , binary
                , bytestring
                , containers
                , deepseq
@@ -183,6 +185,7 @@ Library
                , cmdargs
                , ansi-terminal
                , bifunctors
+               , binary
                , bytestring
                , containers
                , deepseq

--- a/src/Language/Fixpoint/Config.hs
+++ b/src/Language/Fixpoint/Config.hs
@@ -48,12 +48,13 @@ data Config
     , ueqAllSorts :: UeqAllSorts      -- ^ use UEq on all sorts
     , native      :: Bool             -- ^ use haskell solver
     , real        :: Bool             -- ^ interpret div and mul in SMT
-    , newcheck    :: Bool             -- ^ new fixpoint sort check 
+    , newcheck    :: Bool             -- ^ new fixpoint sort check
     , eliminate   :: Bool             -- ^ eliminate non-cut KVars
     , elimStats   :: Bool             -- ^ print eliminate stats
     , metadata    :: Bool             -- ^ print meta-data associated with constraints
     , stats       :: Bool             -- ^ compute constraint statistics
     , parts       :: Bool             -- ^ partition FInfo into separate fq files
+    , binary      :: Bool             -- ^ save FInfo as binary file
     -- , nontriv     :: Bool             -- ^ simplify using non-trivial sorts
     } deriving (Eq,Data,Typeable,Show)
 
@@ -69,12 +70,13 @@ instance Default Config where
                , ueqAllSorts = def
                , native      = def
                , real        = def
-               , newcheck    = False 
+               , newcheck    = False
                , eliminate   = def
                , elimStats   = def
                , metadata    = def
                , stats       = def
                , parts       = def
+               , binary      = def
                }
 
 instance Command Config where
@@ -152,6 +154,7 @@ config = Config {
   , real        = False &= help "(alpha) Theory of real numbers"
   , eliminate   = False &= help "(alpha) Eliminate non-cut KVars"
   , elimStats   = False &= help "(alpha) Print eliminate stats"
+  , binary      = False &= help "(alpha) Save Query as Binary File"
   , metadata    = False &= help "Print meta-data associated with constraints"
   , stats       = False &= help "Compute constraint statistics"
   , parts       = False &= help "Partition constraints into indepdendent .fq files"
@@ -175,5 +178,5 @@ getOpts = do md <- cmdArgs config
              return md
 
 banner :: String
-banner =  "Liquid-Fixpoint Copyright 2009-13 Regents of the University of California.\n"
+banner =  "Liquid-Fixpoint Copyright 2013-15 Regents of the University of California.\n"
        ++ "All Rights Reserved.\n"

--- a/src/Language/Fixpoint/Files.hs
+++ b/src/Language/Fixpoint/Files.hs
@@ -83,10 +83,11 @@ data Ext = Cgi      -- ^ Constraint Generation Information
          | Pred
          | PAss
          | Dat
-         | Smt2   -- ^ SMTLIB2 query file
+         | BinFq    -- ^ Binary representation of .fq / FInfo
+         | Smt2     -- ^ SMTLIB2 query file
          deriving (Eq, Ord, Show)
 
-extMap e = go e
+extMap          = go
   where
     go Cgi      = ".cgi"
     go Pred     = ".pred"
@@ -111,6 +112,7 @@ extMap e = go e
     go Cache    = ".err"
     go Smt2     = ".smt2"
     go Dot      = ".dot"
+    go BinFq    = ".bfq"
     go (Part n) = "." ++ show n
     -- go _      = errorstar $ "extMap: Unknown extension " ++ show e
 

--- a/src/Language/Fixpoint/Names.hs
+++ b/src/Language/Fixpoint/Names.hs
@@ -70,7 +70,7 @@ import           Data.Interned.Internal.Text
 import           Data.Maybe                  (fromMaybe)
 import           Data.String                 (IsString)
 import qualified Data.Text                   as T
-import           Data.Binary                 (Binary)
+import           Data.Binary                 (Binary (..))
 import           Data.Typeable               (Typeable)
 import           GHC.Generics                (Generic)
 
@@ -78,7 +78,7 @@ import           Language.Fixpoint.Misc      (errorstar)
 
 
 ---------------------------------------------------------------
----------------------------- Symbols --------------------------
+-- | Symbols --------------------------------------------------
 ---------------------------------------------------------------
 
 symChars
@@ -113,8 +113,11 @@ instance NFData Symbol where
 instance Hashable Symbol where
   hashWithSalt i (S s) = hashWithSalt i s
 
-instance Binary InternedText
-instance Binary Symbol
+-- instance Binary InternedText
+
+instance Binary Symbol where
+  get = S . intern <$> get
+  put = put . symbolText
 
 symbolString :: Symbol -> String
 symbolString = T.unpack . symbolText

--- a/src/Language/Fixpoint/Names.hs
+++ b/src/Language/Fixpoint/Names.hs
@@ -70,6 +70,7 @@ import           Data.Interned.Internal.Text
 import           Data.Maybe                  (fromMaybe)
 import           Data.String                 (IsString)
 import qualified Data.Text                   as T
+import           Data.Binary                 (Binary)
 import           Data.Typeable               (Typeable)
 import           GHC.Generics                (Generic)
 
@@ -86,11 +87,12 @@ symChars
   ++ ['0' .. '9']
   ++ ['_', '%', '.', '#']
 
-deriving instance Data InternedText
+deriving instance Data     InternedText
 deriving instance Typeable InternedText
-deriving instance Generic InternedText
+deriving instance Generic  InternedText
 
-newtype Symbol = S InternedText deriving (Eq, Ord, Data, Typeable, Generic, IsString)
+newtype Symbol = S InternedText
+                 deriving (Eq, Ord, Data, Typeable, Generic, IsString)
 
 instance Monoid Symbol where
   mempty      = ""
@@ -110,6 +112,9 @@ instance NFData Symbol where
 
 instance Hashable Symbol where
   hashWithSalt i (S s) = hashWithSalt i s
+
+instance Binary InternedText
+instance Binary Symbol
 
 symbolString :: Symbol -> String
 symbolString = T.unpack . symbolText

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -12,7 +12,7 @@ module Language.Fixpoint.Solver.Solution
           -- * Initial Solution
         , init
 
-          -- * Update Solution
+          -- * Update Solutio n
         , update
 
           -- * Lookup Solution
@@ -173,7 +173,6 @@ match xts xs (t : ts)
        match xts (x : xs) (So.apply su <$> ts)
 match _   xs []
   = return xs
-
 
 -----------------------------------------------------------------------
 candidates :: [(F.Symbol, F.Sort)] -> F.Sort -> [(So.TVSubst, F.Symbol)]

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -1493,8 +1493,8 @@ subC γ sr1 sr2 i y z = [SubC γ sr1' (sr2' r2') i y z | r2' <- reftConjuncts r2
    where
      RR t1 r1          = sr1
      RR t2 r2          = sr2
-     sr1'              = RR t1 r1  -- FIXME $ shiftVV r1  vv'
-     sr2' r2'          = RR t2 r2' -- FIXME $ shiftVV r2' vv'
+     sr1'              = RR t1 $ shiftVV r1  vv'
+     sr2' r2'          = RR t2 $ shiftVV r2' vv'
      vv'               = mkVV i
 
 reftConjuncts :: Reft -> [Reft]

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -176,6 +176,7 @@ module Language.Fixpoint.Types (
 
 import           Debug.Trace               (trace)
 
+import           Data.Binary               (Binary)
 import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           GHC.Generics              (Generic)
@@ -1306,8 +1307,53 @@ conjuncts p
   | isTautoPred p   = []
   | otherwise       = [p]
 
+
+
 ----------------------------------------------------------------
----------------------- Strictness ------------------------------
+-- | Source Positions-------------------------------------------
+----------------------------------------------------------------
+
+-- reimplementing because parsec's doesnt have a generic instance...
+
+data SrcPos = SrcPos { srcFile :: !FilePath
+                     , srcLine :: !Int
+                     , srcCol  :: !Int }
+                     deriving (Eq, Generic)
+
+----------------------------------------------------------------
+-- | Serialization ---------------------------------------------
+----------------------------------------------------------------
+
+instance Binary SrcPos
+instance Binary KVar
+instance (Binary a) => Binary (S.HashSet a)
+instance Binary Kuts
+instance Binary Qualifier
+instance Binary FTycon
+instance Binary Sort
+instance Binary Sub
+instance Binary Subst
+instance Binary IBindEnv
+instance Binary BindEnv
+instance Binary Constant
+instance Binary SymConst
+instance Binary Brel
+instance Binary Bop
+instance Binary Expr
+instance Binary Pred
+instance Binary Refa
+instance Binary Reft
+instance Binary SortedReft
+instance (Binary a) => Binary (SEnv a)
+instance (Binary a) => Binary (FixResult a)
+instance (Binary a) => Binary (SubC a)
+instance (Binary a) => Binary (WfC a)
+instance (Binary a) => Binary (SimpC a)
+instance (Binary (c a), Binary a) => Binary (GInfo c a)
+instance (Binary a) => Binary (Located a)
+
+----------------------------------------------------------------
+-- | Strictness ------------------------------------------------
 ----------------------------------------------------------------
 
 instance NFData SourcePos where

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -1493,8 +1493,8 @@ subC γ sr1 sr2 i y z = [SubC γ sr1' (sr2' r2') i y z | r2' <- reftConjuncts r2
    where
      RR t1 r1          = sr1
      RR t2 r2          = sr2
-     sr1'              = RR t1 $ shiftVV r1  vv'
-     sr2' r2'          = RR t2 $ shiftVV r2' vv'
+     sr1'              = RR t1 r1  -- FIXME $ shiftVV r1  vv'
+     sr2' r2'          = RR t2 r2' -- FIXME $ shiftVV r2' vv'
      vv'               = mkVV i
 
 reftConjuncts :: Reft -> [Reft]


### PR DESCRIPTION
Added `--binary` flag for saving `.fq` files in binary format (as `.bfq` files) for fast re-parsing. e.g.

```
1. fixpoint --binary path/to/foo.fq
2. fixpoint path/to/foo.bfq
```

(Should re-run all LH etc. benchmarks FIRST before merging, will do so after the submodule thing...)
