### PR TITLE
Don't inst with string literals or "derived" variables

### DIFF
--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -240,20 +240,12 @@ declareInitEnv
 --   non-function sorted values.
 
 distinctLiterals :: F.GInfo c a -> [[F.Expr]]
--- distinctLiterals fi | F.allowHO fi = [ es | (_, es) <- tess ]
-  -- where
-    -- tess         = groupList [(t, F.expr x) | (x, t) <- F.toListSEnv (F.gLits fi)
-                                            -- , isNotThy x
-                                            -- , isConstant x                      ]
-    -- isNotThy     = isNothing . Thy.smt2Symbol
-    -- isConstant   = isUpper . head . F.symbolString
-
-
 distinctLiterals fi  = [ es | (_, es) <- tess ]
    where
     tess             = groupList [(t, F.expr x) | (x, t) <- F.toListSEnv (F.dLits fi)
-                                                , notFun t]
+                                                , notFun t                            ]
     notFun           = not . F.isFunctionSortedReft . (`F.RR` F.trueReft)
+    _notStr          = not . (F.strSort ==) . F.sr_sort . (`F.RR` F.trueReft)
 
 ---------------------------------------------------------------------------
 stats :: SolveM Stats

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -79,7 +79,7 @@ init si ks = Sol.fromList keqs [] mempty Nothing
 refine :: F.SInfo a -> [F.Qualifier] -> F.WfC a -> (F.KVar, Sol.QBind)
 refine fi qs w = refineK (allowHOquals fi) env qs $ F.wrft w
   where
-    env        = if True then wenv else wenv <> genv
+    env        = if True then F.differenceSEnv wenv genv else wenv <> genv
     wenv       = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
     genv       = F.gLits fi
 

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -32,7 +32,7 @@ import qualified Language.Fixpoint.Solver.Index       as Index
 import           Prelude                              hiding (init, lookup)
 
 -- DEBUG
-import Text.Printf (printf)
+-- import Text.Printf (printf)
 -- import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
@@ -79,16 +79,16 @@ init si ks = Sol.fromList keqs [] mempty Nothing
 refine :: F.SInfo a -> [F.Qualifier] -> F.WfC a -> (F.KVar, Sol.QBind)
 refine fi qs w = refineK (allowHOquals fi) env qs $ F.wrft w
   where
