### PR TITLE
Lambda bug

### DIFF
--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -393,7 +393,7 @@ normalizeLams :: (Symbol, Sort) -> Expr -> Expr
 normalizeLams (x, s) e = ELam (x', s) (bd `subst1` su)
   where
     su = (x, EVar x')
-    x' = makeLamArg s 1 -- $ debruijnIndex e
+    x' = makeLamArg s 1 -- debruijnIndex e
     bd = go 2 e 
     go i (ELam (y, sy) e) = let y' = makeLamArg sy i
                             in ELam (y', sy) (go (i+1) e `subst1` (y, EVar y'))

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -340,6 +340,7 @@ defineFun (f, ELam (x, t) (ECst e tr))
                                   (PAtom Eq (mkApp (EApp (EVar f) (EVar x)) (fst <$> xts)) bd))
        g <- freshSym
        assert2 <- withExtendedEnv [(f, FFunc t tr)] $
+                  withNoExtensionality $ 
                    defunc $ Assert Nothing
         (PAll [(g, FFunc t tr)]
           (PImp

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -25,7 +25,7 @@ module Language.Fixpoint.Smt.Types (
     , Context (..)
 
     -- * SMTLIB2 symbol environment
-    , SMTEnv, emptySMTEnv, SMTSt(..), withExtendedEnv, SMT2, freshSym
+    , SMTEnv, emptySMTEnv, SMTSt(..), withExtendedEnv, SMT2, freshSym, withNoExtensionality
 
     -- * Theory Symbol
     , TheorySymbol (..)
@@ -104,6 +104,15 @@ withExtendedEnv bs act = do
   r <- act
   modify $ \s -> s{smt2env = env}
   return r
+
+withNoExtensionality :: SMT2 a -> SMT2 a
+withNoExtensionality act = do 
+  extFlag <- f_ext <$> get 
+  modify $ \s -> s{f_ext = False}
+  x <- act
+  modify $ \s -> s{f_ext = extFlag}
+  return x 
+
 
 freshSym :: SMT2 Symbol
 freshSym = do

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -97,12 +97,14 @@ subSymbol (Just (EVar y)) _ = y
 subSymbol Nothing         x = x
 subSymbol a               b = errorstar (printf "Cannot substitute symbol %s with expression %s" (showFix b) (showFix a))
 
+substfLam :: (Symbol -> Expr) -> (Symbol, Sort) -> Expr -> Expr 
+substfLam f s@(x, _) e =  ELam s (substf (\y -> if y == x then EVar x else f y) e)
+
 instance Subable Expr where
-  -- NV: assuming all lambda abstractions are unique
   syms                     = exprSymbols
   substa f                 = substf (EVar . f)
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
-  substf f (ELam s e)      = ELam s (substf f e)
+  substf f (ELam x e)      = substfLam f x e 
   substf f (ENeg e)        = ENeg (substf f e)
   substf f (EBin op e1 e2) = EBin op (substf f e1) (substf f e2)
   substf f (EIte p e1 e2)  = EIte (substf f p) (substf f e1) (substf f e2)
@@ -120,7 +122,7 @@ instance Subable Expr where
 
 
   subst su (EApp f e)      = EApp (subst su f) (subst su e)
-  subst su (ELam x e)      = ELam x (subst su e)
+  subst su (ELam x e)      = ELam x (subst (removeSubst su (fst x)) e)
   subst su (ENeg e)        = ENeg (subst su e)
   subst su (EBin op e1 e2) = EBin op (subst su e1) (subst su e2)
   subst su (EIte p e1 e2)  = EIte (subst su p) (subst su e1) (subst su e2)
@@ -138,6 +140,9 @@ instance Subable Expr where
           | disjoint su bs = PExist bs $ subst su p --(substExcept su (fst <$> bs)) p
           | otherwise      = errorstar "subst: EXISTS (without disjoint binds)"
   subst _  p               = p
+
+removeSubst :: Subst -> Symbol -> Subst
+removeSubst (Su su) x = Su $ M.delete x su 
 
 disjoint :: Subst -> [(Symbol, Sort)] -> Bool
 disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -1,8 +1,6 @@
 -- | This module contains the various instances for Subable,
 --   which (should) depend on the visitors, and hence cannot
 --   be in the same place as the @Term@ definitions.
-{-# LANGUAGE FlexibleInstances #-}
-
 module Language.Fixpoint.Types.Substitutions (
     mkSubst
   , isEmptySubst
@@ -150,19 +148,6 @@ disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
     suSyms = S.fromList $ syms (M.elems su) ++ syms (M.keys su)
     bsSyms = S.fromList $ syms $ fst <$> bs
-
-instance Subable (Either (Symbol, Expr) Expr) where
-  syms (Left (x, e)) = x:syms e 
-  syms (Right e)     = syms e
-
-  substa f (Left (x, e)) = Left (f x, substa f e)
-  substa f (Right e)     = Right (substa f e)  
-
-  substf f (Left (x, e)) = Left  (x, substf f e)
-  substf f (Right e)     = Right (substf f e)
-
-  subst su (Left (x, e)) = Left (x, subst su e)
-  subst su (Right e)     = Right (subst su e)
 
 instance Monoid Expr where
   mempty      = PTrue

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -1,6 +1,7 @@
 -- | This module contains the various instances for Subable,
 --   which (should) depend on the visitors, and hence cannot
 --   be in the same place as the @Term@ definitions.
+{-# LANGUAGE FlexibleInstances #-}
 
 module Language.Fixpoint.Types.Substitutions (
     mkSubst
@@ -149,6 +150,19 @@ disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
     suSyms = S.fromList $ syms (M.elems su) ++ syms (M.keys su)
     bsSyms = S.fromList $ syms $ fst <$> bs
+
+instance Subable (Either (Symbol, Expr) Expr) where
+  syms (Left (x, e)) = x:syms e 
+  syms (Right e)     = syms e
+
+  substa f (Left (x, e)) = Left (f x, substa f e)
+  substa f (Right e)     = Right (substa f e)  
+
+  substf f (Left (x, e)) = Left  (x, substf f e)
+  substf f (Right e)     = Right (substf f e)
+
+  subst su (Left (x, e)) = Left (x, subst su e)
+  subst su (Right e)     = Right (subst su e)
 
 instance Monoid Expr where
   mempty      = PTrue


### PR DESCRIPTION
Fixes on generation of unsound function extensionality axioms. 
Allow syntactic beta reduction: once `(EApp (Elam x e) ex)` is observed `(EApp (Elam x e) ex) == e subst1 (x, ex)` is assumes