### PR TITLE
Tidy up error message / failure

### DIFF
--- a/src/Language/Fixpoint/Config.hs
+++ b/src/Language/Fixpoint/Config.hs
@@ -16,8 +16,9 @@ module Language.Fixpoint.Config (
   , multicore
 ) where
 
-import           System.Console.CmdArgs
-import           Language.Fixpoint.Files
+import System.Console.CmdArgs
+import Language.Fixpoint.Files
+import Language.Fixpoint.Misc (errorstar)
 
 class Command a  where
   command :: a -> String
@@ -135,7 +136,7 @@ smtSolver "z3"      = Z3
 smtSolver "cvc4"    = Cvc4
 smtSolver "mathsat" = Mathsat
 smtSolver "z3mem"   = Z3mem
-smtSolver other     = error $ "ERROR: unsupported SMT Solver = " ++ other
+smtSolver other     = errorstar $ "ERROR: unsupported SMT Solver = " ++ other
 
 -- defaultSolver       :: Maybe SMTSolver -> SMTSolver
 -- defaultSolver       = fromMaybe Z3

--- a/src/Language/Fixpoint/Errors.hs
+++ b/src/Language/Fixpoint/Errors.hs
@@ -143,7 +143,7 @@ result :: Error -> Result a
 ---------------------------------------------------------------------
 result e = Result (Crash [] msg) mempty
   where
-    msg  = trace "HITTING RESULT" $ showpp e
+    msg  = {- trace "HITTING RESULT" $ -} showpp e
 
 ---------------------------------------------------------------------
 exit :: a -> IO a -> IO a

--- a/src/Language/Fixpoint/Errors.hs
+++ b/src/Language/Fixpoint/Errors.hs
@@ -99,7 +99,6 @@ data Error = Error { errLoc :: SrcSpan, errMsg :: String }
 
 instance PPrint Error where
   pprint (Error l msg) = ppSrcSpan l <> text (": Error: " ++ msg)
-                         -- text $ printf "%s\n  %s\n" (showpp l) msg
 
 instance Fixpoint Error where
   toFix = pprint
@@ -142,7 +141,7 @@ die = throw
 ---------------------------------------------------------------------
 result :: Error -> Result a
 ---------------------------------------------------------------------
-result e = Result (Crash [] msg) mempty
+result e = Result (Crash [] "msg") mempty
   where
     msg  = showpp e
 
@@ -159,7 +158,8 @@ exit def act = catch act $ \(e :: Error) -> do
 ---------------------------------------------------------------------
 
 errFreeVarInQual  :: Qualifier -> Error
-errFreeVarInQual q = err sp $ printf "Qualifier with free vars : %s \n" (showFix q)
+-- errFreeVarInQual q = err sp $ printf "Qualifier with free vars : %s \n" (showFix q)
+errFreeVarInQual q = err dummySpan $ printf "Qualifier with free vars" --  : %s \n" (showFix q)
   where
     sp             = SS l l
     l              = q_pos q

--- a/src/Language/Fixpoint/Errors.hs
+++ b/src/Language/Fixpoint/Errors.hs
@@ -45,7 +45,7 @@ import           Language.Fixpoint.Misc
 import           Text.Parsec.Pos
 import           Text.PrettyPrint.HughesPJ
 import           Text.Printf
-
+import           Debug.Trace
 -----------------------------------------------------------------------
 -- | A Reusable SrcSpan Type ------------------------------------------
 -----------------------------------------------------------------------
@@ -141,9 +141,9 @@ die = throw
 ---------------------------------------------------------------------
 result :: Error -> Result a
 ---------------------------------------------------------------------
-result e = Result (Crash [] "msg") mempty
+result e = Result (Crash [] msg) mempty
   where
-    msg  = showpp e
+    msg  = trace "HITTING RESULT" $ showpp e
 
 ---------------------------------------------------------------------
 exit :: a -> IO a -> IO a
@@ -158,8 +158,8 @@ exit def act = catch act $ \(e :: Error) -> do
 ---------------------------------------------------------------------
 
 errFreeVarInQual  :: Qualifier -> Error
--- errFreeVarInQual q = err sp $ printf "Qualifier with free vars : %s \n" (showFix q)
-errFreeVarInQual q = err dummySpan $ printf "Qualifier with free vars" --  : %s \n" (showFix q)
+errFreeVarInQual q = err sp $ printf "Qualifier with free vars : %s \n" (showFix q)
+-- errFreeVarInQual q = err dummySpan $ printf "Qualifier with free vars" --  : %s \n" (showFix q)
   where
     sp             = SS l l
     l              = q_pos q

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -63,13 +63,14 @@ type Solver a = Config -> FInfo a -> IO (Result a)
 ---------------------------------------------------------------------------
 solveFQ :: Config -> IO ExitCode
 ---------------------------------------------------------------------------
-solveFQ cfg = do fi      <- readFInfo file
-                 r       <- solve cfg fi
-                 let stat = resStatus $!! r
-                 -- let str  = render $ resultDoc $!! (const () <$> stat)
-                 -- putStrLn "\n"
-                 colorStrLn (colorResult stat) (statStr stat)
-                 return $ eCode r
+solveFQ cfg = do
+    fi      <- readFInfo file
+    r       <- solve cfg fi
+    let stat = resStatus $!! r
+    -- let str  = render $ resultDoc $!! (const () <$> stat)
+    -- putStrLn "\n"
+    colorStrLn (colorResult stat) (statStr stat)
+    return $ eCode r
   where
     file    = inFile       cfg
     eCode   = resultExit . resStatus

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -66,13 +66,14 @@ solveFQ :: Config -> IO ExitCode
 solveFQ cfg = do fi      <- readFInfo file
                  r       <- solve cfg fi
                  let stat = resStatus $!! r
-                 let str  = show $!! stat
+                 -- let str  = render $ resultDoc $!! (const () <$> stat)
                  -- putStrLn "\n"
-                 colorStrLn (colorResult stat) str
+                 colorStrLn (colorResult stat) (statStr stat)
                  return $ eCode r
   where
     file    = inFile       cfg
     eCode   = resultExit . resStatus
+    statStr = render . resultDoc . fmap (const ())
 
 -- | Solve FInfo system of horn-clause constraints ------------------------
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Interface.hs
+++ b/src/Language/Fixpoint/Interface.hs
@@ -187,7 +187,7 @@ solveParWith s c fi0 = do
 ---------------------------------------------------------------------------
 solveNative, solveNative' :: (NFData a, Fixpoint a) => Solver a
 ---------------------------------------------------------------------------
