### PR TITLE
promote ints to reals instead of dropping refinements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /tests/neg/.liquid/
 /tests/pos/.liquid/
 /external/ocamlgraph/config.log
+/TAGS

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -217,7 +217,10 @@ instance SMTLIB2 Command where
   smt2 (Define t)          = format "(declare-sort {})"            (Only $ smt2 t)
   smt2 (Assert Nothing p)  = format "(assert {})"                  (Only $ smt2 p)
   smt2 (Assert (Just i) p) = format "(assert (! {} :named p-{}))"  (smt2 p, i)
-  smt2 (Distinct az)       = format "(assert (distinct {}))"       (Only $ smt2s az)
+  smt2 (Distinct az)
+    -- Distinct must have at least 2 arguments
+    | length az < 2        = ""
+    | otherwise            = format "(assert (distinct {}))"       (Only $ smt2s az)
   smt2 (Push)              = "(push 1)"
   smt2 (Pop)               = "(pop 1)"
   smt2 (CheckSat)          = "(check-sat)"

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -116,9 +116,9 @@ z3Preamble u
 uifDef u f op | u         = format "(declare-fun {} (Int Int) Int)" (Only f)
               | otherwise = format "(define-fun {} ((x Int) (y Int)) Int ({} x y))" (f, op)
 
-smtlibPreamble :: Bool -> [T.Text]
-smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
-  = [        "(set-logic QF_UFLIA)"
+cvc4Preamble :: Bool -> [T.Text]
+cvc4Preamble _ --TODO use uif flag u (see z3Preamble)
+  = [        "(set-logic ALL_SUPPORTED)"
     , format "(define-sort {} () Int)"       (Only elt)
     , format "(define-sort {} () Int)"       (Only set)
     , format "(declare-fun {} () {})"        (emp, set)
@@ -128,6 +128,27 @@ smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
     , format "(declare-fun {} ({} {}) {})"   (dif, set, set, set)
     , format "(declare-fun {} ({} {}) Bool)" (sub, set, set)
     , format "(declare-fun {} ({} {}) Bool)" (mem, elt, set)
+    , format "(define-sort {} () (Array {} {}))"
+        (map, elt, elt)
+    , format "(define-fun {} ((m {}) (k {})) {} (select m k))"
+        (sel, map, elt, elt)
+    , format "(define-fun {} ((m {}) (k {}) (v {})) {} (store m k v))"
+        (sto, map, elt, elt, map)
+    ]
+
+smtlibPreamble :: Bool -> [T.Text]
+smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
+  = [       --  "(set-logic QF_AUFRIA)",
+      format "(define-sort {} () Int)"       (Only elt)
+    , format "(define-sort {} () Int)"       (Only set)
+    , format "(declare-fun {} () {})"        (emp, set)
+    , format "(declare-fun {} ({} {}) {})"   (add, set, elt, set)
+    , format "(declare-fun {} ({} {}) {})"   (cup, set, set, set)
+    , format "(declare-fun {} ({} {}) {})"   (cap, set, set, set)
+    , format "(declare-fun {} ({} {}) {})"   (dif, set, set, set)
+    , format "(declare-fun {} ({} {}) Bool)" (sub, set, set)
+    , format "(declare-fun {} ({} {}) Bool)" (mem, elt, set)
+    , format "(define-sort {} () Int)"       (Only map)
     , format "(declare-fun {} ({} {}) {})"    (sel, map, elt, elt)
     , format "(declare-fun {} ({} {} {}) {})" (sto, map, elt, elt, map)
     ]
@@ -227,5 +248,6 @@ smt2App _ _           = Nothing
 
 
 preamble :: Bool -> SMTSolver -> [T.Text]
-preamble u Z3 = z3Preamble u
-preamble u _  = smtlibPreamble u
+preamble u Z3   = z3Preamble u
+preamble u Cvc4 = cvc4Preamble u
+preamble u _    = smtlibPreamble u

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,10 @@
-# GHC 7.10
-resolver: nightly-2016-01-06
-
+flags: {}
 packages:
-- .
-
+- '.'
 extra-deps:
+- dotgen-0.4.2
+- fgl-visualize-0.1.0.1
 - intern-0.9.1.4
 - located-base-0.1.0.0
-- concurrent-output-1.7.1
-- fgl-visualize-0.1.0.1
-- dotgen-0.4.2
+- text-1.2.2.1
+resolver: lts-5.9


### PR DESCRIPTION
Currently we prune refinements like `0 != 0.0`, which is unsound.
We could just report a sort error, but this leads to problems
for liquidhaskell, as `0` can refer to an Int or a Double.
So instead we promote ints to reals when necessary, which is sound.

It feels a bit wrong, but it's much simpler than any alternative
I can think of that doesn't reject ucsd-progsys/liquidhaskell#602
as ill-formed rather than unsafe.

needed to fix ucsd-progsys/liquidhaskell#602