### PR TITLE
take makeContext's Bool from caller instead of always using False

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -97,10 +97,9 @@ runCommands cmds
 -}
 
 
--- TODO take makeContext's Bool from caller instead of always using False?
-makeZ3Context :: FilePath -> [(Symbol, Sort)] -> IO Context
-makeZ3Context f xts
-  = do me <- makeContextWithSEnv False Z3 f $ fromListSEnv xts
+makeZ3Context :: Bool -> FilePath -> [(Symbol, Sort)] -> IO Context
+makeZ3Context u f xts
+  = do me <- makeContextWithSEnv u Z3 f $ fromListSEnv xts
        smtDecls me (toListSEnv initSMTEnv)
        smtDecls me xts
        return me


### PR DESCRIPTION
i think take the Bool value to control the [different semantics](https://github.com/ucsd-progsys/liquid-fixpoint/blob/master/src/Language/Fixpoint/Smt/Theories.hs#L116-L117) from caller outside is quite necessary, so maybe we should elininate this TODO via this PR?

other places depend on `mkZ3Context` should be update such as [here](https://github.com/ucsd-progsys/prover/blob/master/src/Prover/SMTInterface.hs#L9).