### PR TITLE
Also rename the tick character

### DIFF
--- a/src/Language/Fixpoint/Names.hs
+++ b/src/Language/Fixpoint/Names.hs
@@ -183,10 +183,10 @@ encodeChar c
   | c `S.member` okSymChars
   = [c]
   | otherwise
-  = [symSepName] ++ (show $ ord c) ++ [symSepName]
+  = [symSepName] ++ show (ord c) ++ [symSepName]
 
 decodeStr s
-  = chr ((read s) :: Int)
+  = chr (read s :: Int)
 
 qualifySymbol :: Symbol -> Symbol -> Symbol
 qualifySymbol m'@(symbolText -> m) x'@(symbolText -> x)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -88,6 +88,7 @@ runCommands cmds
        return zs
 -}
 
+debugFile :: FilePath
 debugFile = "DEBUG.smt2"
 
 --------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -88,6 +88,8 @@ runCommands cmds
        return zs
 -}
 
+debugFile = "DEBUG.smt2"
+
 --------------------------------------------------------------------------
 -- | SMT IO --------------------------------------------------------------
 --------------------------------------------------------------------------
@@ -158,6 +160,8 @@ pairs !xs = case L.splitAt 2 xs of
 smtWriteRaw      :: Context -> LT.Text -> IO ()
 smtWriteRaw me !s = {-# SCC "smtWriteRaw" #-} do
   hPutStrLnNow (cOut me) s
+  -- DO NOT DELETE: LTIO.appendFile debugFile s
+  -- DO NOT DELETE: LTIO.appendFile debugFile "\n"
   maybe (return ()) (`hPutStrLnNow` s) (cLog me)
 
 smtReadRaw       :: Context -> IO Raw

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -55,26 +55,23 @@ instance SMTLIB2 Symbol where
     | Just t <- Thy.smt2Symbol s = LT.fromStrict t
   smt2 s                         = LT.fromStrict . encode . symbolText $ s
 
--- FIXME: this is probably too slow
-
+-- FIXME: this is probably too slow.
+-- RJ: Yes it is!
 encode :: T.Text -> T.Text
-encode t = {-# SCC "encode" #-}
+encode t = {-# SCC "smt2-encode" #-}
   foldr (uncurry T.replace) t [("[", "ZM"), ("]", "ZN"), (":", "ZC")
                               ,("(", "ZL"), (")", "ZR"), (",", "ZT")
                               ,("|", "zb"), ("#", "zh"), ("\\","zr")
                               ,("z", "zz"), ("Z", "ZZ"), ("%","zv")
-                              ,(" ", "_")
+                              ,(" ", "_") , ("'", "ZT")
                               ]
 
 instance SMTLIB2 SymConst where
-  -- smt2 (SL s) = LT.fromStrict s
-  smt2 = smt2 . symbol -- encodeSymConst
-
+  smt2 = smt2 . symbol
 
 instance SMTLIB2 Constant where
   smt2 (I n)   = format "{}" (Only n)
   smt2 (R d)   = format "{}" (Only d)
-  -- smt2 (L t _) = t
 
 instance SMTLIB2 LocSymbol where
   smt2 = smt2 . val

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -948,7 +948,7 @@ instance TaggedC SubC a where
   sinfo = _sinfo
 
 data WrappedC a where
-  WrapC :: (TaggedC c a, Show (c a)) => {_x :: (c a)} -> WrappedC a
+  WrapC :: (TaggedC c a, Show (c a)) => { _x :: c a } -> WrappedC a
 
 instance Show (WrappedC a) where
   show (WrapC x) = show x


### PR DESCRIPTION
1. Rename `'` before shipping of to z3
2. Generate `.bfq` by default when run with `--native` (remove later, currently debug)