### PR TITLE
Make Native (i.e. new Haskell) solver the Default

### DIFF
--- a/Fixpoint.hs
+++ b/Fixpoint.hs
@@ -3,13 +3,9 @@ import Language.Fixpoint.Config        (getOpts)
 import System.Exit
 import Language.Fixpoint.Misc (writeLoud)
 
-
-
-
 main :: IO ExitCode
 main = do
   cfg <- getOpts
   writeLoud $  "Options: " ++ show cfg
   e <- solveFQ cfg
-  -- putStrLn $ "EXIT: " ++ show e
   exitWith e

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -101,7 +101,8 @@ Executable fixpoint.native
                , syb
                , cmdargs
                , ansi-terminal
-               , terminal-progress-bar
+               -- , terminal-progress-bar
+               , ascii-progress
                , bifunctors
                , binary
                , bytestring
@@ -133,7 +134,8 @@ Executable fixpoint
                , syb
                , cmdargs
                , ansi-terminal
-               , terminal-progress-bar
+               -- , terminal-progress-bar
+               , ascii-progress
                , bifunctors
                , binary
                , bytestring
@@ -174,6 +176,7 @@ Library
                    Language.Fixpoint.Smt.Serialize,
                    Language.Fixpoint.Smt.Interface,
                    Language.Fixpoint.Misc,
+                   Language.Fixpoint.Progress,
                    Language.Fixpoint.Solver.Types,
                    Language.Fixpoint.Solver.Graph,
                    Language.Fixpoint.Solver.Solution,
@@ -196,7 +199,8 @@ Library
                , syb
                , cmdargs
                , ansi-terminal
-               , terminal-progress-bar
+               -- , terminal-progress-bar
+               , ascii-progress
                , bifunctors
                , binary
                , bytestring

--- a/src/Language/Fixpoint/Config.hs
+++ b/src/Language/Fixpoint/Config.hs
@@ -46,7 +46,6 @@ data Config
     , solver      :: SMTSolver           -- ^ which SMT solver to use
     , genSorts    :: GenQualifierSort    -- ^ generalize qualifier sorts
     , ueqAllSorts :: UeqAllSorts         -- ^ use UEq on all sorts
-    , native      :: Bool                -- ^ use haskell solver
     , real        :: Bool                -- ^ interpret div and mul in SMT
     , newcheck    :: Bool                -- ^ new fixpoint sort check
     , eliminate   :: Bool                -- ^ eliminate non-cut KVars
@@ -55,6 +54,7 @@ data Config
     , stats       :: Bool                -- ^ compute constraint statistics
     , parts       :: Bool                -- ^ partition FInfo into separate fq files
     , binary      :: Bool                -- ^ save FInfo as binary file
+    , extSolver   :: Bool                -- ^ use external (ocaml) solver
     -- , nontriv     :: Bool             -- ^ simplify using non-trivial sorts
     } deriving (Eq,Data,Typeable,Show)
 
@@ -69,7 +69,6 @@ instance Default Config where
                , solver      = def
                , genSorts    = def
                , ueqAllSorts = def
-               , native      = def
                , real        = def
                , newcheck    = False
                , eliminate   = def
@@ -78,6 +77,7 @@ instance Default Config where
                , stats       = def
                , parts       = def
                , binary      = def
+               , extSolver   = def
                }
 
 instance Command Config where