-solveNative !cfg !fi0 = (solveNative cfg fi0) -- `catch` (return . result)
+solveNative !cfg !fi0 = (solveNative' cfg fi0) `catch` (return . result)
 
 solveNative' !cfg !fi0 = do
   -- writeLoud $ "fq file in: \n" ++ render (toFixpoint cfg fi)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -522,7 +522,7 @@ wfCP = do reserved "env"
           env <- envP
           reserved "reft"
           r   <- sortedReftP
-          let [w] = wfC env r () --TODO error handling?
+          let [w] = wfC env r ()
           return w
 
 subCP :: Parser (SubC ())

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -53,6 +53,7 @@ module Language.Fixpoint.Smt.Interface (
     ) where
 
 import           Language.Fixpoint.Config (SMTSolver (..))
+import           Language.Fixpoint.Misc   (errorstar)
 import           Language.Fixpoint.Errors
 import           Language.Fixpoint.Files
 import           Language.Fixpoint.Types
@@ -96,10 +97,10 @@ runCommands cmds
 
 -- TODO take makeContext's Bool from caller instead of always using False?
 makeZ3Context :: FilePath -> [(Symbol, Sort)] -> IO Context
-makeZ3Context f xts 
+makeZ3Context f xts
   = do me <- makeContext False Z3 f
-       smtDecls me xts 
-       return me 
+       smtDecls me xts
+       return me
 
 checkValidWithContext :: Context -> [(Symbol, Sort)] -> Pred -> Pred -> IO Bool
 checkValidWithContext me xts p q
@@ -117,7 +118,7 @@ checkValid u f xts p q
        smtAssert me $ pAnd [p, PNot q]
        smtCheckUnsat me
 
--- | If you already HAVE a context, where all the variables have declared types 
+-- | If you already HAVE a context, where all the variables have declared types
 --   (e.g. if you want to make MANY repeated Queries)
 
 -- checkValid :: e:Env -> [ClosedPred e] -> IO [Bool]
@@ -156,7 +157,7 @@ smtRead me = {-# SCC "smtRead" #-}
     do ln  <- smtReadRaw me
        res <- A.parseWith (smtReadRaw me) responseP ln
        case A.eitherResult res of
-         Left e  -> error e
+         Left e  -> errorstar $ "SMTREAD:" ++ e
          Right r -> do
            maybe (return ()) (\h -> hPutStrLnNow h $ format "; SMT Says: {}" (Only $ show r)) (cLog me)
            -- when (verbose me) $ TIO.putStrLn $ format "SMT Says: {}" (Only $ show r)

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -42,7 +42,7 @@ import           Language.Fixpoint.Misc (errorstar)
 
 -}
 instance SMTLIB2 Sort where
-  smt2 s@(FFunc _ _)           = error $ "smt2 FFunc: " ++ show s
+  smt2 s@(FFunc _ _)           = errorstar $ "smt2 FFunc: " ++ show s
   smt2 FInt                    = "Int"
   smt2 FReal                   = "Real"
   smt2 t
@@ -85,7 +85,7 @@ instance SMTLIB2 Brel where
   smt2 Ge    = ">="
   smt2 Lt    = "<"
   smt2 Le    = "<="
-  smt2 _     = error "SMTLIB2 Brel"
+  smt2 _     = errorstar "SMTLIB2 Brel"
 
 instance SMTLIB2 Expr where
   smt2 (ESym z)         = smt2 (symbol z)
@@ -96,9 +96,9 @@ instance SMTLIB2 Expr where
   smt2 (EBin o e1 e2)   = smt2Bop o e1 e2
   smt2 (EIte e1 e2 e3)  = format "(ite {} {} {})" (smt2 e1, smt2 e2, smt2 e3)
   smt2 (ECst e _)       = smt2 e
-  smt2 e                = error  $ "TODO: SMTLIB2 Expr: " ++ show e
+  smt2 e                = errorstar  $ "TODO: SMTLIB2 Expr: " ++ show e
 
-smt2Bop o e1 e2 
+smt2Bop o e1 e2
   | o == Times || o == Div = smt2App (uOp o) [e1, e2]
   | otherwise  = format "({} {} {})" (smt2 o, smt2 e1, smt2 e2)
 
@@ -126,7 +126,7 @@ instance SMTLIB2 Pred where
   smt2 (PExist bs p)    = format "(exists ({}) {})"  (smt2s bs, smt2 p)
   smt2 (PBexp e)        = smt2 e
   smt2 (PAtom r e1 e2)  = mkRel r e1 e2
-  smt2 _                = error "smtlib2 Pred"
+  smt2 _                = errorstar "smtlib2 Pred"
 
 
 mkRel Ne  e1 e2         = mkNe e1 e2

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -58,11 +58,7 @@ banQualifFreeVars fi = Misc.applyNonNull (Right fi) (Left . badQuals) bads
     isOk q = F.syms (F.q_body q) `isSubset` (lits ++ (F.syms $ fst <$> (F.q_params q)))
 
 badQuals :: Misc.ListNE F.Qualifier -> E.Error
-badQuals = E.catErrors . map badQual
-
-badQual :: F.Qualifier -> E.Error
-badQual q = E.err E.dummySpan $ printf "Qualifier with free vars : %s \n"
-              (showpp $ F.q_name q)
+badQuals = E.catErrors . map E.errFreeVarInQual
 
 -- True if first is a subset of second
 isSubset a b = S.null $ a' `S.difference` b'

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -19,7 +19,7 @@ import           Language.Fixpoint.PrettyPrint
 import           Language.Fixpoint.Visitor     (isConcC, isKvarC)
 import           Language.Fixpoint.Sort        (isFirstOrder)
 import qualified Language.Fixpoint.Misc   as Misc
-import           Language.Fixpoint.Misc        (fM)
+import           Language.Fixpoint.Misc        (fM, errorstar)
 import qualified Language.Fixpoint.Types  as F
 import qualified Language.Fixpoint.Errors as E
 import qualified Data.HashMap.Strict      as M

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -33,7 +33,7 @@ type ValidateM a = Either E.Error a
 
 ---------------------------------------------------------------------------
 validate :: F.SInfo a -> ValidateM ()
-validate = error "TODO: validate input"
+validate = errorstar "TODO: validate input"
 ---------------------------------------------------------------------------
 
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Sort.hs
+++ b/src/Language/Fixpoint/Sort.hs
@@ -130,9 +130,9 @@ instance Freshable [Int] where
 -------------------------------------------------------------------------
 
 checkSortedReft :: SEnv SortedReft -> [Symbol] -> SortedReft -> Maybe Doc
-checkSortedReft env xs sr = applyNonNull Nothing error unknowns
+checkSortedReft env xs sr = applyNonNull Nothing oops unknowns
   where
-    error                 = Just . (text "Unknown symbols:" <+>) . toFix
+    oops                  = Just . (text "Unknown symbols:" <+>) . toFix
     unknowns              = [ x | x <- syms sr, x `notElem` v : xs, not (x `memberSEnv` env)]
     Reft (v,_)            = sr_reft sr
 

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -1627,7 +1627,7 @@ instance Reftable SortedReft where
   isTauto  = isTauto . toReft
   ppTy     = ppTy . toReft
   toReft   = sr_reft
-  ofReft   = error "No instance of ofReft for SortedReft"
+  ofReft   = errorstar "No instance of ofReft for SortedReft"
   params _ = []
   bot s    = s { sr_reft = falseReft }
 

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -1005,11 +1005,11 @@ instance (Ord a, Fixpoint a) => Fixpoint (FixResult (SubC a)) where
   toFix (Crash xs msg)   = vcat $ [ text "Crash!" ] ++  pprSinfos "CRASH: " xs ++ [parens (text msg)]
   toFix (Unsafe xs)      = vcat $ text "Unsafe:" : pprSinfos "WARNING: " xs
 
+
 pprSinfos :: (Ord a, Fixpoint a) => String -> [SubC a] -> [Doc]
 pprSinfos msg = map ((text msg <>) . toFix) . sort . fmap sinfo
 
-
-resultDoc :: (Ord a, Fixpoint a) => FixResult a -> Doc
+resultDoc :: (Fixpoint a) => FixResult a -> Doc
 resultDoc Safe             = text "Safe"
 resultDoc (UnknownError d) = text $ "Unknown Error: " ++ d
 resultDoc (Crash xs msg)   = vcat $ text ("Crash!: " ++ msg) : (((text "CRASH:" <+>) . toFix) <$> xs)

--- a/tests/neg/test00.hs.fq
+++ b/tests/neg/test00.hs.fq
@@ -1,812 +1,286 @@
-qualif IsEmp(v : GHC.Types.Bool, fix##126#Xs : [@(0)]): ((? Prop([v])) <=> (len([fix##126#Xs]) > 0)) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 13, column 8)
-qualif IsEmp(v : GHC.Types.Bool, fix##126#Xs : [@(0)]): ((? Prop([v])) <=> (len([fix##126#Xs]) = 0)) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 14, column 8)
-qualif ListZ(v : [@(0)]): (len([v]) = 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 16, column 8)
-qualif ListZ(v : [@(0)]): (len([v]) >= 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 17, column 8)
-qualif ListZ(v : [@(0)]): (len([v]) > 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 18, column 8)
-qualif CmpLen(v : [@(1)], fix##126#Xs : [@(0)]): (len([v]) = len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 20, column 8)
-qualif CmpLen(v : [@(1)], fix##126#Xs : [@(0)]): (len([v]) >= len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 21, column 8)
-qualif CmpLen(v : [@(1)], fix##126#Xs : [@(0)]): (len([v]) > len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 22, column 8)
-qualif CmpLen(v : [@(1)], fix##126#Xs : [@(0)]): (len([v]) <= len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 23, column 8)
-qualif CmpLen(v : [@(1)], fix##126#Xs : [@(0)]): (len([v]) < len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 24, column 8)
-qualif EqLen(v : int, fix##126#Xs : [@(0)]): (v = len([fix##126#Xs])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 26, column 8)
-qualif LenEq(v : [@(0)], fix##126#X : int): (fix##126#X = len([v])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 27, column 8)
-qualif LenDiff(v : [@(0)], fix##126#X : int): (len([v]) = (fix##126#X + 1)) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 28, column 8)
-qualif LenDiff(v : [@(0)], fix##126#X : int): (len([v]) = (fix##126#X - 1)) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 29, column 8)
-qualif LenAcc(v : int, fix##126#Xs : [@(0)], fix##126#N : int): (v = (len([fix##126#Xs]) + fix##126#N)) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.hquals" (line 30, column 8)
-qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 3, column 8)
-qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 4, column 8)
-qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 5, column 8)
-qualif Bot(v : bool): (0 = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 6, column 8)
-qualif Bot(v : int): (0 = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 7, column 8)
-qualif CmpZ(v : @(0)): (v < 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 9, column 8)
-qualif CmpZ(v : @(0)): (v <= 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 10, column 8)
-qualif CmpZ(v : @(0)): (v > 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 11, column 8)
-qualif CmpZ(v : @(0)): (v >= 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 12, column 8)
-qualif CmpZ(v : @(0)): (v = 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 13, column 8)
-qualif CmpZ(v : @(0)): (v != 0) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 14, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v < fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 16, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v <= fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 17, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v > fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 18, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v >= fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 19, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v = fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 20, column 8)
-qualif Cmp(v : @(0), fix##126#X : @(0)): (v != fix##126#X) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 21, column 8)
-qualif One(v : int): (v = 1) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 28, column 8)
-qualif True(v : bool): (? v) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 29, column 8)
-qualif False(v : bool): (~ ((? v))) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 30, column 8)
-qualif True1(v : GHC.Types.Bool): (? Prop([v])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 31, column 8)
-qualif False1(v : GHC.Types.Bool): (~ ((? Prop([v])))) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 32, column 8)
-qualif Papp(v : @(0), fix##126#P : FAppTy Pred  @(0)): (? papp1([fix##126#P;
-                                                                 v])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 35, column 8)
-qualif Papp2(v : @(1), fix##126#X : @(0), fix##126#P : FAppTy (FAppTy Pred  @(1))  @(0)): (? papp2([fix##126#P;
-                                                                                                    v;
-                                                                                                    fix##126#X])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 38, column 8)
-qualif Papp3(v : @(2), fix##126#X : @(0), fix##126#Y : @(1), fix##126#P : FAppTy (FAppTy (FAppTy Pred  @(2))  @(0))  @(1)): (? papp3([fix##126#P;
-                                                                                                                                      v;
-                                                                                                                                      fix##126#X;
-                                                                                                                                      fix##126#Y])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/Prelude.hquals" (line 41, column 8)
-qualif Fst(v : @(1), fix##126#Y : @(0)): (v = fst([fix##126#Y])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.spec" (line 26, column 8)
-qualif Snd(v : @(1), fix##126#Y : @(0)): (v = snd([fix##126#Y])) // "/Users/rjhala/research/liquid/liquidhaskell/.cabal-sandbox/share/x86_64-osx-ghc-7.8.3/liquidhaskell-0.3.1.0/include/GHC/Base.spec" (line 27, column 8)
+qualif Fst(v : @(1), y : @(0)): (v = fst([y])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 29, column 8)
+qualif Snd(v : @(1), y : @(0)): (v = snd([y])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 30, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]): ((? Prop([v])) <=> (len([xs]) > 0)) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 13, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]): ((? Prop([v])) <=> (len([xs]) = 0)) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 14, column 8)
+qualif ListZ(v : [@(0)]): (len([v]) = 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 16, column 8)
+qualif ListZ(v : [@(0)]): (len([v]) >= 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 17, column 8)
+qualif ListZ(v : [@(0)]): (len([v]) > 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 18, column 8)
+qualif CmpLen(v : [@(1)], xs : [@(0)]): (len([v]) = len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 20, column 8)
+qualif CmpLen(v : [@(1)], xs : [@(0)]): (len([v]) >= len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 21, column 8)
+qualif CmpLen(v : [@(1)], xs : [@(0)]): (len([v]) > len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 22, column 8)
+qualif CmpLen(v : [@(1)], xs : [@(0)]): (len([v]) <= len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 23, column 8)
+qualif CmpLen(v : [@(1)], xs : [@(0)]): (len([v]) < len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 24, column 8)
+qualif EqLen(v : int, xs : [@(0)]): (v = len([xs])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 26, column 8)
+qualif LenEq(v : [@(0)], x : int): (x = len([v])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 27, column 8)
+qualif LenDiff(v : [@(0)], x : int): (len([v]) = (x + 1)) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 28, column 8)
+qualif LenDiff(v : [@(0)], x : int): (len([v]) = (x - 1)) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 29, column 8)
+qualif LenAcc(v : int, xs : [@(0)], n : int): (v = (len([xs]) + n)) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 30, column 8)
+qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 3, column 8)
+qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 4, column 8)
+qualif Bot(v : @(0)): (0 = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 5, column 8)
+qualif Bot(v : bool): (0 = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 6, column 8)
+qualif Bot(v : int): (0 = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 7, column 8)
+qualif CmpZ(v : @(0)): (v < 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 9, column 8)
+qualif CmpZ(v : @(0)): (v <= 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 10, column 8)
+qualif CmpZ(v : @(0)): (v > 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 11, column 8)
+qualif CmpZ(v : @(0)): (v >= 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 12, column 8)
+qualif CmpZ(v : @(0)): (v = 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 13, column 8)
+qualif CmpZ(v : @(0)): (v != 0) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 14, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v < x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 16, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v <= x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 17, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v > x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 18, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v >= x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 19, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v = x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 20, column 8)
+qualif Cmp(v : @(0), x : @(0)): (v != x) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 21, column 8)
+qualif One(v : int): (v = 1) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 28, column 8)
+qualif True(v : bool): (? v) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 29, column 8)
+qualif False(v : bool): (~ ((? v))) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 30, column 8)
+qualif True1(v : GHC.Types.Bool): (? Prop([v])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 31, column 8)
+qualif False1(v : GHC.Types.Bool): (~ ((? Prop([v])))) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 32, column 8)
+qualif Papp(v : @(0), p : (Pred  @(0))): (? papp1([p;
+                                                   v])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 35, column 8)
+qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))): (? papp2([p;
+                                                                    v;
+                                                                    x])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 38, column 8)
+qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))): (? papp3([p;
+                                                                                    v;
+                                                                                    x;
+                                                                                    y])) // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 41, column 8)
 
