### PR TITLE
Optional equivalences

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -55,7 +55,7 @@ module Language.Fixpoint.Smt.Interface (
 
     ) where
 
-import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality)
+import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality, alphaEquivalence, betaEquivalence)
 import           Language.Fixpoint.Misc   (errorstar, getUniqueInt)
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
@@ -269,6 +269,8 @@ makeProcess cfg
                   , cLog    = Nothing
                   , verbose = loud
                   , c_ext   = extensionality cfg
+                  , c_aeq   = alphaEquivalence cfg  
+                  , c_beq   = betaEquivalence  cfg  
                   , smtenv  = initSMTEnv
                   }
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -55,7 +55,7 @@ module Language.Fixpoint.Smt.Interface (
 
     ) where
 
-import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality, alphaEquivalence, betaEquivalence)
+import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality, alphaEquivalence, betaEquivalence, normalForm)
 import           Language.Fixpoint.Misc   (errorstar, getUniqueInt)
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
@@ -271,6 +271,7 @@ makeProcess cfg
                   , c_ext   = extensionality cfg
                   , c_aeq   = alphaEquivalence cfg  
                   , c_beq   = betaEquivalence  cfg  
+                  , c_norm  = normalForm       cfg 
                   , smtenv  = initSMTEnv
                   }
 

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -476,7 +476,12 @@ grapLambdas = go []
 
 
 makeBetaReductionAsserts :: Expr -> SMT2 [Expr]
-makeBetaReductionAsserts e = mapM defunc (fold betaVis () [] e ++ fold lamVis () [] e)
+makeBetaReductionAsserts e 
+  = do aFlag <- a_eq <$> get
+       bFlag <- b_eq <$> get 
+       let as1 = if aFlag then fold lamVis  () [] e else []
+       let as2 = if bFlag then fold betaVis () [] e else []
+       mapM defunc (as1 ++ as2)
   where
     betaVis = (defaultVisitor :: Visitor [Expr] ()) {accExpr = go }
     go _ e@(EApp f ex)

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -509,7 +509,7 @@ makeBetaReductionAsserts e
     normVis = (defaultVisitor :: Visitor [Expr] ()) {accExpr = go'' }
     go'' _ ee@(ELam _ _)
       -- optimization: do it for each lambda once
-      -- | notElem ee cxt 
+      --  notElem ee cxt 
       = [mkEq ee (normalizeLams $  normalForm ee)]
     go'' _ _ = []
 

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -530,20 +530,6 @@ makeBetaReductionAsserts e
       | otherwise = PAtom Eq e1 e2    
 
 
-{- 
-
-maxList :: [Int] -> Int -> Int -> Int 
-maxList [] _ _ = error ""
-maxList (i:is) i1 i2 
-  | i == i1 = i2 
-  | i == i2 = i1 
-  | otherwise = maxList is i1 i2 
-
-
-next :: [Int] -> (Int -> Int)
-next is j = traceShow (" NEXT ON  " ++ show (is, j)) $ head $ tail $ dropWhile (j/=) is  
--}
-
 makeApplication :: Expr -> [Expr] -> SMT2 Expr
 makeApplication e es = defunc e >>= (`go` es)
   where

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -501,7 +501,7 @@ makeBetaReductionAsserts e
     lamVis = (defaultVisitor :: Visitor [Expr] ()) {accExpr = go' }
     go' _ ee@(ELam (x, s) e)
       -- optimization: do it for each lambda once
-      -- | notElem ee cxt 
+      --  notElem ee cxt 
       = [mkEq ee ee' | (i, ee') <- map (\j -> normalizeLamsFromTo j (ELam (x, s) e)) [1..maxLamArg-1], i <= maxLamArg ]
     go' _ _ = []
 

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -76,6 +76,7 @@ data Context      = Ctx { pId     :: !ProcessHandle
                         , c_ext   :: !Bool              -- flag to enable function extentionality axioms
                         , c_aeq   :: !Bool              -- flag to enable lambda a-equivalence axioms
                         , c_beq   :: !Bool              -- flag to enable lambda b-equivalence axioms
+                        , c_norm  :: !Bool              -- flag to enable lambda normal form equivalence axioms
                         , smtenv  :: !SMTEnv
                         }
 
@@ -94,9 +95,10 @@ type SMTEnv = SEnv Sort
 data SMTSt  
   = SMTSt { fresh   :: !Int 
           , smt2env :: !SMTEnv
-          , f_ext   :: !Bool
-          , a_eq    :: !Bool
-          , b_eq    :: !Bool
+          , f_ext   :: !Bool   -- enable extensionality axioms
+          , a_eq    :: !Bool   -- enable alpha equivalence axioms
+          , b_eq    :: !Bool   -- enable beta equivalence axioms
+          , f_norm  :: !Bool   -- enable normal form axioms
           }
 
 type SMT2   = State SMTSt
