### PR TITLE
Tidy

### DIFF
--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -255,7 +255,7 @@ addIds = zipWith (\i c -> (i, shiftId i $ c {_sid = Just i})) [1..]
     shiftId i c = c { slhs = shiftSR i $ slhs c }
                     { srhs = shiftSR i $ srhs c }
     shiftSR i sr = sr { sr_reft = shiftR i $ sr_reft sr }
-    shiftR i r@(Reft (v, _)) = shiftVV r (v `mappend` symbol (show i))
+    shiftR i r@(Reft (v, _)) = shiftVV r (intSymbol v i)
 
 --------------------------------------------------------------------------------
 -- | Qualifiers ----------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -41,7 +41,7 @@ module Language.Fixpoint.Types.Names (
   , consSym
   , unconsSym
   , dropSym
-  , singletonSym
+  -- , singletonSym
   , headSym
   , takeWhileSym
   , lengthSym
@@ -346,8 +346,8 @@ consSym c (symbolText -> s) = symbol $ T.cons c s
 unconsSym :: Symbol -> Maybe (Char, Symbol)
 unconsSym (symbolText -> s) = second symbol <$> T.uncons s
 
-singletonSym :: Char -> Symbol -- Yuck
-singletonSym = (`consSym` "")
+-- singletonSym :: Char -> Symbol -- Yuck
+-- singletonSym = (`consSym` "")
 
 lengthSym :: Symbol -> Int
 lengthSym (symbolText -> t) = T.length t

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -53,11 +53,11 @@ module Language.Fixpoint.Types.Names (
 
   -- * Widely used prefixes
   , anfPrefix
-  -- , litPrefix
   , tempPrefix
   , vv
   , symChars
   -- , kArgPrefix
+  -- , litPrefix
 
   -- * Creating Symbols
   , dummySymbol
@@ -69,6 +69,7 @@ module Language.Fixpoint.Types.Names (
   , renameSymbol
   , kArgSymbol
   , existSymbol
+  , suffixSymbol
 
   -- * Unwrapping Symbols
   , unLitSymbol

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -188,6 +188,8 @@ instance Show Symbol where
 
 --instance Monoid Symbol where
 -- mempty        = ""
+
+mappendSym :: Symbol -> Symbol -> Symbol
 mappendSym s1 s2 = textSymbol $ mappend s1' s2'
     where
       s1'        = symbolText s1
@@ -365,7 +367,7 @@ isNontrivialVV      :: Symbol -> Bool
 isNontrivialVV      = not . (vv Nothing ==)
 
 vvCon, dummySymbol :: Symbol
-vvCon       = vvName `mappendSym` symbol [symSepName] `mappendSym` "F"
+vvCon       = vvName `suffixSymbol` "F"
 dummySymbol = dummyName
 
 litSymbol :: Symbol -> Symbol
@@ -375,7 +377,10 @@ unLitSymbol :: Symbol -> Maybe Symbol
 unLitSymbol = stripPrefix litPrefix
 
 intSymbol :: (Show a) => Symbol -> a -> Symbol
-intSymbol x i = x `mappendSym` symbol ('#' : show i)
+intSymbol x i = x `suffixSymbol` (symbol $ show i)
+
+suffixSymbol :: Symbol -> Symbol -> Symbol
+suffixSymbol  x y = x `mappendSym` symbol [symSepName] `mappendSym` y
 
 tempSymbol :: Symbol -> Integer -> Symbol
 tempSymbol prefix = intSymbol (tempPrefix `mappendSym` prefix)
@@ -383,8 +388,8 @@ tempSymbol prefix = intSymbol (tempPrefix `mappendSym` prefix)
 renameSymbol :: Symbol -> Int -> Symbol
 renameSymbol prefix = intSymbol (renamePrefix `mappendSym` prefix)
 
-kArgSymbol :: Symbol -> Symbol
-kArgSymbol x = kArgPrefix `mappendSym` x
+kArgSymbol :: Symbol -> Symbol -> Symbol
+kArgSymbol x k = (kArgPrefix `mappendSym` x) `suffixSymbol` k
 
 existSymbol :: Symbol -> Integer -> Symbol
 existSymbol prefix = intSymbol (existPrefix `mappendSym` prefix)

--- a/src/Language/Fixpoint/Types/PrettyPrint.hs
+++ b/src/Language/Fixpoint/Types/PrettyPrint.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-
 module Language.Fixpoint.Types.PrettyPrint where
 
 import           Debug.Trace               (trace)
@@ -101,7 +100,7 @@ instance (PPrint a, PPrint b) => PPrint (M.HashMap a b) where
   pprint = pprintKVs . M.toList
 
 pprintKVs :: (PPrint k, PPrint v) => [(k, v)] -> Doc
-pprintKVs = vcat . punctuate (text "\n") . map pp1 -- . M.toList
+pprintKVs = vcat . punctuate (text "\n") . map pp1
   where
     pp1 (x,y) = pprint x <+> text ":=" <+> pprint y
 
@@ -130,7 +129,7 @@ instance PPrint Int where
 instance PPrint Integer where
   pprint = integer
 
-instance PPrint T.Text where 
+instance PPrint T.Text where
   pprint = text . T.unpack
 
 newtype DocTable = DocTable [(Doc, Doc)]

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -140,7 +140,7 @@ refaConjuncts p              = [p' | p' <- conjuncts p, not $ isTautoPred p']
 -- | Kvars ---------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-newtype KVar = KV {kv :: Symbol }
+newtype KVar = KV { kv :: Symbol }
                deriving (Eq, Ord, Data, Typeable, Generic, IsString)
 
 
@@ -248,7 +248,7 @@ encodeSymConst        :: SymConst -> Symbol
 encodeSymConst (SL s) = litSymbol $ symbol s
 
 decodeSymConst :: Symbol -> Maybe SymConst
-decodeSymConst = fmap (SL . symbolText) . unLitSymbol 
+decodeSymConst = fmap (SL . symbolText) . unLitSymbol
 
 instance Fixpoint SymConst where
   toFix  = toFix . encodeSymConst

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -245,10 +245,10 @@ instance Symbolic SymConst where
   symbol = encodeSymConst
 
 encodeSymConst        :: SymConst -> Symbol
-encodeSymConst (SL s) = litPrefix `mappend` symbol s
+encodeSymConst (SL s) = litSymbol $ symbol s
 
 decodeSymConst :: Symbol -> Maybe SymConst
-decodeSymConst = fmap (SL . symbolText) . stripPrefix litPrefix
+decodeSymConst = fmap (SL . symbolText) . unLitSymbol 
 
 instance Fixpoint SymConst where
   toFix  = toFix . encodeSymConst


### PR DESCRIPTION
Various changes to constrain how `Symbol`s are created, in order to make
it easier to _undo_ changes and such.

1. Remove the `Monoid` instance so you cannot randomly concat symbols,
2. If you must (and often one must) use `suffixSymbol` instead,
2. Hide various prefixes, instead exported functions in `Names` to create various temporaries.

This is correlated with LH 