-constant Prop : (func(0, [GHC.Types.Bool; bool]))
-constant x_Tuple54 : (func(5, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4);
+
+
+
+constant runFun : (func(2, [(Arrow  @(0)  @(1)); @(0); @(1)]))
+constant addrLen : (func(0, [int; int]))
+constant xsListSelector : (func(1, [[@(0)]; [@(0)]]))
+constant x_Tuple21 : (func(2, [(Tuple  @(0)  @(1)); @(0)]))
+constant x_Tuple65 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
+                               @(4)]))
+constant GHC.Types.False$35$68 : (GHC.Types.Bool)
+constant x_Tuple55 : (func(5, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4));
+                               @(4)]))
+constant x_Tuple33 : (func(3, [(Tuple  @(0)  @(1)  @(2)); @(2)]))
+constant x_Tuple77 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
+                               @(6)]))
+constant papp3 : (func(6, [(Pred  @(0)  @(1)  @(2));
+                           @(3);
+                           @(4);
+                           @(5);
+                           bool]))
+constant x_Tuple63 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
+                               @(2)]))
+constant x_Tuple41 : (func(4, [(Tuple  @(0)  @(1)  @(2)  @(3));
+                               @(0)]))
+constant papp4 : (func(8, [(Pred  @(0)  @(1)  @(2)  @(6));
+                           @(3);
+                           @(4);
+                           @(5);
+                           @(7);
+                           bool]))
+constant x_Tuple64 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
                                @(3)]))