@@ -167,4 +169,4 @@ class SMTLIB2 a where
   smt2 :: a -> LT.Builder
 
 runSmt2 :: (SMTLIB2 a) => Int -> Context -> a -> LT.Builder
-runSmt2 n cxt a = smt2 $ evalState (defunc a) (SMTSt n (smtenv cxt) (c_ext cxt) (c_aeq cxt) (c_beq cxt))
+runSmt2 n cxt a = smt2 $ evalState (defunc a) (SMTSt n (smtenv cxt) (c_ext cxt) (c_aeq cxt) (c_beq cxt) (c_norm cxt))

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -74,6 +74,8 @@ data Context      = Ctx { pId     :: !ProcessHandle
                         , cLog    :: !(Maybe Handle)
                         , verbose :: !Bool
                         , c_ext   :: !Bool              -- flag to enable function extentionality axioms
+                        , c_aeq   :: !Bool              -- flag to enable lambda a-equivalence axioms
+                        , c_beq   :: !Bool              -- flag to enable lambda b-equivalence axioms
                         , smtenv  :: !SMTEnv
                         }
 
@@ -89,7 +91,13 @@ data TheorySymbol  = Thy { tsSym  :: !Symbol
 --------------------------------------------------------------------------------
 
 type SMTEnv = SEnv Sort
-data SMTSt  = SMTSt {fresh :: !Int , smt2env :: !SMTEnv, f_ext :: !Bool}
+data SMTSt  
+  = SMTSt { fresh   :: !Int 
+          , smt2env :: !SMTEnv
+          , f_ext   :: !Bool
+          , a_eq    :: !Bool
+          , b_eq    :: !Bool
+          }
 
 type SMT2   = State SMTSt
 
@@ -159,4 +167,4 @@ class SMTLIB2 a where
   smt2 :: a -> LT.Builder
 
 runSmt2 :: (SMTLIB2 a) => Int -> Context -> a -> LT.Builder
-runSmt2 n cxt a = smt2 $ evalState (defunc a) (SMTSt n (smtenv cxt) (c_ext cxt))
+runSmt2 n cxt a = smt2 $ evalState (defunc a) (SMTSt n (smtenv cxt) (c_ext cxt) (c_aeq cxt) (c_beq cxt))

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -65,6 +65,8 @@ data Config
     -- , nontriv     :: Bool             -- ^ simplify using non-trivial sorts
     , gradual     :: Bool                -- ^ solve "gradual" constraints
     , extensionality :: Bool             -- ^ allow function extensionality
+    , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
+    , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
     , autoKuts    :: Bool                -- ^ ignore given kut variables
     , pack        :: Bool                -- ^ Use pack annotations
     , nonLinCuts  :: Bool                -- ^ Treat non-linear vars as cuts
@@ -97,6 +99,8 @@ instance Default Config where
                , minimizeQs  = def
                , gradual     = False
                , extensionality = False
+               , alphaEquivalence = False
+               , betaEquivalence  = False
                , autoKuts       = False
                , pack           = False
                , nonLinCuts     = False
@@ -175,6 +179,8 @@ config = Config {
   , minimizeQs  = False &= help "Delta debug to minimize fq file (sat with min qualifiers)"
   , gradual     = False &= help "Solve gradual-refinement typing constraints"
   , extensionality = False &= help "Allow function extensionality axioms"
+  , alphaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
+  , betaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
   , autoKuts       = False &= help "Ignore given Kut vars, compute from scratch"
   , pack           = False &= help "Use pack annotations"
   , nonLinCuts     = False &= help "Treat non-linear kvars as cuts"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -67,6 +67,7 @@ data Config
     , extensionality :: Bool             -- ^ allow function extensionality
     , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
     , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
+    , normalForm  :: Bool                -- ^ allow lambda normal-form equivalence axioms
     , autoKuts    :: Bool                -- ^ ignore given kut variables
     , pack        :: Bool                -- ^ Use pack annotations
     , nonLinCuts  :: Bool                -- ^ Treat non-linear vars as cuts
@@ -101,6 +102,7 @@ instance Default Config where
                , extensionality = False
                , alphaEquivalence = False
                , betaEquivalence  = False
+               , normalForm     = False 
                , autoKuts       = False
                , pack           = False
                , nonLinCuts     = False
@@ -181,6 +183,7 @@ config = Config {
   , extensionality = False &= help "Allow function extensionality axioms"
   , alphaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
   , betaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
+  , normalForm     = False  &= help "Allow lambda normal-form equivalence axioms"
   , autoKuts       = False &= help "Ignore given Kut vars, compute from scratch"
   , pack           = False &= help "Use pack annotations"
   , nonLinCuts     = False &= help "Treat non-linear kvars as cuts"


### PR DESCRIPTION
Adding flags for lambda 
  α-, β-, and normal form equivalences, all needed to prove monadic laws on Reader