### PR TITLE
Expose fApp'

### DIFF
--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -33,7 +33,7 @@ module Language.Fixpoint.Types.Sorts (
   , listFTyCon
   , isListTC
   , fTyconSymbol, symbolFTycon, fTyconSort
-  , fApp, fAppTC
+  , fApp, fApp', fAppTC
   , fObj
 
   , sortSubst


### PR DESCRIPTION
This is a useful function that I'd like to use from LiquidHaskell, but it's not currently exported.