### PR TITLE
tidy symbols before returning solution

### DIFF
--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -41,7 +41,6 @@ module Language.Fixpoint.Types.Names (
   , consSym
   , unconsSym
   , dropSym
-  -- , singletonSym
   , headSym
   , takeWhileSym
   , lengthSym
@@ -56,8 +55,6 @@ module Language.Fixpoint.Types.Names (
   , tempPrefix
   , vv
   , symChars
-  -- , kArgPrefix
-  -- , litPrefix
 
   -- * Creating Symbols
   , dummySymbol


### PR DESCRIPTION
@bmcfluff -- we can do all the uniqifying and renaming we like, but we should ensure that the returned `FixSolution` is in terms of the WF variables sent in the input query. Hence the need to be able to figure out the _original_ names of all the `Symbol`s.
 