-constant x_Tuple44 : (func(4, [FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3);
+constant autolen : (func(1, [@(0); int]))
+constant x_Tuple52 : (func(5, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4));
+                               @(1)]))
+constant null : (func(1, [[@(0)]; bool]))
+constant papp2 : (func(4, [(Pred  @(0)  @(1)); @(2); @(3); bool]))
+constant x_Tuple62 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
+                               @(1)]))
+constant fromJust : (func(1, [(GHC.Base.Maybe  @(0)); @(0)]))
+constant x_Tuple53 : (func(5, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4));
+                               @(2)]))
+constant x_Tuple71 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
+                               @(0)]))
+constant x_Tuple74 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
+                               @(3)]))
+constant len : (func(2, [(@(0)  @(1)); int]))
+constant x_Tuple22 : (func(2, [(Tuple  @(0)  @(1)); @(1)]))
+constant x_Tuple66 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
+                               @(5)]))
+constant x_Tuple44 : (func(4, [(Tuple  @(0)  @(1)  @(2)  @(3));
                                @(3)]))
 constant xListSelector : (func(1, [[@(0)]; @(0)]))
-constant x_Tuple41 : (func(4, [FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3);
-                               @(0)]))
-constant x_Tuple76 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(5)]))
-constant addrLen : (func(0, [int; int]))
-constant x_Tuple65 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
-                               @(4)]))
-constant x_Tuple52 : (func(5, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4);
+constant strLen : (func(0, [int; int]))
+constant x_Tuple72 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
                                @(1)]))
-constant GHC.Types.False#68 : (GHC.Types.Bool)
-constant x_Tuple64 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
+constant isJust : (func(1, [(GHC.Base.Maybe  @(0)); bool]))
+constant Prop : (func(0, [GHC.Types.Bool; bool]))
+constant x_Tuple31 : (func(3, [(Tuple  @(0)  @(1)  @(2)); @(0)]))
+constant x_Tuple75 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
+                               @(4)]))
+constant papp1 : (func(1, [(Pred  @(0)); @(0); bool]))
+constant x_Tuple61 : (func(6, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5));
+                               @(0)]))
+constant x_Tuple43 : (func(4, [(Tuple  @(0)  @(1)  @(2)  @(3));
+                               @(2)]))
+constant x_Tuple51 : (func(5, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4));
+                               @(0)]))
+constant GHC.Types.I$35$$35$6c : (func(0, [int; int]))
+constant x_Tuple73 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
+                               @(2)]))
+constant x_Tuple54 : (func(5, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4));
                                @(3)]))
-constant x_Tuple33 : (func(3, [FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2);
-                               @(2)]))
-constant fst : (func(2, [FAppTy (FAppTy fix##40##41#  @(0))  @(1);
-                         @(0)]))
-constant x_Tuple55 : (func(5, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4);
-                               @(4)]))
-constant x_Tuple31 : (func(3, [FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2);
-                               @(0)]))
-constant x_Tuple43 : (func(4, [FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3);
-                               @(2)]))
-constant x_Tuple71 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(0)]))
-constant x_Tuple32 : (func(3, [FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2);
-                               @(1)]))
-constant x_Tuple72 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(1)]))
-constant x_Tuple63 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
-                               @(2)]))
-constant x_Tuple75 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(4)]))
-constant x_Tuple51 : (func(5, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4);
-                               @(0)]))
-constant len : (func(1, [[@(0)]; int]))
-constant xsListSelector : (func(1, [[@(0)]; [@(0)]]))
-constant null : (func(1, [[@(0)]; bool]))
-constant x_Tuple53 : (func(5, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4);
-                               @(2)]))
-constant x_Tuple22 : (func(2, [FAppTy (FAppTy fix##40##41#  @(0))  @(1);
-                               @(1)]))
-constant fromJust : (func(1, [FAppTy Data.Maybe.Maybe  @(0);
-                              @(0)]))
-constant snd : (func(2, [FAppTy (FAppTy fix##40##41#  @(0))  @(1);
-                         @(1)]))
-constant x_Tuple73 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(2)]))
-constant x_Tuple62 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
-                               @(1)]))
-constant x_Tuple74 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(3)]))
+constant x_Tuple32 : (func(3, [(Tuple  @(0)  @(1)  @(2)); @(1)]))
 constant cmp : (func(0, [GHC.Types.Ordering; GHC.Types.Ordering]))
