### PR TITLE
Suppress output when run in `quiet` mode

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -26,7 +26,7 @@ import           Data.Binary
 -- import qualified Data.HashSet                       as S
 import           System.Exit                        (ExitCode (..))
 
--- import           System.Console.CmdArgs.Verbosity   hiding (Loud)
+import           System.Console.CmdArgs.Verbosity   (whenNormal)
 import           Text.PrettyPrint.HughesPJ          (render)
 -- import           Text.Printf                        (printf)
 import           Control.Monad                      (when)

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -65,7 +65,7 @@ solveFQ cfg = do
     let stat = resStatus $!! r
     -- let str  = render $ resultDoc $!! (const () <$> stat)
     -- putStrLn "\n"
-    colorStrLn (colorResult stat) (statStr $!! stat)
+    whenNormal $ colorStrLn (colorResult stat) (statStr $!! stat)
     return $ eCode r
   where
     file    = inFile       cfg

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -128,7 +128,7 @@ result _ wkl s = do
   lift $ writeLoud "Computing Result"
   stat    <- result_ wkl s
   -- stat'   <- gradualSolve cfg stat
-  lift $ print (F.sid <$> stat)
+  lift $ whenNormal $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
   return   $ F.Result (ci <$> stat) (F.solResult s)
   where
     ci c = (F.subcId c, F.sinfo c)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -20,10 +20,9 @@ import qualified Language.Fixpoint.Solver.Worklist as W
 import           Language.Fixpoint.Solver.Monad
 import           Language.Fixpoint.Solver.Graph (isTarget)
 import           Text.PrettyPrint.HughesPJ
-
 -- DEBUG
 import           Text.Printf
-import           System.Console.CmdArgs.Verbosity (whenLoud)
+import           System.Console.CmdArgs.Verbosity (whenNormal, whenLoud)
 import           Control.DeepSeq
 
 import           Data.List  (sort)

--- a/unix/Language/Fixpoint/Utils/Progress.hs
+++ b/unix/Language/Fixpoint/Utils/Progress.hs
@@ -6,9 +6,9 @@ module Language.Fixpoint.Utils.Progress (
     , progressClose
     ) where
 
-import           Control.Monad                    (unless)
+import           Control.Monad                    (when)
 import           System.IO.Unsafe                 (unsafePerformIO)
-import           System.Console.CmdArgs.Verbosity (isLoud)
+import           System.Console.CmdArgs.Verbosity (isNormal)
 import           Data.IORef
 
 
@@ -28,8 +28,8 @@ withProgress n act = displayConsoleRegions $ do
 
 progressInit :: Int -> IO ()
 progressInit n = do
-  loud <- isLoud
-  unless loud $ do
+  normal <- isNormal 
+  when normal $ do
     pr <- mkPB n
     writeIORef pbRef (Just pr)
 


### PR DESCRIPTION
This suppresses *all* output when run in `quiet` mode. This is to help with editor integration: clients like liquidhaskell and refscript can then output just a JSON string with status and errors.

https://github.com/ucsd-progsys/liquidhaskell/pull/665