### PR TITLE
Minor edits to debug `--eliminate`

### DIFF
--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -48,7 +48,7 @@ import qualified Data.Tree                            as T
 import           Data.Function (on)
 import           Data.Hashable
 import           Text.PrettyPrint.HughesPJ
-import           Debug.Trace
+-- import           Debug.Trace
 
 ---------------------------------------------------------------------------
 -- | Compute constraints that transitively affect target constraints,
@@ -222,10 +222,10 @@ subcEdges bs c =  [(KVar k, Cstr i ) | k  <- V.envKVars bs c]
 -- | Eliminated Dependencies
 --------------------------------------------------------------------------------
 elimDeps :: F.SInfo a -> [CEdge] -> S.HashSet F.KVar -> CDeps
-elimDeps si es nonKutVs = graphDeps si $ trace msg es'
+elimDeps si es nonKutVs = graphDeps si {- $ trace msg -} es'
   where
     es'                 = graphElim es nonKutVs
-    msg                 = "graphElim: " ++ show (length es')
+    -- msg                 = "graphElim: " ++ show (length es')
 
 {- | `graphElim` "eliminates" a kvar k by replacing every "path"
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -91,6 +91,7 @@ import           Language.Fixpoint.Smt.Types
 import           Language.Fixpoint.Types.Visitor   (foldSort, mapSort)
 import           Language.Fixpoint.Types hiding    (mapSort)
 import           Text.PrettyPrint.HughesPJ         (text, nest, vcat, (<+>))
+
 type Parser = Parsec String Integer
 
 --------------------------------------------------------------------
@@ -575,7 +576,7 @@ intP :: Parser Int
 intP = fromInteger <$> integer
 
 defsFInfo :: [Def a] -> FInfo a
-defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts kts qs mempty mempty False 
+defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts kts qs mempty mempty False
   where
     cm     = M.fromList       [(cid c, c)       | Cst c       <- defs]
     ws     = M.fromList       [(thd3 $ wrft w, w) | Wfc w     <- defs]

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -71,7 +71,8 @@ nonCutHyp kI si k = nonCutCube <$> cs
     cs            = getSubC   si <$> M.lookupDefault [] k kI
 
 nonCutCube :: SimpC a -> Cube
-nonCutCube c = Cube (senv c) (rhsSubst c)
+nonCutCube c = Cube (senv c) (rhsSubst c) (subcId c) (stag c)
+
 
 rhsSubst :: SimpC a -> Subst
 rhsSubst             = rsu . crhs

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -96,7 +96,8 @@ import qualified Data.HashSet              as S
 -- | Constraints ---------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-{-@ type Tag = { v : [Int] | len(v) = 1 } @-}
+{-@ type Tag = { v : [Int] | len v == 1 } @-}
+
 type Tag           = [Int]
 
 data WfC a  = WfC  { wenv  :: !IBindEnv
@@ -505,8 +506,10 @@ data Sol a = Sol { sMap :: M.HashMap KVar a
                  }
 
 data Cube = Cube
-  { cuBinds :: IBindEnv
-  , cuSubst :: Subst
+  { cuBinds :: IBindEnv  -- ^ Binders       from defining Env
+  , cuSubst :: Subst     -- ^ Substitutions from cstrs    Rhs
+  , cuId    :: Integer   -- ^ Id            of   defining Cstr (DEBUG)
+  , cuTag   :: Tag       -- ^ Tag           of   defining Cstr (DEBUG)
   }
 
 type Hyp      = ListNE Cube

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -193,7 +193,7 @@ toFixSort t@(FFunc _ _)= toFixAbsApp t
 toFixSort (FTC c)      = toFix c
 toFixSort t@(FApp _ _) = toFixFApp (fApp' t)
 
-
+toFixAbsApp :: Sort -> Doc
 toFixAbsApp t = text "func" <> parens (toFix n <> text ", " <> toFix ts)
   where
     Just (vs, ss, s) = functionSort t
@@ -220,18 +220,17 @@ intSort  = fTyconSort intFTyCon
 realSort = fTyconSort realFTyCon
 funcSort = fTyconSort funcFTyCon
 
-bitVecSort :: Sort
-mapSort :: Sort -> Sort -> Sort
-
 setSort :: Sort -> Sort
 setSort    = FApp (FTC $ symbolFTycon' "Set_Set")
 
-
+bitVecSort :: Sort
 bitVecSort = FApp (FTC $ symbolFTycon' bitVecName) (FTC $ symbolFTycon' size32Name)
+
+mapSort :: Sort -> Sort -> Sort
 mapSort k v = FApp (FApp (FTC $ symbolFTycon' "Map_t") k) v
 
+symbolFTycon' :: Symbol -> FTycon
 symbolFTycon' = symbolFTycon . dummyLoc
-
 
 fTyconSort :: FTycon -> Sort
 fTyconSort c

--- a/src/Language/Fixpoint/Types/Spans.hs
+++ b/src/Language/Fixpoint/Types/Spans.hs
@@ -80,6 +80,7 @@ ofSourcePos p = (f, l, c)
 toSourcePos :: (SourceName, Line, Column) -> SourcePos
 toSourcePos (f, l, c) = newPos f l c
 
+sourcePosElts :: SourcePos -> (SourceName, Line, Column)
 sourcePosElts s = (src, line, col)
   where
     src         = sourceName   s
@@ -154,7 +155,7 @@ instance PPrint SrcSpan where
 --     (f,l ,c )     = sourcePosElts $ sp_start z
 --     (_,l',c')     = sourcePosElts $ sp_stop  z
 
-
+ppSrcSpan :: SrcSpan -> Doc
 ppSrcSpan z       = text (printf "%s:%d:%d-%d:%d" f l c l' c')
                 -- parens $ text (printf "file %s: (%d, %d) - (%d, %d)" (takeFileName f) l c l' c')
   where
@@ -165,6 +166,7 @@ ppSrcSpan z       = text (printf "%s:%d:%d-%d:%d" f l c l' c')
 instance Hashable SrcSpan where
   hashWithSalt i z = hashWithSalt i (sp_start z, sp_stop z)
 
+dummySpan :: SrcSpan
 dummySpan = SS l l
   where l = initialPos ""
 

--- a/src/Language/Fixpoint/Utils/Files.hs
+++ b/src/Language/Fixpoint/Utils/Files.hs
@@ -41,6 +41,7 @@ import           Language.Fixpoint.Misc (errorstar)
 -- | Hardwired Paths and Files -----------------------------
 ------------------------------------------------------------
 
+getFixpointPath :: IO FilePath
 getFixpointPath = fromMaybe msg . msum <$>
                   sequence [ findExecutable "fixpoint.native"
                            , findExecutable "fixpoint.native.exe"
@@ -50,6 +51,7 @@ getFixpointPath = fromMaybe msg . msum <$>
   where
     msg = errorstar "Cannot find fixpoint binary [fixpoint.native]"
 
+getZ3LibPath :: IO FilePath
 getZ3LibPath    = dropFileName <$> getFixpointPath
 
 
@@ -90,6 +92,7 @@ data Ext = Cgi      -- ^ Constraint Generation Information
          | Min      -- ^ filter constraints with delta debug
          deriving (Eq, Ord, Show)
 
+extMap :: Ext -> FilePath
 extMap          = go
   where
     go Cgi      = ".cgi"
@@ -140,6 +143,7 @@ tempDirectory f
     dir         = takeDirectory f
     isTmp       = (tmpDirName `isSuffixOf`)
 
+tmpDirName :: FilePath
 tmpDirName      = ".liquid"
 
 extFileNameR     :: Ext -> FilePath -> FilePath
@@ -180,8 +184,9 @@ copyFiles srcs tgt
 getFileInDirs :: FilePath -> [FilePath] -> IO (Maybe FilePath)
 getFileInDirs name = findFirst (testM doesFileExist . (</> name))
 
+testM :: (Monad m) => (a -> m Bool) -> a -> m [a]
 testM f x = do b <- f x
-               return $ if b then [x] else []
+               return [ x | b ]
 
 findFirst ::  Monad m => (t -> m [a]) -> [t] -> m (Maybe a)
 findFirst _ []     = return Nothing


### PR DESCRIPTION
Added code to track how "big" a formula a `KVar` gets expanded into. TL;DR -- sequences of monadic binds cause super long chains, and hence, potential blowup.