### PR TITLE
Ws to hashmap

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -84,7 +84,7 @@ import           Language.Fixpoint.Smt.Types
 
 import           Language.Fixpoint.Names     (headSym)
 import           Language.Fixpoint.Types
-import           Language.Fixpoint.Visitor   (foldSort, mapSort, wfKvar)
+import           Language.Fixpoint.Visitor   (foldSort, mapSort)
 
 import           Data.Maybe                  (fromJust)
 
@@ -518,7 +518,8 @@ wfCP = do reserved "env"
           env <- envP
           reserved "reft"
           r   <- sortedReftP
-          return $ WfC env r ()
+          let [w] = wfC env r ()
+          return w
 
 subCP :: Parser (SubC ())
 subCP = do pos <- getPosition
@@ -564,7 +565,7 @@ defsFInfo :: [Def a] -> FInfo a
 defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts kts qs mempty mempty
   where
     cm     = M.fromList       [(sid c, c)       | Cst c       <- defs]
-    ws     = M.fromList       [(k, w)           | Wfc w       <- defs, let Just (_, _, k) = wfKvar w] --TODO simplify
+    ws     = M.fromList       [(k, w)           | Wfc w       <- defs, let (_, _, k) = wrft w] --TODO simplify
     bs     = bindEnvFromList  [(n, x, r)        | IBind n x r <- defs]
     lts    = fromListSEnv     [(x, t)           | Con x t     <- defs]
     kts    = KS $ S.fromList  [k                | Kut k       <- defs]

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -84,7 +84,7 @@ import           Language.Fixpoint.Smt.Types
 
 import           Language.Fixpoint.Names     (headSym)
 import           Language.Fixpoint.Types
-import           Language.Fixpoint.Visitor   (foldSort, mapSort)
+import           Language.Fixpoint.Visitor   (foldSort, mapSort, wfKvar)
 
 import           Data.Maybe                  (fromJust)
 
@@ -564,7 +564,7 @@ defsFInfo :: [Def a] -> FInfo a
 defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts kts qs mempty mempty
   where
     cm     = M.fromList       [(sid c, c)       | Cst c       <- defs]
-    ws     =                  [w                | Wfc w       <- defs]
+    ws     = M.fromList       [(k, w)           | Wfc w       <- defs, let Just (_, _, k) = wfKvar w] --TODO simplify
     bs     = bindEnvFromList  [(n, x, r)        | IBind n x r <- defs]
     lts    = fromListSEnv     [(x, t)           | Con x t     <- defs]
     kts    = KS $ S.fromList  [k                | Kut k       <- defs]

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -518,7 +518,7 @@ wfCP = do reserved "env"
           env <- envP
           reserved "reft"
           r   <- sortedReftP
-          return $ wfC env r ()
+          return $ WfC env r ()
 
 subCP :: Parser (SubC ())
 subCP = do pos <- getPosition

--- a/src/Language/Fixpoint/Partition.hs
+++ b/src/Language/Fixpoint/Partition.hs
@@ -209,10 +209,7 @@ kvEdges fi = selfes ++ concatMap (subcEdges bs) cs
              [(KVar k, KVar k) | k <- fiKVars fi]
 
 fiKVars :: F.FInfo a -> [F.KVar]
-fiKVars fi = sortNub $ concatMap wfKvars (F.ws fi)
-
-wfKvars :: F.WfC a -> [F.KVar]
-wfKvars = V.kvars . F.sr_reft . F.wrft
+fiKVars = M.keys . F.ws
 
 subcEdges :: F.BindEnv -> F.SubC a -> [CEdge]
 subcEdges bs c =  [(KVar k, Cstr i ) | k  <- V.envKVars bs c]

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -64,9 +64,7 @@ functionsInBindEnv :: BindEnv -> [Symbol]
 functionsInBindEnv be = [sym | (_, sym, sr) <- bindEnvToList be, isFunctionSortedReft sr]
 
 domain :: BindEnv -> WfC a -> [Symbol]