-    env        = if True then F.differenceSEnv wenv genv else wenv <> genv
+    env        = if True then wenv else wenv <> genv
     wenv       = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
     genv       = F.gLits fi
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
-refineK ho env qs (v, t, k) = F.tracepp _msg (k, eqs')
+refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')
    where
     eqs                     = instK ho env v t qs
     eqs'                    = filter (okInst env v t) eqs
-    _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
+    -- _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
 
 --------------------------------------------------------------------------------
 instK :: Bool

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -71,17 +71,24 @@ init :: F.SInfo a -> S.HashSet F.KVar -> Sol.Solution
 --------------------------------------------------------------------------------
 init si ks = Sol.fromList keqs [] mempty Nothing
   where
-    keqs   = map (refine si qs) ws `using` parList rdeepseq
+    keqs   = map (refine si qs genv) ws `using` parList rdeepseq
     qs     = F.quals si
     ws     = [ w | (k, w) <- M.toList (F.ws si), k `S.member` ks]
+    genv   = instConstants si
 
 --------------------------------------------------------------------------------
-refine :: F.SInfo a -> [F.Qualifier] -> F.WfC a -> (F.KVar, Sol.QBind)
-refine fi qs w = refineK (allowHOquals fi) env qs $ F.wrft w
+refine :: F.SInfo a -> [F.Qualifier] -> F.SEnv F.Sort -> F.WfC a -> (F.KVar, Sol.QBind)
+refine fi qs genv w = refineK (allowHOquals fi) env qs $ F.wrft w
   where
-    env        = if True then wenv else wenv <> genv
-    wenv       = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
-    genv       = F.gLits fi
+    env             = wenv <> genv
+    wenv            = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
+
+instConstants :: F.SInfo a -> F.SEnv F.Sort
+-- instConstants fi = F.gLits fi
+instConstants = F.fromListSEnv . filter notLit . F.toListSEnv . F.gLits
+  where
+    notLit    = not . F.isLitSymbol . fst
+
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
 refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -32,7 +32,7 @@ import qualified Language.Fixpoint.Solver.Index       as Index
 import           Prelude                              hiding (init, lookup)
 
 -- DEBUG
--- import Text.Printf (printf)
+import Text.Printf (printf)
 -- import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
@@ -76,22 +76,19 @@ init si ks = Sol.fromList keqs [] mempty Nothing
     ws     = [ w | (k, w) <- M.toList (F.ws si), k `S.member` ks]
 
 --------------------------------------------------------------------------------
-refine :: F.SInfo a
-       -> [F.Qualifier]
-       -> F.WfC a
-       -> (F.KVar, Sol.QBind)
+refine :: F.SInfo a -> [F.Qualifier] -> F.WfC a -> (F.KVar, Sol.QBind)
 refine fi qs w = refineK (allowHOquals fi) env qs $ F.wrft w
   where
-    env        = wenv <> genv
+    env        = if True then wenv else wenv <> genv
     wenv       = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
     genv       = F.gLits fi
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
-refineK ho env qs (v, t, k) = {- tracepp msg -} (k, eqs')
+refineK ho env qs (v, t, k) = F.tracepp _msg (k, eqs')
    where
-    eqs                  = instK ho env v t qs
-    eqs'                 = filter (okInst env v t) eqs
-    -- msg                  = printf "refineK: k = %s, eqs = %s" (showpp k) (showpp eqs)
+    eqs                     = instK ho env v t qs
+    eqs'                    = filter (okInst env v t) eqs
+    _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
 
 --------------------------------------------------------------------------------
 instK :: Bool

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -278,13 +278,12 @@ sanitizeWfC :: F.SInfo a -> F.SInfo a
 sanitizeWfC si = si { F.ws = ws' }
   where
     ws'        = deleteWfCBinds drops <$> F.ws si
-    drops      = F.tracepp "sanitizeWfC: dropping" $ L.sort drops'
-    (_,drops') = filterBindEnv keepF   $  F.bs si
-    keepF      = conjKF [nonConstantF si, nonFunctionF si {-, nonDerivedLH -}]
+    (_,drops)  = filterBindEnv keepF   $  F.bs si
+    keepF      = conjKF [nonConstantF si, nonFunctionF si, _nonDerivedLH]
+    -- drops   = F.tracepp "sanitizeWfC: dropping" $ L.sort drops'
 
 conjKF :: [KeepBindF] -> KeepBindF
 conjKF fs x t = and [f x t | f <- fs]
-
 
 -- | `nonDerivedLH` keeps a bind x if it does not start with `$` which is used
 --   typically for names that are automatically "derived" by GHC (and which can)

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -280,7 +280,7 @@ sanitizeWfC si = si { F.ws = ws' }
     ws'        = deleteWfCBinds drops <$> F.ws si
     drops      = F.tracepp "sanitizeWfC: dropping" $ L.sort drops'
     (_,drops') = filterBindEnv keepF   $  F.bs si
-    keepF      = conjKF [nonConstantF si, nonFunctionF si, nonDerivedLH]
+    keepF      = conjKF [nonConstantF si, nonFunctionF si {-, nonDerivedLH -}]
 
 conjKF :: [KeepBindF] -> KeepBindF
 conjKF fs x t = and [f x t | f <- fs]
@@ -288,11 +288,11 @@ conjKF fs x t = and [f x t | f <- fs]
 
 -- | `nonDerivedLH` keeps a bind x if it does not start with `$` which is used
 --   typically for names that are automatically "derived" by GHC (and which can)
---   blow up the environments thereby clogging instantiation, etc. 
+--   blow up the environments thereby clogging instantiation, etc.
 --   NOTE: This is an LH specific hack and should be moved there.
 
-nonDerivedLH :: KeepBindF
-nonDerivedLH x _ = not . T.isPrefixOf "$" . last . T.split ('.' ==) . F.symbolText $ x
+_nonDerivedLH :: KeepBindF
+_nonDerivedLH x _ = not . T.isPrefixOf "$" . last . T.split ('.' ==) . F.symbolText $ x
 
 nonConstantF :: F.SInfo a -> KeepBindF
 nonConstantF si = \x _ -> not (x `F.memberSEnv` cEnv)

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -34,6 +34,7 @@ module Language.Fixpoint.Types.Names (
   , isPrefixOfSym
   , isSuffixOfSym
   , isNonSymbol
+  , isLitSymbol
   , isNontrivialVV
   , isDummy
 
@@ -391,6 +392,9 @@ dummySymbol = dummyName
 
 litSymbol :: Symbol -> Symbol
 litSymbol s = litPrefix `mappendSym` s
+
+isLitSymbol :: Symbol -> Bool
+isLitSymbol = isPrefixOfSym litPrefix
 
 unLitSymbol :: Symbol -> Maybe Symbol
 unLitSymbol = stripPrefix litPrefix


### PR DESCRIPTION
This PR modifies the instantiation environments to ensure that we don't instantiate qualifier parameters with:

1. `Str` literals, or,
2. GHC derived variables (whose names starts with a `$`).

**The latter should really be in LH and not in fixpoint.**