### PR TITLE
pprint EApp

### DIFF
--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -441,7 +441,7 @@ instance PPrint Expr where
                                    "-" <> pprintPrec (zn + 1) k e
     where zn = 2
   pprintPrec z k (EApp f es)     = parensIf (z > za) $
-                                   pprintTidy k f <+> (pprintPrec (za+1) k es)
+                                   pprintPrec za k f <+> pprintPrec (za+1) k es
     where za = 8
   pprintPrec z k (EBin o e1 e2)  = parensIf (z > zo) $
                                    pprintPrec (zo+1) k e1 <+>


### PR DESCRIPTION
Revised pretty printing for EApp:

```
λ> let [f, g, h] = expr . symbol <$> ["f", "g", "h"]
λ> pprint $ eApps f [g, h]
f g h
λ> pprint $ eApps f [eApps g [h]]
f (g h)
λ> pprint $ eApps (eApps f [g]) [h]
f g h
λ> pprint $ eApps (eApps f [g]) [eApps h [f]]
f g (h f)
λ> pprint $ eApps (eApps f [eApps h [g]]) [h]
f (h g) h
```