-constant x_Tuple42 : (func(4, [FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3);
-                               @(1)]))
-constant x_Tuple21 : (func(2, [FAppTy (FAppTy fix##40##41#  @(0))  @(1);
-                               @(0)]))
-constant x_Tuple61 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
-                               @(0)]))
-constant isJust : (func(1, [FAppTy Data.Maybe.Maybe  @(0); bool]))
-constant x_Tuple66 : (func(6, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5);
+constant x_Tuple76 : (func(7, [(Tuple  @(0)  @(1)  @(2)  @(3)  @(4)  @(5)  @(6));
                                @(5)]))
-constant GHC.Types.True#6u : (GHC.Types.Bool)
-constant x_Tuple77 : (func(7, [FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy (FAppTy fix##40##41#  @(0))  @(1))  @(2))  @(3))  @(4))  @(5))  @(6);
-                               @(6)]))
-bind 0 GHC.Types.False#68 : {VV#153 : GHC.Types.Bool | []}
-bind 1 GHC.Types.I##6c : {VV : func(0, [int; int]) | []}
-bind 2 GHC.Types.True#6u : {VV#155 : GHC.Types.Bool | []}
-bind 3 fix#GHC.Classes.#36#fOrdInt#35#rhx : {VV#157 : FAppTy GHC.Classes.Ord  int | []}
-bind 4 Language.Haskell.Liquid.Prelude.geq#rpA : {VV : func(0, [int;
-                                                                int;
-                                                                GHC.Types.Bool]) | []}
-bind 5 Language.Haskell.Liquid.Prelude.liquidAssertB#rpD : {VV : func(0, [GHC.Types.Bool;
-                                                                          GHC.Types.Bool]) | []}
-bind 6 Language.Haskell.Liquid.Prelude.choose#rpK : {VV : func(0, [int;
-                                                                   int]) | []}
-bind 7 GHC.Types.EQ#6U : {VV#161 : GHC.Types.Ordering | []}
-bind 8 GHC.Types.LT#6S : {VV#162 : GHC.Types.Ordering | []}
-bind 9 GHC.Types.GT#6W : {VV#163 : GHC.Types.Ordering | []}
-bind 10 GHC.Types.True#6u : {v : GHC.Types.Bool | [(? Prop([v]))]}
-bind 11 GHC.Types.False#68 : {v : GHC.Types.Bool | [(~ ((? Prop([v]))))]}
-bind 12 Language.Haskell.Liquid.Prelude.plus#rou : {VV : func(0, [int;
-                                                                  int;
-                                                                  int]) | []}
-bind 13 Language.Haskell.Liquid.Prelude.minus#rpv : {VV : func(0, [int;
-                                                                   int;
-                                                                   int]) | []}
-bind 14 Language.Haskell.Liquid.Prelude.times#rpw : {VV : func(0, [int;
-                                                                   int;
-                                                                   int]) | []}
-bind 15 Language.Haskell.Liquid.Prelude.eq#rpx : {VV : func(0, [int;
-                                                                int;
-                                                                GHC.Types.Bool]) | []}
-bind 16 Language.Haskell.Liquid.Prelude.neq#rpy : {VV : func(0, [int;
-                                                                 int;
-                                                                 GHC.Types.Bool]) | []}
-bind 17 Language.Haskell.Liquid.Prelude.leq#rpz : {VV : func(0, [int;
-                                                                 int;
-                                                                 GHC.Types.Bool]) | []}
-bind 18 Language.Haskell.Liquid.Prelude.geq#rpA : {VV : func(0, [int;
-                                                                 int;
-                                                                 GHC.Types.Bool]) | []}
-bind 19 Language.Haskell.Liquid.Prelude.lt#rpB : {VV : func(0, [int;
-                                                                int;
-                                                                GHC.Types.Bool]) | []}
-bind 20 Language.Haskell.Liquid.Prelude.gt#rpC : {VV : func(0, [int;
-                                                                int;
-                                                                GHC.Types.Bool]) | []}
-bind 21 Language.Haskell.Liquid.Prelude.liquidAssertB#rpD : {VV : func(0, [GHC.Types.Bool;
-                                                                           GHC.Types.Bool]) | []}
-bind 22 Language.Haskell.Liquid.Prelude.isEven#rpL : {VV : func(0, [int;
-                                                                    GHC.Types.Bool]) | []}
-bind 23 Language.Haskell.Liquid.Prelude.isOdd#rpM : {VV : func(0, [int;
-                                                                   GHC.Types.Bool]) | []}
-bind 24 GHC.Integer.Type.smallInteger#0Z : {VV : func(0, [int;
-                                                          int]) | []}
-bind 25 GHC.Types.I##6c : {VV : func(0, [int; int]) | []}
-bind 26 fix#GHC.Prim.#43##35##35#98 : {VV : func(0, [int;
-                                                     int;
-                                                     int]) | []}
-bind 27 fix#GHC.Prim.#45##35##35#99 : {VV : func(0, [int;
-                                                     int;
-                                                     int]) | []}
-bind 28 fix#GHC.Prim.#61##61##35##35#9o : {VV : func(0, [int;
-                                                         int;
-                                                         int]) | []}
-bind 29 fix#GHC.Prim.#62##61##35##35#9n : {VV : func(0, [int;
-                                                         int;
-                                                         int]) | []}
-bind 30 fix#GHC.Prim.#60##61##35##35#9r : {VV : func(0, [int;
-                                                         int;
-                                                         int]) | []}
-bind 31 fix#GHC.Prim.#60##35##35#9q : {VV : func(0, [int;
-                                                     int;
-                                                     int]) | []}
-bind 32 fix#GHC.Prim.#62##35##35#9m : {VV : func(0, [int;
-                                                     int;
-                                                     int]) | []}
-bind 33 GHC.Types.EQ#6U : {VV#200 : GHC.Types.Ordering | [(cmp([VV#200]) = GHC.Types.EQ#6U)]}
-bind 34 GHC.Types.LT#6S : {VV#202 : GHC.Types.Ordering | [(cmp([VV#202]) = GHC.Types.LT#6S)]}
-bind 35 GHC.Types.GT#6W : {VV#203 : GHC.Types.Ordering | [(cmp([VV#203]) = GHC.Types.GT#6W)]}
-bind 36 z#a12L : {VV#212 : int | [$k_213]}
-bind 37 lq_anf__d130 : {lq_tmp_x220 : int | [(lq_tmp_x220 = (100  :  int))]}
-bind 38 lq_anf__d131 : {lq_tmp_x227 : GHC.Types.Bool | [((? Prop([lq_tmp_x227])) <=> (z#a12L >= lq_anf__d130))]}
-bind 39 Test0.baz#r12i : {VV : func(0, [int; GHC.Types.Bool]) | []}
-bind 40 lq_anf__d132 : {lq_tmp_x245 : int | [(lq_tmp_x245 = (0  :  int))]}
-bind 41 Test0.x#rZN : {VV#241 : int | [$k_242]}
-bind 42 lq_anf__d133 : {lq_tmp_x260 : int | [(lq_tmp_x260 = (0  :  int))]}
-bind 43 lq_anf__d134 : {lq_tmp_x266 : GHC.Types.Bool | [((? Prop([lq_tmp_x266])) <=> (Test0.x#rZN > lq_anf__d133))]}
-bind 44 lq_anf__d135 : {lq_tmp_x282 : GHC.Types.Bool | [((? Prop([lq_tmp_x282])) <=> (Test0.x#rZN > lq_anf__d133));
-                                                        (lq_tmp_x282 = lq_anf__d134)]}
-bind 45 lq_anf__d135 : {lq_tmp_x284 : GHC.Types.Bool | [((? Prop([lq_tmp_x284])) <=> (Test0.x#rZN > lq_anf__d133));
-                                                        (lq_tmp_x284 = lq_anf__d134)]}
-bind 46 lq_anf__d135 : {lq_tmp_x284 : GHC.Types.Bool | [((? Prop([lq_tmp_x284])) <=> (Test0.x#rZN > lq_anf__d133));
-                                                        (lq_tmp_x284 = lq_anf__d134);
-                                                        (~ ((? Prop([lq_tmp_x284]))));
-                                                        (~ ((? Prop([lq_tmp_x284]))))]}
-bind 47 lq_anf__d135 : {lq_tmp_x290 : GHC.Types.Bool | [((? Prop([lq_tmp_x290])) <=> (Test0.x#rZN > lq_anf__d133));
-                                                        (lq_tmp_x290 = lq_anf__d134)]}
-bind 48 lq_anf__d135 : {lq_tmp_x290 : GHC.Types.Bool | [((? Prop([lq_tmp_x290])) <=> (Test0.x#rZN > lq_anf__d133));
-                                                        (lq_tmp_x290 = lq_anf__d134);
-                                                        (? Prop([lq_tmp_x290]));
-                                                        (? Prop([lq_tmp_x290]))]}
-// bind 49 Test0.prop_abs#r12h : {VV#256 : GHC.Types.Bool | [$k_257]}
-bind 50 VV#301 : {VV#301 : GHC.Types.Bool | [$k_217[VV#216:=VV#301][z#a12L:=Test0.x#rZN][lq_tmp_x298:=Test0.x#rZN][lq_tmp_x296:=VV#301]]}
-bind 51 VV#301 : {VV#301 : GHC.Types.Bool | [$k_217[VV#216:=VV#301][z#a12L:=Test0.x#rZN][lq_tmp_x298:=Test0.x#rZN][lq_tmp_x296:=VV#301]]}
-bind 52 VV#304 : {VV#304 : int | [$k_242[VV#241:=VV#304][lq_tmp_x299:=VV#304];
-                                  (VV#304 = Test0.x#rZN)]}
-bind 53 VV#304 : {VV#304 : int | [$k_242[VV#241:=VV#304][lq_tmp_x299:=VV#304];
-                                  (VV#304 = Test0.x#rZN)]}
-bind 54 VV#307 : {VV#307 : GHC.Types.Bool | [(~ ((? Prop([VV#307]))));
-                                             (VV#307 = GHC.Types.False#68)]}
-bind 55 VV#307 : {VV#307 : GHC.Types.Bool | [(~ ((? Prop([VV#307]))));
-                                             (VV#307 = GHC.Types.False#68)]}
-bind 56 VV#310 : {VV#310 : int | [(VV#310 = (0  :  int));
-                                  (VV#310 = lq_anf__d133)]}
-bind 57 VV#310 : {VV#310 : int | [(VV#310 = (0  :  int));
-                                  (VV#310 = lq_anf__d133)]}
-bind 58 VV#313 : {VV#313 : int | [$k_242[VV#241:=VV#313][lq_tmp_x279:=VV#313];
-                                  (VV#313 = Test0.x#rZN)]}
-bind 59 VV#313 : {VV#313 : int | [$k_242[VV#241:=VV#313][lq_tmp_x279:=VV#313];
-                                  (VV#313 = Test0.x#rZN)]}
-bind 60 VV#316 : {VV#316 : int | [(VV#316 = 0)]}
-bind 61 VV#316 : {VV#316 : int | [(VV#316 = 0)]}
-bind 62 VV#319 : {VV#319 : int | []}
-bind 63 VV#319 : {VV#319 : int | []}
-bind 64 VV#322 : {VV#322 : int | [(VV#322 = (0  :  int));
-                                  (VV#322 = lq_anf__d132)]}
-bind 65 VV#322 : {VV#322 : int | [(VV#322 = (0  :  int));
-                                  (VV#322 = lq_anf__d132)]}
-bind 66 VV#325 : {VV#325 : int | [(VV#325 = 0)]}
-bind 67 VV#325 : {VV#325 : int | [(VV#325 = 0)]}
-bind 68 VV#328 : {VV#328 : GHC.Types.Bool | [(? Prop([VV#328]))]}
-bind 69 VV#328 : {VV#328 : GHC.Types.Bool | [(? Prop([VV#328]))]}
-bind 70 VV#331 : {VV#331 : GHC.Types.Bool | [((? Prop([VV#331])) <=> (z#a12L >= lq_anf__d130));
-                                             (VV#331 = lq_anf__d131)]}
-bind 71 VV#331 : {VV#331 : GHC.Types.Bool | [((? Prop([VV#331])) <=> (z#a12L >= lq_anf__d130));
-                                             (VV#331 = lq_anf__d131)]}
-bind 72 VV#334 : {VV#334 : int | [(VV#334 = (100  :  int));
-                                  (VV#334 = lq_anf__d130)]}
-bind 73 VV#334 : {VV#334 : int | [(VV#334 = (100  :  int));
-                                  (VV#334 = lq_anf__d130)]}
-bind 74 VV#337 : {VV#337 : int | [$k_213[VV#212:=VV#337][lq_tmp_x232:=VV#337];
-                                  (VV#337 = z#a12L)]}
-bind 75 VV#337 : {VV#337 : int | [$k_213[VV#212:=VV#337][lq_tmp_x232:=VV#337];
-                                  (VV#337 = z#a12L)]}
-bind 76 VV#340 : {VV#340 : int | [(VV#340 = 100)]}
-bind 77 VV#340 : {VV#340 : int | [(VV#340 = 100)]}
-bind 78 VV#273 : {VV#273 : int | [$k_274]}
-bind 79 VV#256 : {VV#256 : GHC.Types.Bool | [$k_257]}
-bind 80 VV#241 : {VV#241 : int | [$k_242]}
-bind 81 VV#212 : {VV#212 : int | [$k_213]}
-bind 82 VV#216 : {VV#216 : GHC.Types.Bool | [$k_217]}
+constant fst : (func(2, [(Tuple  @(0)  @(1)); @(0)]))
+constant snd : (func(2, [(Tuple  @(0)  @(1)); @(1)]))
+constant x_Tuple42 : (func(4, [(Tuple  @(0)  @(1)  @(2)  @(3));
+                               @(1)]))
+constant GHC.Types.True$35$6u : (GHC.Types.Bool)
+
+
+bind 0 GHC.Types.False$35$68 : {VV$35$159 : GHC.Types.Bool | []}
+bind 1 GHC.Types.True$35$6u : {VV$35$161 : GHC.Types.Bool | []}
+bind 2 GHC.Classes.$36$fOrdInt$35$rni : {VV$35$166 : (GHC.Classes.Ord  int) | []}
+bind 3 GHC.Types.EQ$35$6U : {VV$35$167 : GHC.Types.Ordering | [(VV$35$167 = GHC.Types.EQ$35$6U)]}
+bind 4 GHC.Types.LT$35$6S : {VV$35$168 : GHC.Types.Ordering | [(VV$35$168 = GHC.Types.LT$35$6S)]}
+bind 5 GHC.Types.GT$35$6W : {VV$35$169 : GHC.Types.Ordering | [(VV$35$169 = GHC.Types.GT$35$6W)]}
+bind 6 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(? Prop([v$35$4]))]}
+bind 7 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((? Prop([v$35$5]))))]}
+bind 8 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((? Prop([v$35$5]))))]}
+bind 9 GHC.Types.$91$$93$$35$6m : {VV : func(1, [[@(0)]]) | []}
+bind 10 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(? Prop([v$35$4]))]}
+bind 11 GHC.Types.GT$35$6W : {VV$35$214 : GHC.Types.Ordering | [(cmp([VV$35$214]) = GHC.Types.GT$35$6W)]}
+bind 12 GHC.Types.LT$35$6S : {VV$35$215 : GHC.Types.Ordering | [(cmp([VV$35$215]) = GHC.Types.LT$35$6S)]}
+bind 13 GHC.Types.EQ$35$6U : {VV$35$216 : GHC.Types.Ordering | [(cmp([VV$35$216]) = GHC.Types.EQ$35$6U)]}
+bind 14 GHC.Base.Nothing$35$r1d : {VV : func(1, [(GHC.Base.Maybe  @(0))]) | []}
+bind 15 z$35$a10N : {VV$35$221 : int | [$k_$35$222]}
+bind 16 lq_anf$36$_d116 : {lq_tmp$36$x$35$229 : int | [(lq_tmp$36$x$35$229 = (100  :  int))]}
+bind 17 lq_anf$36$_d117 : {lq_tmp$36$x$35$236 : GHC.Types.Bool | [((? Prop([lq_tmp$36$x$35$236])) <=> (z$35$a10N >= lq_anf$36$_d116))]}
+bind 18 lq_anf$36$_d118 : {lq_tmp$36$x$35$254 : int | [(lq_tmp$36$x$35$254 = (0  :  int))]}
+bind 19 Test0.x$35$rYP : {VV$35$250 : int | [$k_$35$251]}
+bind 20 lq_anf$36$_d119 : {lq_tmp$36$x$35$269 : int | [(lq_tmp$36$x$35$269 = (0  :  int))]}
+bind 21 lq_anf$36$_d11a : {lq_tmp$36$x$35$275 : GHC.Types.Bool | [((? Prop([lq_tmp$36$x$35$275])) <=> (Test0.x$35$rYP > lq_anf$36$_d119))]}
+bind 22 lq_anf$36$_d11b : {lq_tmp$36$x$35$291 : GHC.Types.Bool | [(lq_tmp$36$x$35$291 = lq_anf$36$_d11a)]}
+bind 23 lq_anf$36$_d11b : {lq_tmp$36$x$35$293 : GHC.Types.Bool | [(lq_tmp$36$x$35$293 = lq_anf$36$_d11a)]}
+bind 24 lq_anf$36$_d11b : {lq_tmp$36$x$35$293 : GHC.Types.Bool | [(lq_tmp$36$x$35$293 = lq_anf$36$_d11a);
+                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))));
+                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))));
+                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))))]}
+bind 25 lq_anf$36$_d11b : {lq_tmp$36$x$35$299 : GHC.Types.Bool | [(lq_tmp$36$x$35$299 = lq_anf$36$_d11a)]}
+bind 26 lq_anf$36$_d11b : {lq_tmp$36$x$35$299 : GHC.Types.Bool | [(lq_tmp$36$x$35$299 = lq_anf$36$_d11a);
+                                                                  (? Prop([lq_tmp$36$x$35$299]));
+                                                                  (? Prop([lq_tmp$36$x$35$299]));
+                                                                  (? Prop([lq_tmp$36$x$35$299]))]}
+bind 27 Test0.prop_abs$35$r10h : {VV$35$265 : GHC.Types.Bool | [$k_$35$266]}
+bind 28 VV$35$310 : {VV$35$310 : GHC.Types.Bool | [$k_$35$226[lq_tmp$36$x$35$307:=Test0.x$35$rYP][lq_tmp$36$x$35$305:=VV$35$310][VV$35$225:=VV$35$310][z$35$a10N:=Test0.x$35$rYP]]}
+bind 29 VV$35$310 : {VV$35$310 : GHC.Types.Bool | [$k_$35$226[lq_tmp$36$x$35$307:=Test0.x$35$rYP][lq_tmp$36$x$35$305:=VV$35$310][VV$35$225:=VV$35$310][z$35$a10N:=Test0.x$35$rYP]]}
+bind 30 VV$35$313 : {VV$35$313 : int | [(VV$35$313 = Test0.x$35$rYP)]}
+bind 31 VV$35$313 : {VV$35$313 : int | [(VV$35$313 = Test0.x$35$rYP)]}
+bind 32 VV$35$316 : {VV$35$316 : GHC.Types.Bool | [(VV$35$316 = GHC.Types.False$35$68)]}
+bind 33 VV$35$316 : {VV$35$316 : GHC.Types.Bool | [(VV$35$316 = GHC.Types.False$35$68)]}
+bind 34 VV$35$319 : {VV$35$319 : int | [(VV$35$319 = lq_anf$36$_d119)]}
+bind 35 VV$35$319 : {VV$35$319 : int | [(VV$35$319 = lq_anf$36$_d119)]}
+bind 36 VV$35$322 : {VV$35$322 : int | [(VV$35$322 = Test0.x$35$rYP)]}
+bind 37 VV$35$322 : {VV$35$322 : int | [(VV$35$322 = Test0.x$35$rYP)]}
+bind 38 VV$35$325 : {VV$35$325 : int | [(VV$35$325 = 0)]}
+bind 39 VV$35$325 : {VV$35$325 : int | [(VV$35$325 = 0)]}
+bind 40 VV$35$328 : {VV$35$328 : int | []}
+bind 41 VV$35$328 : {VV$35$328 : int | []}
+bind 42 VV$35$331 : {VV$35$331 : int | [(VV$35$331 = lq_anf$36$_d118)]}
+bind 43 VV$35$331 : {VV$35$331 : int | [(VV$35$331 = lq_anf$36$_d118)]}
+bind 44 VV$35$334 : {VV$35$334 : int | [(VV$35$334 = 0)]}
+bind 45 VV$35$334 : {VV$35$334 : int | [(VV$35$334 = 0)]}
+bind 46 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(? Prop([VV$35$337]))]}
+bind 47 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(? Prop([VV$35$337]))]}
+bind 48 VV$35$340 : {VV$35$340 : GHC.Types.Bool | [(VV$35$340 = lq_anf$36$_d117)]}
+bind 49 VV$35$340 : {VV$35$340 : GHC.Types.Bool | [(VV$35$340 = lq_anf$36$_d117)]}
+bind 50 VV$35$343 : {VV$35$343 : int | [(VV$35$343 = lq_anf$36$_d116)]}
+bind 51 VV$35$343 : {VV$35$343 : int | [(VV$35$343 = lq_anf$36$_d116)]}
+bind 52 VV$35$346 : {VV$35$346 : int | [(VV$35$346 = z$35$a10N)]}
+bind 53 VV$35$346 : {VV$35$346 : int | [(VV$35$346 = z$35$a10N)]}
+bind 54 VV$35$349 : {VV$35$349 : int | [(VV$35$349 = 100)]}
+bind 55 VV$35$349 : {VV$35$349 : int | [(VV$35$349 = 100)]}
+bind 56 VV$35$282 : {VV$35$282 : int | [$k_$35$283]}
+bind 57 VV$35$265 : {VV$35$265 : GHC.Types.Bool | [$k_$35$266]}
+bind 58 VV$35$250 : {VV$35$250 : int | [$k_$35$251]}
+bind 59 VV$35$221 : {VV$35$221 : int | [$k_$35$222]}
+bind 60 VV$35$225 : {VV$35$225 : GHC.Types.Bool | [$k_$35$226]}
+
+
+
+
+constraint:
+  env [0;
+       1;
+       2;
+       3;
+       19;
+       4;
+       20;
+       5;
+       21;
+       6;
+       22;
+       7;
+       8;
+       9;
+       25;
+       10;
+       26;
+       11;
+       12;
+       13;
+       14;
+       30]
+  lhs {VV$35$F2 : int | [(VV$35$F2 = Test0.x$35$rYP)]}
+  rhs {VV$35$F2 : int | [$k_$35$222[VV$35$221:=VV$35$F2][lq_tmp$36$x$35$304:=VV$35$F2][VV$35$313:=VV$35$F2][VV$35$F:=VV$35$F2]]}
+  id 2 tag [3]
+  // META constraint id 2 : tests/neg/test00.hs:8:30
+
+
+constraint:
+  env [0; 1; 2; 18; 3; 4; 5; 6; 7; 8; 40; 9; 10; 11; 12; 13; 14]
+  lhs {VV$35$F6 : int | []}
+  rhs {VV$35$F6 : int | [$k_$35$251[VV$35$328:=VV$35$F6][VV$35$250:=VV$35$F6][VV$35$F:=VV$35$F6]]}
+  id 6 tag [2]
+  // META constraint id 6 : tests/neg/test00.hs:6:1-12
 
 
 constraint:
   env [0;
        16;
-       32;
        48;
        1;
        17;
-       33;
        2;
-       18;
-       34;
        3;
-       19;
-       35;
        4;
-       20;
-       52;
        5;
-       21;
        6;
-       22;
        7;
-       23;
-       39;
        8;
-       24;
        9;
-       25;
-       41;
        10;
-       26;
-       42;
        11;
-       27;
-       43;
        12;
-       28;
-       44;
        13;
-       29;
        14;
-       30;
-       15;
-       31;
-       47]
-  lhs {VV#F2 : int | [$k_242[VV#241:=VV#F2][lq_tmp_x299:=VV#F2][VV#304:=VV#F2][VV#F:=VV#F2];
-                      (VV#F2 = Test0.x#rZN)]}
-  rhs {VV#F2 : int | [$k_213[VV#212:=VV#F2][lq_tmp_x295:=VV#F2][VV#304:=VV#F2][VV#F:=VV#F2]]}
-  id 2 tag [3]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       54;
-       7;
-       23;
-       39;
-       8;
-       24;
-       9;
-       25;
-       41;
-       10;
-       26;
-       42;
-       11;
-       27;
-       43;
-       12;
-       28;
-       44;
-       13;
-       29;
-       45;
-       14;
-       30;
-       46;
-       15;
-       31]
-  lhs {VV#F3 : GHC.Types.Bool | [(~ ((? Prop([VV#F3]))));
-                                 (VV#F3 = GHC.Types.False#68)]}
-  rhs {VV#F3 : GHC.Types.Bool | [$k_257[VV#256:=VV#F3][VV#307:=VV#F3][VV#F:=VV#F3]]}
-  id 3 tag [3]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       56;
-       9;
-       25;
-       41;
-       10;
-       26;
-       42;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  lhs {VV#F4 : int | [(VV#F4 = (0  :  int)); (VV#F4 = lq_anf__d133)]}
-  rhs {VV#F4 : int | [$k_274[VV#273:=VV#F4][lq_tmp_x270:=fix#GHC.Classes.#36#fOrdInt#35#rhx][lq_tmp_x271:=Test0.x#rZN][lq_tmp_x276:=VV#F4][VV#310:=VV#F4][VV#F:=VV#F4]]}
-  id 4 tag [3]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       9;
-       25;
-       41;
-       10;
-       26;
-       42;
-       58;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  lhs {VV#F5 : int | [$k_242[VV#241:=VV#F5][lq_tmp_x279:=VV#F5][VV#313:=VV#F5][VV#F:=VV#F5];
-                      (VV#F5 = Test0.x#rZN)]}
-  rhs {VV#F5 : int | [$k_274[VV#273:=VV#F5][lq_tmp_x270:=fix#GHC.Classes.#36#fOrdInt#35#rhx][lq_tmp_x276:=VV#F5][VV#313:=VV#F5][VV#F:=VV#F5]]}
-  id 5 tag [3]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       40;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       62;
-       15;
-       31]
-  lhs {VV#F6 : int | []}
-  rhs {VV#F6 : int | [$k_242[VV#241:=VV#F6][VV#319:=VV#F6][VV#F:=VV#F6]]}
-  id 6 tag [2]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       36;
-       68;
-       5;
-       21;
-       37;
-       6;
-       22;
-       38;
-       7;
-       23;
-       8;
-       24;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  lhs {VV#F7 : GHC.Types.Bool | [(? Prop([VV#F7]))]}
-  rhs {VV#F7 : GHC.Types.Bool | [$k_217[VV#216:=VV#F7][VV#328:=VV#F7][VV#F:=VV#F7]]}
-  id 7 tag [1]
-
-
-constraint:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       36;
-       5;
-       21;
-       37;
-       6;
-       22;
-       38;
-       70;
-       7;
-       23;
-       8;
-       24;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  lhs {VV#F8 : GHC.Types.Bool | [((? Prop([VV#F8])) <=> (z#a12L >= lq_anf__d130));
-                                 (VV#F8 = lq_anf__d131)]}
-  rhs {VV#F8 : GHC.Types.Bool | [(? Prop([VV#F8]))]}
+       15]
+  lhs {VV$35$F8 : GHC.Types.Bool | [(VV$35$F8 = lq_anf$36$_d117)]}
+  rhs {VV$35$F8 : GHC.Types.Bool | [(? Prop([VV$35$F8]))]}
   id 8 tag [1]
+  // META constraint id 8 : tests/neg/test00.hs:11:23-35
+
+
 
 
 wf:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       9;
-       25;
-       41;
-       10;
-       26;
-       42;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  reft {VV#273 : int | [$k_274]}
-  
+  env [0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14]
+  reft {VV$35$221 : int | [$k_$35$222]}
+  // META wf : <no location info>
 
 
 wf:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       9;
-       25;
-       41;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  reft {VV#256 : GHC.Types.Bool | [$k_257]}
-  
+  env [0; 1; 2; 3; 4; 5; 6; 7; 8; 9; 10; 11; 12; 13; 14]
+  reft {VV$35$250 : int | [$k_$35$251]}
+  // META wf : <no location info>
 
 
-wf:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       39;
-       8;
-       24;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  reft {VV#241 : int | [$k_242]}
-  
 
 
-wf:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       8;
-       24;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  reft {VV#212 : int | [$k_213]}
-  
 
 
-wf:
-  env [0;
-       16;
-       32;
-       1;
-       17;
-       33;
-       2;
-       18;
-       34;
-       3;
-       19;
-       35;
-       4;
-       20;
-       36;
-       5;
-       21;
-       6;
-       22;
-       7;
-       23;
-       8;
-       24;
-       9;
-       25;
-       10;
-       26;
-       11;
-       27;
-       12;
-       28;
-       13;
-       29;
-       14;
-       30;
-       15;
-       31]
-  reft {VV#216 : GHC.Types.Bool | [$k_217]}
-  
+


### PR DESCRIPTION
There is more to do, but will return to this...

@bmcfluff -- please don't use raw `die` or `error` -- if you *must* then use `errorstar` -- but ideally, create an `Error` and associate it with any (good) nearby source information.