### PR TITLE
implementation of delta debugging minimization

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -248,9 +248,8 @@ makeProcess s
 --------------------------------------------------------------------------
 cleanupContext :: Context -> IO ExitCode
 --------------------------------------------------------------------------
-cleanupContext me@(Ctx {..})
-  = do smtWrite me "(exit)"
-       code <- waitForProcess pId
+cleanupContext (Ctx {..})
+  = do code <- waitForProcess pId
        hClose cIn
        hClose cOut
        maybe (return ()) hClose cLog

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -78,7 +78,11 @@ runSolverM :: Config -> F.GInfo c b -> Int -> SolveM a -> IO a
 ---------------------------------------------------------------------------
 runSolverM cfg fi _ act = do
   ctx <-  makeContext (not $ real cfg) (solver cfg) file
-  fst <$> runStateT (declare fi >> act) (SS ctx be $ stats0 fi)
+  res <- runStateT (declare fi >> act) (SS ctx be $ stats0 fi)
+
+  -- add the following line to make delta debug minimize work
+  cleanupContext ctx
+  return $ fst res
   where
     be   = F.bs     fi
     file = F.fileName fi -- (inFile cfg)

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -56,6 +56,7 @@ data Config
     , stats       :: Bool                -- ^ compute constraint statistics
     , parts       :: Bool                -- ^ partition FInfo into separate fq files
     , save        :: Bool                -- ^ save FInfo as .bfq and .fq file
+    , minimize    :: Bool                -- ^ use delta debug to min fq file
     -- , nontriv     :: Bool             -- ^ simplify using non-trivial sorts
     } deriving (Eq,Data,Typeable,Show)
 
@@ -78,6 +79,7 @@ instance Default Config where
                , stats       = def
                , parts       = def
                , save        = def
+               , minimize    = def
                }
 
 instance Command Config where
@@ -150,6 +152,7 @@ config = Config {
   , cores       = def   &= help "(numeric) Number of threads to use"
   , minPartSize = defaultMinPartSize &= help "(numeric) Minimum partition size when solving in parallel"
   , maxPartSize = defaultMaxPartSize &= help "(numeric) Maximum partiton size when solving in parallel."
+  , minimize    = False &= help "Use delta debug to minimize fq file"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Utils/Files.hs
+++ b/src/Language/Fixpoint/Utils/Files.hs
@@ -86,6 +86,7 @@ data Ext = Cgi      -- ^ Constraint Generation Information
          | Dat
          | BinFq    -- ^ Binary representation of .fq / FInfo
          | Smt2     -- ^ SMTLIB2 query file
+         | Min      -- ^ filter constraints with delta debug
          deriving (Eq, Ord, Show)
 
 extMap          = go
@@ -117,6 +118,7 @@ extMap          = go
     go Dot      = ".dot"
     go BinFq    = ".bfq"
     go (Part n) = "." ++ show n
+    go Min      = ".minfq"
     -- go _      = errorstar $ "extMap: Unknown extension " ++ show e
 
 withExt         :: FilePath -> Ext -> FilePath


### PR DESCRIPTION
* The delta debugging code lives in `Solver.hs`; I can't move it to its own module because it has a circular / mutual dependency with `solve`.

* Use case is `fixpoint --minimize [file]`. The minimization code then outputs `.liquid/[file].minfq`, which is an FQ file that contains the minimal unsatisfiable subtyping constraint set.

* Added cleanup code and exception handling to `runSolverM` in `Solver/Monad.hs`. Multiple calls to the solver, such as what delta debugging minimization does, broke previously because the *.smt2 file was not released.