-domain be wfc = (sortedReftValueVariable $ wrft wfc) : map fst (envCs be $ wenv wfc)
-
-sortedReftValueVariable (RR _ (Reft (v,_))) = v
+domain be wfc = (fst3 $ wrft wfc) : map fst (envCs be $ wenv wfc)
 
 projectNonWFVars :: [(Symbol,Sort)] -> [Symbol] -> Pred -> Pred
 projectNonWFVars binds kDom pr = PExist [v | v <- binds, notElem (fst v) kDom] pr

--- a/src/Language/Fixpoint/Solver/Graph.hs
+++ b/src/Language/Fixpoint/Solver/Graph.hs
@@ -22,7 +22,7 @@ module Language.Fixpoint.Solver.Graph (
 
 -- import           Debug.Trace (trace)
 import           Prelude hiding (init)
-import           Language.Fixpoint.Visitor (wfKvar, rhsKVars, envKVars, kvars, isConcC)
+import           Language.Fixpoint.Visitor (rhsKVars, envKVars, kvars, isConcC)
 import           Language.Fixpoint.Misc (errorstar, fst3, thd3, sortNub, group)
 import qualified Language.Fixpoint.Types   as F
 import           Language.Fixpoint.Solver.Types

--- a/src/Language/Fixpoint/Solver/Graph.hs
+++ b/src/Language/Fixpoint/Solver/Graph.hs
@@ -42,16 +42,14 @@ slice :: (F.TaggedC c a) => F.GInfo c a -> F.GInfo c a
 slice fi = fi { F.cm = cm'
               , F.ws = ws' }
   where
-     cm' = M.filterWithKey inC (F.cm fi)
-     ws' = filter (inW ks)     (F.ws fi)
+     cm' = M.filterWithKey inC      (F.cm fi)
+     ws' = M.filterWithKey (inW ks) (F.ws fi)
      ks  = sliceKVars fi sl
      is  = S.fromList (slKVarCs sl ++ slConcCs sl)
      sl  = mkSlice fi
      inC i _ = S.member i is
 
-inW ks w
-  | Just (_,_,k) <- wfKvar w = S.member k ks
-  | otherwise                = False
+inW ks k _ = S.member k ks
 
 sliceKVars :: (F.TaggedC c a) => F.GInfo c a -> Slice -> S.HashSet F.KVar
 sliceKVars fi sl = S.fromList $ concatMap (subcKVars be) cs

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -121,24 +121,24 @@ update1 s (k, qs) = (change, M.insert k qs s)
 --------------------------------------------------------------------
 -- | Initial Solution (from Qualifiers and WF constraints) ---------
 --------------------------------------------------------------------
-init :: F.GInfo c a -> Solution
+init :: F.SInfo a -> Solution
 --------------------------------------------------------------------
 init fi  = M.fromList keqs
   where
     -- PARALLELIZE THIS!
     -- keqs = parMap rdeepseq (refine fi qs) ws -- How to make this parallel?
-    keqs = mapMaybe (refine fi qs) ws `using` parList rdeepseq -- How to make this parallel?
+    keqs = map (refine fi qs) ws `using` parList rdeepseq -- How to make this parallel?
     qs   = F.quals fi
     ws   = M.elems $ F.ws fi
 
 
 --------------------------------------------------------------------
-refine :: F.GInfo c a
+refine :: F.SInfo a
        -> [F.Qualifier]
        -> F.WfC a
-       -> Maybe (F.KVar, KBind)
+       -> (F.KVar, KBind)
 --------------------------------------------------------------------
-refine fi qs w = refineK env qs <$> V.wfKvar w
+refine fi qs w = refineK env qs $ F.wrft w
   where
     env        = F.sr_sort <$> (wenv <> genv)
     wenv       = F.fromListSEnv $ F.envCs (F.bs fi) (F.wenv w)

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -129,7 +129,7 @@ init fi  = M.fromList keqs
     -- keqs = parMap rdeepseq (refine fi qs) ws -- How to make this parallel?
     keqs = mapMaybe (refine fi qs) ws `using` parList rdeepseq -- How to make this parallel?
     qs   = F.quals fi
-    ws   = F.ws    fi
+    ws   = M.elems $ F.ws fi
 
 
 --------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/TrivialSort.hs
+++ b/src/Language/Fixpoint/Solver/TrivialSort.hs
@@ -147,7 +147,7 @@ simplifyBindEnv :: NonTrivSorts -> BindEnv -> BindEnv
 simplifyBindEnv = mapBindEnv . second . simplifySortedReft
 
 simplifyWfCs :: NonTrivSorts -> M.HashMap KVar (WfC a) -> M.HashMap KVar (WfC a)
-simplifyWfCs tm = M.filter (isNonTrivialSort tm . sr_sort . wrft)
+simplifyWfCs tm = M.filter (isNonTrivialSort tm . snd3 . wrft)
 
 simplifySubCs ti cm = trace msg cm'
   where

--- a/src/Language/Fixpoint/Solver/TrivialSort.hs
+++ b/src/Language/Fixpoint/Solver/TrivialSort.hs
@@ -146,8 +146,8 @@ simplifyFInfo tm fi = fi {
 simplifyBindEnv :: NonTrivSorts -> BindEnv -> BindEnv
 simplifyBindEnv = mapBindEnv . second . simplifySortedReft
 
-simplifyWfCs :: NonTrivSorts -> [WfC a] -> [WfC a]
-simplifyWfCs tm = filter (isNonTrivialSort tm . sr_sort . wrft)
+simplifyWfCs :: NonTrivSorts -> M.HashMap KVar (WfC a) -> M.HashMap KVar (WfC a)
+simplifyWfCs tm = M.filter (isNonTrivialSort tm . sr_sort . wrft)
 
 simplifySubCs ti cm = trace msg cm'
   where

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -40,7 +40,6 @@ sanitize :: F.SInfo a -> ValidateM (F.SInfo a)
 sanitize   = fM dropHigherOrderBinders
          >=> fM dropFuncSortedShadowedBinders
          >=> fM dropFunctionSubs
-         >=> fM dropExtraWfCs
          >=>    checkRhsCs
 
 
@@ -128,16 +127,6 @@ type SymBinds = (F.Symbol, [(F.Sort, [F.BindId])])
 
 binders :: F.BindEnv -> [(F.Symbol, (F.Sort, F.BindId))]
 binders be = [(x, (F.sr_sort t, i)) | (i, x, t) <- F.bindEnvToList be]
-
-
----------------------------------------------------------------------------
--- | Drop WfCs that do not have a KVar (TODO - check well-sorted first?)
----------------------------------------------------------------------------
-dropExtraWfCs :: F.SInfo a -> F.SInfo a
----------------------------------------------------------------------------
-dropExtraWfCs fi = fi { F.ws = filter hasKVar $ F.ws fi }
-  where
-    hasKVar = not . null . kvars . F.wrft
 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -951,7 +951,7 @@ instance TaggedC WrappedC a where
   clhs  b (WrapC x) = clhs b x
 
 data WfC a  = WfC  { wenv  :: !IBindEnv
-                   , wrft  :: !SortedReft
+                   , wrft  :: (Symbol, Sort, KVar)
                    , winfo :: !a
                    }
               deriving (Eq, Generic, Functor)
@@ -1059,8 +1059,9 @@ instance Fixpoint a => Fixpoint (WfC a) where
   toFix w     = hang (text "\n\nwf:") 2 bd
     where bd  =   -- text "env"  <+> toFix (wenv w)
                   toFix (wenv w)
-              $+$ text "reft" <+> toFix (wrft w)
+              $+$ text "reft" <+> toFix (RR t (Reft (v, PKVar k emptySubst)))
               $+$ toFixMeta (text "wf") (toFix (winfo w))
+          (v, t, k) = wrft w
 
 toFixMeta :: Doc -> Doc -> Doc
 toFixMeta k v = text "// META" <+> k <+> text ":" <+> v
@@ -1385,7 +1386,7 @@ wfC :: IBindEnv -> SortedReft -> a -> [WfC a]
 wfC be sr x
   | Reft (v, PKVar k su) <- sr_reft sr
               = if isEmptySubst su
-                   then [WfC be sr x] -- Just (v, sr_sort sr, k)
+                   then [WfC be (v, sr_sort sr, k) x]
                    else err
   | otherwise = []
   where

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE UndecidableInstances       #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE PatternGuards              #-}
 
 -- | This module contains the data types, operations and
 --   serialization functions for representing Fixpoint's
@@ -1380,8 +1381,15 @@ instance Hashable FTycon where
 -------- Constraint Constructor Wrappers ----------------------------------
 ---------------------------------------------------------------------------
 
-wfC  :: IBindEnv -> SortedReft -> a -> WfC a
-wfC  = WfC
+wfC :: IBindEnv -> SortedReft -> a -> [WfC a]
+wfC be sr x
+  | Reft (v, PKVar k su) <- sr_reft sr
+              = if isEmptySubst su
+                   then [WfC be sr x] -- Just (v, sr_sort sr, k)
+                   else err
+  | otherwise = []
+  where
+    err       = errorstar $ "wfKvar: malformed wfC " ++ show sr
 
 niSubC :: IBindEnv -> SortedReft -> SortedReft -> Tag -> a -> [NISubC a]
 niSubC γ sr1 sr2 y z = [NISubC γ sr1' (sr2' r2') y z | r2' <- reftConjuncts r2]

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -1463,7 +1463,7 @@ type FInfo a   = GInfo SubC a
 type SInfo a   = GInfo SimpC a
 data GInfo c a =
   FI { cm       :: M.HashMap Integer (c a)
-     , ws       :: ![WfC a]
+     , ws       :: M.HashMap KVar (WfC a)
      , bs       :: !BindEnv
      , lits     :: !(SEnv Sort)
      , kuts     :: Kuts
@@ -1514,7 +1514,7 @@ toFixpoint cfg x' =    qualsDoc x'
   where
     conDoc        = vcat     . map toFixConstant . toListSEnv . lits
     csDoc         = vcat     . map toFix . M.elems . cm
-    wsDoc         = vcat     . map toFix . ws
+    wsDoc         = vcat     . map toFix . M.elems . ws
     kutsDoc       = toFix    . kuts
     bindsDoc      = toFix    . bs
     qualsDoc      = vcat     . map toFix . quals
@@ -1808,7 +1808,7 @@ fTyconSort c
 -------------------------------------------------------------------------
 
 
-data CPart a = CPart { pws :: [WfC a]
+data CPart a = CPart { pws :: M.HashMap KVar (WfC a)
                      , pcm :: M.HashMap Integer (SubC a)
                      , cFileName :: FilePath
                      }

--- a/src/Language/Fixpoint/Visitor.hs
+++ b/src/Language/Fixpoint/Visitor.hs
@@ -20,7 +20,6 @@ module Language.Fixpoint.Visitor (
   , kvars
   , envKVars
   , rhsKVars
-  , wfKvar
   , mapKVars, mapKVars', mapKVarSubsts
 
   -- * Predicates on Constraints
@@ -217,18 +216,6 @@ isKvar _          = False
 
 isConc :: Pred -> Bool
 isConc = null . kvars
-
------------------------------------------------------------------------
-wfKvar :: WfC a -> Maybe (Symbol, Sort, KVar)
------------------------------------------------------------------------
-wfKvar (WfC {wrft = sr})
-   | Reft (v, PKVar k su) <- sr_reft sr
-               = if isEmptySubst su
-                   then Just (v, sr_sort sr, k)
-                   else err
-   | otherwise = Nothing
-   where
-     err       = errorstar $ "wfKvar: malformed wfC " ++ show sr
 
 ---------------------------------------------------------------------------------
 -- | Visitors over @Sort@


### PR DESCRIPTION
Edit WfC so that instead of a SortedReft it has a (Symbol, Sort, KVar) tuple, with equivalence {v :: t | k} <-> (v, t, k)  This is possible because those are the only useful WfCs anyway so we can drop the rest.

Also changed FInfo's ws field to be a Map from KVar to WfC instead of just a list of WfCs.

These are breaking changes, so there is a corresponding LH PR.