@@ -150,7 +150,6 @@ config = Config {
   , solver      = def   &= help "Name of SMT Solver"
   , genSorts    = def   &= help "Generalize qualifier sorts"
   , ueqAllSorts = def   &= help "Use UEq on all sorts"
-  , native      = False &= help "(alpha) Haskell Solver"
   , newcheck    = False &= help "(alpha) New liquid-fixpoint sort checking "
   , real        = False &= help "(alpha) Theory of real numbers"
   , eliminate   = False &= help "(alpha) Eliminate non-cut KVars"
@@ -162,6 +161,7 @@ config = Config {
   , cores       = def   &= help "(numeric) Number of threads to use"
   , minPartSize = defaultMinPartSize &= help "(numeric) Minimum partition size when solving in parallel"
   , maxPartSize = defaultMaxPartSize &= help "(numeric) Maximum partiton size when solving in parallel."
+  , extSolver   = False &= help "Use external (Ocaml) Solver"
   }
   &= verbosity
   &= program "fixpoint"
@@ -184,4 +184,3 @@ banner =  "\n\nLiquid-Fixpoint Copyright 2013-15 Regents of the University of Ca
 
 multicore :: Config -> Bool
 multicore cfg = cores cfg /= Just 1
-

--- a/src/Language/Fixpoint/Errors.hs
+++ b/src/Language/Fixpoint/Errors.hs
@@ -101,6 +101,7 @@ instance Fixpoint Error where
   toFix = pprint
 
 instance Exception Error
+instance Exception (FixResult Error)
 
 instance E.Error Error where
   strMsg = Error dummySpan

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -38,6 +38,7 @@ import           Language.Fixpoint.Solver.Solution  (Solution)
 import           Language.Fixpoint.Config           (multicore, Config (..), command, withTarget)
 import           Language.Fixpoint.Files            hiding (Result)
 import           Language.Fixpoint.Misc
+import           Language.Fixpoint.Progress
 import           Language.Fixpoint.Statistics       (statistics)
 import           Language.Fixpoint.Partition        (partition, partition')
 import           Language.Fixpoint.Parse            (rr, rr', mkQual)
@@ -46,6 +47,7 @@ import           Language.Fixpoint.Errors           (exit)
 import           Language.Fixpoint.PrettyPrint      (showpp)
 import           Language.Fixpoint.Parallel         (inParallelUsing)
 import           Control.DeepSeq
+
 
 ---------------------------------------------------------------------------
 -- | Top level Solvers ----------------------------------------------------
@@ -59,9 +61,10 @@ solveFQ :: Config -> IO ExitCode
 ---------------------------------------------------------------------------
 solveFQ cfg = do fi      <- readFInfo file
                  r       <- solve cfg fi
-                 let stat = resStatus r
-                 putStrLn "\n"
-                 colorStrLn (colorResult stat) (show stat)
+                 let stat = resStatus $!! r
+                 let str  = show $!! stat
+                 -- putStrLn "\n"
+                 colorStrLn (colorResult stat) str
                  return $ eCode r
   where
     file    = inFile       cfg

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -187,6 +187,7 @@ solveNative !cfg !fi0 = do
   -- let qs   = quals fi0
   -- whenLoud $ print qs
   let fi1  = fi0 { quals = remakeQual <$> quals fi0 }
+  whenLoud $ print (quals fi1) 
   let si   = {-# SCC "convertFormat" #-} convertFormat fi1
   -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si)
   -- rnf si `seq` donePhase Loud "Format Conversion"

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -187,7 +187,7 @@ solveNative !cfg !fi0 = do
   -- let qs   = quals fi0
   -- whenLoud $ print qs
   let fi1  = fi0 { quals = remakeQual <$> quals fi0 }
-  whenLoud $ putStrLn $ showFix (quals fi1) 
+  whenLoud $ putStrLn $ showFix (quals fi1)
   let si   = {-# SCC "convertFormat" #-} convertFormat fi1
   -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si)
   -- rnf si `seq` donePhase Loud "Format Conversion"
@@ -221,7 +221,7 @@ elim cfg fi
   | otherwise     = return (M.empty, fi)
 
 remakeQual :: Qualifier -> Qualifier
-remakeQual q = {- traceShow msg $ -} mkQual (q_name q) (q_params q) (q_body q) (q_pos q)
+remakeQual q = traceShow msg $ mkQual (q_name q) (q_params q) (q_body q) (q_pos q)
   where
     msg      = "REMAKEQUAL: " ++ show q
 

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -91,8 +91,8 @@ saveBin cfg fi = when (binary cfg) $ saveBinaryFile cfg fi
 
 configSolver   :: (NFData a, Fixpoint a) => Config -> Solver a
 configSolver cfg
-  | native cfg = solveNative
-  | otherwise  = solveExt
+  | extSolver cfg = solveExt
+  | otherwise     = solveNative
 
 configSW :: (NFData a, Fixpoint a) => Config -> Solver a -> Solver a
 configSW cfg

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -221,7 +221,7 @@ elim cfg fi
   | otherwise     = return (M.empty, fi)
 
 remakeQual :: Qualifier -> Qualifier
-remakeQual q = traceShow msg $ mkQual (q_name q) (q_params q) (q_body q) (q_pos q)
+remakeQual q = {- traceShow msg $ -} mkQual (q_name q) (q_params q) (q_body q) (q_pos q)
   where
     msg      = "REMAKEQUAL: " ++ show q
 

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -187,7 +187,7 @@ solveNative !cfg !fi0 = do
   -- let qs   = quals fi0
   -- whenLoud $ print qs
   let fi1  = fi0 { quals = remakeQual <$> quals fi0 }
-  whenLoud $ print (quals fi1) 
+  whenLoud $ putStrLn $ showFix (quals fi1) 
   let si   = {-# SCC "convertFormat" #-} convertFormat fi1
   -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si)
   -- rnf si `seq` donePhase Loud "Format Conversion"

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -25,7 +25,7 @@ import           System.Process                   (system)
 import           System.Directory                 (createDirectoryIfMissing)
 import           System.FilePath                  (takeDirectory)
 import           Text.PrettyPrint.HughesPJ        hiding (first)
-import           System.ProgressBar
+-- import           System.ProgressBar
 import           System.IO ( hSetBuffering, BufferMode(NoBuffering), stdout, hFlush )
 
 #ifdef MIN_VERSION_located_base
@@ -212,29 +212,10 @@ ensurePath = createDirectoryIfMissing True . takeDirectory
 fM :: (Monad m) => (a -> b) -> a -> m b
 fM f = return . f
 
----------------------------------------------------------------------------
--- | Progress Bar API
----------------------------------------------------------------------------
-
-{-# NOINLINE pbRef #-}
-pbRef :: IORef (Maybe ProgressRef)
-pbRef = unsafePerformIO (newIORef Nothing)
-
-progressInit :: Integer -> IO ()
-progressInit n = do
-  loud <- isLoud
-  unless loud $ do
-    pr <- mkPB n
-    writeIORef pbRef (Just pr)
-
-mkPB   :: Integer -> IO ProgressRef
-mkPB n = do
-  hSetBuffering stdout NoBuffering
-  -- fst <$> startProgress percentage exact 80 n
-  fst <$> startProgress noLabel percentage 80 n
-
-progressTick :: IO ()
-progressTick    = go =<< readIORef pbRef
-  where
-   go (Just pr) = incProgress pr 1
-   go _         = return ()
+{-
+exitColorStrLn :: Moods -> String -> IO ()
+exitColorStrLn c s = do
+  writeIORef pbRef Nothing --(Just pr)
+  putStrLn "\n"
+  colorStrLn c s
+-}

--- a/src/Language/Fixpoint/Names.hs
+++ b/src/Language/Fixpoint/Names.hs
@@ -258,6 +258,7 @@ keywords   = S.fromList [ "env"
                         , "lhs"
                         , "rhs"
                         , "NaN"
+                        , "min"
                         ]
 
 -- | RJ: We allow the extra 'unsafeChars' to allow parsing encoded symbols.

--- a/src/Language/Fixpoint/Names.hs
+++ b/src/Language/Fixpoint/Names.hs
@@ -259,6 +259,7 @@ keywords   = S.fromList [ "env"
                         , "rhs"
                         , "NaN"
                         , "min"
+                        , "map"
                         ]
 
 -- | RJ: We allow the extra 'unsafeChars' to allow parsing encoded symbols.

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -25,6 +25,7 @@ module Language.Fixpoint.Parse (
   , colon   , dcolon
   , whiteSpace
   , blanks
+  , pairP
 
   -- * Parsing basic entities
 

--- a/src/Language/Fixpoint/Progress.hs
+++ b/src/Language/Fixpoint/Progress.hs
@@ -24,9 +24,10 @@ progressInit n = do
     writeIORef pbRef (Just pr)
 
 mkPB   :: Int -> IO ProgressBar
-mkPB n = newProgressBar def { pgWidth = 80
-                            , pgTotal = n
-                            , pgFormat = "Working :percent [:bar]"
+mkPB n = newProgressBar def { pgWidth       = 80
+                            , pgTotal       = n
+                            , pgFormat      = "Working :percent [:bar]"
+                            , pgPendingChar = '.'
                             }
 
 progressTick :: IO ()

--- a/src/Language/Fixpoint/Progress.hs
+++ b/src/Language/Fixpoint/Progress.hs
@@ -1,0 +1,42 @@
+-- | Progress Bar API
+
+module Language.Fixpoint.Progress (
+      progressInit
+    , progressTick
+    , progressClose
+    ) where
+
+import           Control.Monad                    (unless)
+import           System.IO.Unsafe                 (unsafePerformIO)
+import           System.Console.CmdArgs.Verbosity (isLoud, whenLoud)
+import           Data.IORef
+import           System.Console.AsciiProgress -- (ProgressBar(..), Options(..), isComplete, def, newProgressBar, tick)
+
+{-# NOINLINE pbRef #-}
+pbRef :: IORef (Maybe ProgressBar)
+pbRef = unsafePerformIO (newIORef Nothing)
+
+progressInit :: Int -> IO ()
+progressInit n = do
+  loud <- isLoud
+  unless loud $ do
+    pr <- mkPB n
+    writeIORef pbRef (Just pr)
+
+mkPB   :: Int -> IO ProgressBar
+mkPB n = newProgressBar def { pgWidth = 80
+                            , pgTotal = n
+                            , pgFormat = "Working :percent [:bar]"
+                            }
+
+progressTick :: IO ()
+progressTick    = go =<< readIORef pbRef
+  where
+   go (Just pr) = tick pr
+   go _         = return ()
+
+progressClose :: IO ()
+progressClose = go =<< readIORef pbRef
+  where
+    go (Just p) = complete p
+    go _        = return ()

--- a/src/Language/Fixpoint/Progress.hs
+++ b/src/Language/Fixpoint/Progress.hs
@@ -1,7 +1,8 @@
 -- | Progress Bar API
 
 module Language.Fixpoint.Progress (
-      progressInit
+      withProgress
+    , progressInit
     , progressTick
     , progressClose
     ) where
@@ -15,6 +16,14 @@ import           System.Console.AsciiProgress -- (ProgressBar(..), Options(..), 
 {-# NOINLINE pbRef #-}
 pbRef :: IORef (Maybe ProgressBar)
 pbRef = unsafePerformIO (newIORef Nothing)
+
+withProgress :: Int -> IO a -> IO a
+withProgress n act = do
+  progressInit n
+  r <- act
+  progressClose
+  return r
+
 
 progressInit :: Int -> IO ()
 progressInit n = do

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 -- | This is a wrapper around IO that permits SMT queries
 
 module Language.Fixpoint.Solver.Monad
@@ -17,10 +19,14 @@ module Language.Fixpoint.Solver.Monad
        , Stats
        , tickIter
        , stats
+       , numIter
        )
        where
 
-import           Language.Fixpoint.Misc    (progressTick, groupList)
+import           Control.DeepSeq
+import           GHC.Generics
+import           Language.Fixpoint.Progress
+import           Language.Fixpoint.Misc    (groupList)
 import           Language.Fixpoint.Config  (Config, solver)
 import qualified Language.Fixpoint.Types   as F
 import qualified Language.Fixpoint.Errors  as E
@@ -50,7 +56,9 @@ data Stats = Stats { numCstr :: !Int -- ^ # Horn Constraints
                    , numBrkt :: !Int -- ^ # smtBracket    calls (push/pop)
                    , numChck :: !Int -- ^ # smtCheckUnsat calls
                    , numVald :: !Int -- ^ # times SMT said RHS Valid
-                   } deriving (Show)
+                   } deriving (Show, Generic)
+
+instance NFData Stats
 
 stats0    :: F.GInfo c b -> Stats
 stats0 fi = Stats nCs 0 0 0 0

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -125,9 +125,7 @@ init :: F.SInfo a -> Solution
 --------------------------------------------------------------------
 init fi  = M.fromList keqs
   where
-    -- PARALLELIZE THIS!
-    -- keqs = parMap rdeepseq (refine fi qs) ws -- How to make this parallel?
-    keqs = map (refine fi qs) ws `using` parList rdeepseq -- How to make this parallel?
+    keqs = map (refine fi qs) ws `using` parList rdeepseq 
     qs   = F.quals fi
     ws   = M.elems $ F.ws fi
 

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -9,6 +9,7 @@ import           Control.Concurrent (threadDelay)
 import           Control.Monad (filterM)
 import           Control.Monad.State.Strict (lift)
 import qualified Data.HashMap.Strict  as M
+import           Language.Fixpoint.Progress
 import           Language.Fixpoint.Misc
 import qualified Language.Fixpoint.Types as F
 import           Language.Fixpoint.Config hiding (stats)
@@ -20,16 +21,18 @@ import           Text.Printf
 import           Language.Fixpoint.PrettyPrint
 import           Debug.Trace
 import           System.Console.CmdArgs.Verbosity (whenLoud)
-
+import           Control.DeepSeq
 
 ---------------------------------------------------------------------------
-solve :: (F.Fixpoint a) => Config -> S.Solution -> F.SInfo a -> IO (F.Result a)
+solve :: (NFData a, F.Fixpoint a) => Config -> S.Solution -> F.SInfo a -> IO (F.Result a)
 ---------------------------------------------------------------------------
 solve cfg s0 fi = do
     -- donePhase Loud "Worklist Initialize"
-    (r, s) <- runSolverM cfg fi n act
-    whenLoud $ printStats fi wkl s
-    return r
+    (res, stat) <- runSolverM cfg fi n act
+    progressClose
+    whenLoud $ printStats fi wkl stat
+    -- print (numIter stat)
+    return res
   where
     wkl  = W.init fi
     n    = fromIntegral $ W.wRanks wkl
@@ -42,16 +45,17 @@ printStats fi w s = putStrLn "\n" >> ppTs [ ptable fi, ptable s, ptable w ]
 
 
 ---------------------------------------------------------------------------
-solve_ :: (F.Fixpoint a) => F.SInfo a -> S.Solution -> W.Worklist a -> SolveM (F.Result a, Stats)
+solve_ :: (NFData a, F.Fixpoint a) => F.SInfo a -> S.Solution -> W.Worklist a -> SolveM (F.Result a, Stats)
 ---------------------------------------------------------------------------
 solve_ fi s0 wkl = do
   let s0' = mappend s0 $ {-# SCC "sol-init" #-} S.init fi
   s   <- {-# SCC "sol-refine" #-} refine s0' wkl
   -- donePhase' "Solution: Fixpoint"
   st  <- stats
-  res <- {-# SCC "sol-result" #-} result fi wkl s
+  res <- {-# SCC "sol-result" #-} result wkl s
   -- donePhase' "Solution: Check"
-  return (res, st)
+  return $!! (res, st)
+
 
 ---------------------------------------------------------------------------
 refine :: S.Solution -> W.Worklist a -> SolveM S.Solution
@@ -104,9 +108,9 @@ predKs _              = []
 ---------------------------------------------------------------------------
 -- | Convert Solution into Result -----------------------------------------
 ---------------------------------------------------------------------------
-result :: (F.Fixpoint a) => F.SInfo a -> W.Worklist a -> S.Solution -> SolveM (F.Result a)
+result :: (F.Fixpoint a) => W.Worklist a -> S.Solution -> SolveM (F.Result a)
 ---------------------------------------------------------------------------
-result fi wkl s = do
+result wkl s = do
   let sol  = M.map (F.pAnd . fmap S.eqPred) s
   stat    <- result_ wkl s
   return   $ F.Result (F.WrapC <$> stat) sol

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -29,7 +29,6 @@ solve :: (NFData a, F.Fixpoint a) => Config -> S.Solution -> F.SInfo a -> IO (F.
 solve cfg s0 fi = do
     -- donePhase Loud "Worklist Initialize"
     (res, stat) <- runSolverM cfg fi n act
-    progressClose
     whenLoud $ printStats fi wkl stat
     -- print (numIter stat)
     return res

--- a/src/Language/Fixpoint/Statistics.hs
+++ b/src/Language/Fixpoint/Statistics.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 -- | This module implements functions that print out
 --   statistics about the constraints.
 module Language.Fixpoint.Statistics (statistics) where
 
+import           Control.DeepSeq
+import           GHC.Generics
 import           Control.Arrow ((&&&))
 
 import           Language.Fixpoint.Misc                (donePhase, Moods(..), applyNonNull)
@@ -37,7 +41,9 @@ data Stats = Stats { cSizes  :: [Float]
                    , cMean   :: Float
                    , cMax    :: Float
                    , cSpeed  :: Float
-                   } deriving (Show)
+                   } deriving (Show, Generic)
+
+instance NFData Stats
 
 instance PPrint Stats where
   pprint s = vcat [ text "STAT: max/total = " <+> pprint (cMax   s) <+> text "/" <+> pprint (cTotal s)

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,3 +14,4 @@ flags:
 extra-deps:
 - intern-0.9.1.4
 - located-base-0.1.0.0
+- ascii-progress-0.2.1.2

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -23,7 +23,7 @@ unitTests
       testGroup "native-pos" <$> dirTests nativeCmd "tests/pos"  []  ExitSuccess
     , testGroup "native-neg" <$> dirTests nativeCmd "tests/neg"  []  (ExitFailure 1)
     --Given all the changes in LH, Ben doesn't trust test000 anymore until he can reproduce the failure using a current LH test
-    , testGroup "elim-pos1"  <$> dirTests elimCmd   "tests/pos"  ["test000.hs.fq"]  ExitSuccess 
+    , testGroup "elim-pos1"  <$> dirTests elimCmd   "tests/pos"  ["test000.hs.fq"]  ExitSuccess
     , testGroup "elim-pos2"  <$> dirTests elimCmd   "tests/elim" []  ExitSuccess
     , testGroup "elim-neg"   <$> dirTests elimCmd   "tests/neg"  []  (ExitFailure 1)
    ]
@@ -60,19 +60,19 @@ mkTest testCmd code dir file
     test = dir </> file
     log  = let (d,f) = splitFileName file in dir </> d </> ".liquid" </> f <.> "log"
 
-binPath pkgName = do 
+binPath pkgName = do
   testPath <- getExecutablePath
-  return    $ (takeDirectory $ takeDirectory testPath) </> pkgName </> pkgName 
+  return    $ (takeDirectory $ takeDirectory testPath) </> pkgName </> pkgName
 
 knownToFail = []
 ---------------------------------------------------------------------------
 type TestCmd = FilePath -> FilePath -> FilePath -> String
 
 nativeCmd :: TestCmd
-nativeCmd bin dir file = printf "cd %s && %s --native %s" dir bin file
+nativeCmd bin dir file = printf "cd %s && %s %s" dir bin file
 
 elimCmd :: TestCmd
-elimCmd bin dir file = printf "cd %s && %s --native --eliminate %s" dir bin file
+elimCmd bin dir file = printf "cd %s && %s --eliminate %s" dir bin file
 
 
 


### PR DESCRIPTION
As said above.

All tests pass on LH and RSC (not counting RSC benchmarks) so we can start thinking about nuking the ocaml solver...