### PR TITLE
String interpretation by Z3

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -601,12 +601,13 @@ intP :: Parser Int
 intP = fromInteger <$> integer
 
 defsFInfo :: [Def a] -> FInfo a
-defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts dts kts qs mempty mempty mempty
+defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs lts dts ss kts qs mempty mempty mempty
   where
     cm         = M.fromList         [(cid c, c)         | Cst c       <- defs]
     ws         = M.fromList         [(thd3 $ wrft w, w) | Wfc w       <- defs]
     bs         = bindEnvFromList    [(n, x, r)          | IBind n x r <- defs]
-    lts        = fromListSEnv       [(x, t)             | Con x t     <- defs]
+    lts        = fromListSEnv       [(x, t)             | Con x t     <- defs, not (isSymbolSymConst (x, t))]
+    ss         =                    [symbolSymConst x   | Con x t     <- defs, isSymbolSymConst (x, t)]
     dts        = fromListSEnv       [(x, t)             | Dis x t     <- defs]
     kts        = KS $ S.fromList    [k                  | Kut k       <- defs]
     -- pks        = Packs $ M.fromList [(k, i)             | Pack k i    <- defs]

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -38,6 +38,7 @@ module Language.Fixpoint.Parse (
   , bindP       -- Binder (lowerIdP <* colon)
   , sortP       -- Sort
   , mkQual      -- constructing qualifiers
+  , fTyConP
 
   -- * Parsing recursive entities
   , exprP       -- Expressions
@@ -379,6 +380,8 @@ fTyConP
   <|> (reserved "real"    >> return realFTyCon)
   <|> (reserved "bool"    >> return boolFTyCon)
   <|> (reserved "num"     >> return numFTyCon)
+  <|> (reserved "Char"    >> return charFTyCon)
+  <|> (reserved "String"  >> return strFTyCon)
   <|> (symbolFTycon      <$> locUpperIdP)
 
 bvSortP :: Parser Sort

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -55,7 +55,7 @@ module Language.Fixpoint.Smt.Interface (
 
     ) where
 
-import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality, alphaEquivalence, betaEquivalence, normalForm)
+import           Language.Fixpoint.Types.Config (SMTSolver (..), Config, solver, extensionality, alphaEquivalence, betaEquivalence, normalForm, stringTheory)
 import           Language.Fixpoint.Misc   (errorstar, getUniqueInt)
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
@@ -272,6 +272,7 @@ makeProcess cfg
                   , c_aeq   = alphaEquivalence cfg  
                   , c_beq   = betaEquivalence  cfg  
                   , c_norm  = normalForm       cfg 
+                  , c_str   = stringTheory     cfg 
                   , smtenv  = initSMTEnv
                   }
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -299,20 +299,23 @@ smtPreamble :: Config -> SMTSolver -> Context -> IO [LT.Text]
 smtPreamble cfg Z3 me
   = do smtWrite me "(get-info :version)"
        v:_ <- T.words . (!!1) . T.splitOn "\"" <$> smtReadRaw me
-       if T.splitOn "." v `versionGreater` ["4", "3", "2"]
+       if (stringTheory cfg && not (T.splitOn "." v `versionGreaterEq` ["4", "4", "2"])) 
+         then errorstar "String Theory is not supported by z3 <= 4.4.1" 
+         else return ()
+       if T.splitOn "." v `versionGreaterEq` ["4", "3", "2"]
          then return $ z3_432_options ++ makeMbqi cfg ++ preamble cfg Z3
          else return $ z3_options     ++ makeMbqi cfg ++ preamble cfg Z3
 smtPreamble cfg s _
   = return $ preamble cfg s
 
-versionGreater :: Ord a => [a] -> [a] -> Bool
-versionGreater (x:xs) (y:ys)
+versionGreaterEq :: Ord a => [a] -> [a] -> Bool
+versionGreaterEq (x:xs) (y:ys)
   | x >  y = True
-  | x == y = versionGreater xs ys
+  | x == y = versionGreaterEq xs ys
   | x <  y = False
-versionGreater _  [] = True
-versionGreater [] _  = False
-versionGreater _ _ = errorstar "Interface.versionGreater called with bad arguments"
+versionGreaterEq _  [] = True
+versionGreaterEq [] _  = False
+versionGreaterEq _ _ = errorstar "Interface.versionGreater called with bad arguments"
 
 -----------------------------------------------------------------------------
 -- | SMT Commands -----------------------------------------------------------

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -549,7 +549,8 @@ makeApplication e es = defunc e >>= (`go` es)
     go f []     = return f
     go f (e:es) = do df <- defunc $ makeFunSymbol f 1
                      de <- defunc e
-                     let res = eApps (EVar df) [ECst f (exprSort f), de]
+                     de' <- toInt de 
+                     let res = eApps (EVar df) [ECst f (exprSort f), de']
                      let s  = exprSort (EApp f de)
                      go ((`ECst` s) res) es
 
@@ -592,7 +593,6 @@ dropArgs s j (FFunc _ t) = dropArgs s (j-1) t
 dropArgs str j s
   = die $ err dummySpan $ text (str ++ "  dropArgs: the impossible happened" ++ show (j, s))
 
-{-
 toInt :: Expr -> SMT2 Expr
 toInt e
   |  (FApp (FTC c) _)         <- s, fTyconSymbol c == "Set_Set"
@@ -605,6 +605,8 @@ toInt e
   = castWith boolToIntName e
   | FTC c                     <- s, c == realFTyCon
   = castWith realToIntName e
+  | isString s 
+  = castWith strToIntName e 
   | otherwise
   = defunc e
   where
@@ -616,7 +618,7 @@ castWith s e =
      be <- defunc e
      return $ EApp (EVar bs) be
 
--}
+
 isSMTSort :: Sort -> Bool
 isSMTSort s
   | (FApp (FTC c) _)         <- s, fTyconSymbol c == "Set_Set"

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -222,7 +222,7 @@ defuncApp :: Expr -> SMT2 Expr
 defuncApp e = case Thy.smt2App (eliminate f) (smt2 <$> es) of
                 Just _ -> eApps f <$> mapM defunc es
                 _      -> if stringLen es'
-                           then EApp (EVar Thy.strLen) <$> defunc (head es')  
+                           then defunc $ EApp (EVar Thy.strLen) (head es')  
                            else defuncApp' f' es'
   where
     (f, es)   = splitEApp' e

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -92,7 +92,8 @@ instance SMTLIB2 (Symbol, Sort) where
 
 
 instance SMTLIB2 SymConst where
-  smt2 (SL t)  = build "\"{}\"" (Only t) -- smt2   . symbol
+  -- smt2 (SL t)  = build "\"{}\"" (Only t) -- smt2   . symbol
+  smt2 = smt2 . symbol
 
 
 instance SMTLIB2 Constant where

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -92,9 +92,7 @@ instance SMTLIB2 (Symbol, Sort) where
 
 
 instance SMTLIB2 SymConst where
-  -- smt2 (SL t)  = build "\"{}\"" (Only t) -- smt2   . symbol
-  smt2 = smt2 . symbol
-
+  smt2 (SL s)  = build "\"{}\"" (Only s) -- smt2   . symbol
 
 instance SMTLIB2 Constant where
   smt2 (I n)   = build "{}" (Only n)
@@ -151,7 +149,7 @@ instance SMTLIB2 Expr where
 
 
 -- new version
-  defunc e@(ESym _)       = return e
+  defunc (ESym s)         = defuncESym s
   defunc e@(ECon _)       = return e
   defunc e@(EVar _)       = return e
   defunc e@(EApp _ _)     = defuncApp e
@@ -184,6 +182,13 @@ instance SMTLIB2 Expr where
   defunc (ELam x e)       = ELam x <$> defunc e 
   defunc  e               = errorstar ("defunc Pred: " ++ show e)
 
+
+defuncESym :: SymConst -> SMT2 Expr
+defuncESym s = do 
+    istr <- istring <$> get 
+    if istr 
+      then return $ ESym s 
+      else return $ eVar s 
 -- This is not defuncionalization, should not happen in defunc
 
 defuncBop :: Bop -> Expr -> Expr -> SMT2 Expr

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -63,7 +63,7 @@ instance SMTLIB2 Sort where
   smt2 t
     | t == boolSort            = "Bool"
   smt2 t 
-    | isString t               = "String"
+    | isString t               = build "{}" (Only Thy.string)
   smt2 t
     | Just d <- Thy.smt2Sort t = d
   smt2 _                       = "Int"

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -22,6 +22,7 @@ module Language.Fixpoint.Smt.Theories
      , theoryEnv
 
        -- * String 
+     , string
      , strLen, genLen
 
        -- * Theories
@@ -108,7 +109,7 @@ substrSort = mkFFunc 0 [strSort, intSort, intSort, strSort]
 
 
 string :: Raw
-string = "String" 
+string = "Str" 
 
 z3Preamble :: Config -> [T.Text]
 z3Preamble u
@@ -139,10 +140,6 @@ z3Preamble u
         (sel, map, elt, elt)
     , format "(define-fun {} ((m {}) (k {}) (v {})) {} (store m k v))"
         (sto, map, elt, elt, map)
-    , format "(define-fun {} ((s {})) Int ({} s))"
-        (strlen, string, z3strlen)
-    , format "(define-fun {} ((s {}) (i Int) (j Int)) {} ({} s i j))"
-        (strsubstr, string, string, z3strsubstr)
     , uifDef u (symbolText mulFuncName) ("*"::T.Text)
     , uifDef u (symbolText divFuncName) ("div"::T.Text)
     ]
@@ -198,13 +195,24 @@ smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
 
 stringPrealble :: Config -> [T.Text]
 stringPrealble cfg | stringTheory cfg
-  = [] 
+  = [
+      format "(define-sort {} () String)" (Only string)
+    , format "(define-fun {} ((s {})) Int ({} s))"
+        (strlen, string, z3strlen)
+    , format "(define-fun {} ((s {}) (i Int) (j Int)) {} ({} s i j))"
+        (strsubstr, string, string, z3strsubstr)
+    ] 
 stringPrealble _ 
   = [
       format "(define-sort {} () Int)" (Only string)
-    , format "(declare-fun {} ({}) Int)" (z3strlen, string)
-    , format "(declare-fun {} ({} Int Int) {})" (z3strsubstr, string, string)
+    , format "(declare-fun {} ({}) Int)"
+        (strlen, string)
+    , format "(declare-fun {} ({} Int Int) {})"
+        (strsubstr, string, string)
     ]
+
+
+
 
 {-
 mkSetSort _ _  = set

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -78,6 +78,7 @@ data Context      = Ctx { pId     :: !ProcessHandle
                         , c_beq   :: !Bool              -- flag to enable lambda b-equivalence axioms
                         , c_norm  :: !Bool              -- flag to enable lambda normal form equivalence axioms
                         , smtenv  :: !SMTEnv
+                        , c_str   :: !Bool              -- enable string interpretation 
                         }
 
 -- | Theory Symbol
@@ -99,6 +100,7 @@ data SMTSt
           , a_eq    :: !Bool   -- enable alpha equivalence axioms
           , b_eq    :: !Bool   -- enable beta equivalence axioms
           , f_norm  :: !Bool   -- enable normal form axioms
+          , istring :: !Bool   -- allow string interpretation  
           }
 
 type SMT2   = State SMTSt
@@ -169,4 +171,5 @@ class SMTLIB2 a where
   smt2 :: a -> LT.Builder
 
 runSmt2 :: (SMTLIB2 a) => Int -> Context -> a -> LT.Builder
-runSmt2 n cxt a = smt2 $ evalState (defunc a) (SMTSt n (smtenv cxt) (c_ext cxt) (c_aeq cxt) (c_beq cxt) (c_norm cxt))
+runSmt2 n cxt a = smt2 $ evalState (defunc a) 
+   (SMTSt n (smtenv cxt) (c_ext cxt) (c_aeq cxt) (c_beq cxt) (c_norm cxt) (c_str cxt))

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -232,7 +232,7 @@ declare cfg xts' ess cs p = withContext $ \me -> do
     isThy   = isJust . Thy.smt2Symbol
 
 declareConst :: Config -> [F.SymConst] -> Context -> IO ()
-declareConst cfg cs me | C.stringTheory cfg
+declareConst cfg _ _ | C.stringTheory cfg
   = return () 
 declareConst _ cs me
   = smtDistinct me (F.eVar <$> cs) 

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE PatternGuards         #-}
 
 -- | This module has the functions that perform sort-checking, and related
 -- operations on Fixpoint expressions and predicates.
@@ -689,6 +690,9 @@ unify1 f θ FInt t = do
   checkNumeric f t `withError` (errUnify FInt t)
   return θ
 
+unify1 _ θ t1 t2 | isString t1, isString t2
+  = return θ
+
 unify1 f θ (FFunc t1 t2) (FFunc t1' t2') = do
   unifyMany f θ [t1, t2] [t1', t2']
 
@@ -791,8 +795,7 @@ errElabExpr    :: Expr -> String
 errElabExpr e  = printf "Elaborate fails on %s" (showpp e)
 
 errUnify :: Sort -> Sort -> String
-errUnify t1 t2       = printf "Cannot unify %s with %s" (showpp t1) (showpp t2)
-
+errUnify t1 t2       = printf "Cannot unify %s with %s" (showpp t1) (showpp t2) 
 
 errUnifyMany :: [Sort] -> [Sort] -> String
 errUnifyMany ts ts'  = printf "Cannot unify types with different cardinalities %s and %s"

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -700,7 +700,7 @@ unify1 f e θ FInt t = do
   checkNumeric f t `withError` (errUnify e FInt t)
   return θ
 
-unify1 _ θ t1 t2 | isString t1, isString t2
+unify1 _ _ θ t1 t2 | isString t1, isString t2
   = return θ
 
 unify1 f e θ (FFunc t1 t2) (FFunc t1' t2') = do

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -56,10 +56,9 @@ data Config
     , extensionality :: Bool             -- ^ allow function extensionality
     , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
     , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
-    , normalForm  :: Bool                -- ^ allow lambda normal-form equivalence axioms
-    , autoKuts    :: Bool                -- ^ ignore given kut variables
-    -- , pack        :: Bool                -- ^ Use pack annotations
-    , nonLinCuts  :: Bool                -- ^ Treat non-linear vars as cuts
+    , normalForm       :: Bool           -- ^ allow lambda normal-form equivalence axioms
+    , autoKuts         :: Bool           -- ^ ignore given kut variables
+    , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
     , stringTheory     :: Bool           -- ^ Strings are interpreted by SMT 
     } deriving (Eq,Data,Typeable,Show)
 

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -60,6 +60,7 @@ data Config
     , autoKuts    :: Bool                -- ^ ignore given kut variables
     -- , pack        :: Bool                -- ^ Use pack annotations
     , nonLinCuts  :: Bool                -- ^ Treat non-linear vars as cuts
+    , stringTheory     :: Bool           -- ^ Strings are interpreted by SMT 
     } deriving (Eq,Data,Typeable,Show)
 
 instance Default Config where
@@ -111,6 +112,7 @@ defConfig = Config {
   , autoKuts       = False &= help "Ignore given Kut vars, compute from scratch"
   -- , pack           = False &= help "Use pack annotations"
   , nonLinCuts     = False &= help "Treat non-linear kvars as cuts"
+  , stringTheory   = False &= help "Use SAT solver string interpretation"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -412,6 +412,7 @@ fi :: [SubC a]
    -> BindEnv
    -> SEnv Sort
    -> SEnv Sort
+   -> [SymConst]
    -> Kuts
    -> [Qualifier]
    -> M.HashMap BindId a
@@ -419,12 +420,13 @@ fi :: [SubC a]
    -> Bool
    -> Bool
    -> GInfo SubC a
-fi cs ws binds ls ds ks qs bi fn aHO aHOq
+fi cs ws binds ls ds ss ks qs bi fn aHO aHOq
   = FI { cm       = M.fromList $ addIds cs
        , ws       = M.fromListWith err [(k, w) | w <- ws, let (_, _, k) = wrft w]
        , bs       = binds
        , gLits    = ls
        , dLits    = ds
+       , symconst = ss 
        , kuts     = ks
        , quals    = qs
        , bindInfo = bi
@@ -457,6 +459,7 @@ data GInfo c a =
      , bs       :: !BindEnv                   -- ^ Bind  |-> (Symbol, SortedReft)
      , gLits    :: !(SEnv Sort)               -- ^ Global Constant symbols
      , dLits    :: !(SEnv Sort)               -- ^ Distinct Constant symbols
+     , symconst :: ![SymConst]                -- ^ Symbols unsed in the logic 
      , kuts     :: !Kuts                      -- ^ Set of KVars *not* to eliminate
   --    , packs    :: !Packs                     -- ^ Pack-sets of related KVars
      , quals    :: ![Qualifier]               -- ^ Abstract domain
@@ -473,12 +476,13 @@ instance Monoid HOInfo where
                       }
 
 instance Monoid (GInfo c a) where
-  mempty        = FI M.empty mempty mempty mempty mempty mempty mempty mempty mempty mempty
+  mempty        = FI M.empty mempty mempty mempty mempty mempty mempty mempty mempty mempty mempty
   mappend i1 i2 = FI { cm       = mappend (cm i1)       (cm i2)
                      , ws       = mappend (ws i1)       (ws i2)
                      , bs       = mappend (bs i1)       (bs i2)
                      , gLits    = mappend (gLits i1)    (gLits i2)
                      , dLits    = mappend (dLits i1)    (dLits i2)
+                     , symconst = mappend (symconst i1) (symconst i2)
                      , kuts     = mappend (kuts i1)     (kuts i2)
                      -- , packs    = mappend (packs i1)    (packs i2)
                      , quals    = mappend (quals i1)    (quals i2)

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -96,8 +96,8 @@ module Language.Fixpoint.Types.Names (
   , divFuncName
 
   -- * Casting function names
-  , setToIntName, bitVecToIntName, mapToIntName, boolToIntName, realToIntName
-  , setApplyName, bitVecApplyName, mapApplyName, boolApplyName, realApplyName, intApplyName
+  , setToIntName, bitVecToIntName, mapToIntName, boolToIntName, strToIntName, realToIntName
+  , setApplyName, bitVecApplyName, mapApplyName, boolApplyName, strApplyName, realApplyName, intApplyName
 
   , lambdaName
   , intArgName
@@ -473,19 +473,21 @@ lambdaName = "smt_lambda"
 intArgName :: Int -> Symbol
 intArgName = intSymbol "lam_int_arg"
 
-setToIntName, bitVecToIntName, mapToIntName, boolToIntName , realToIntName:: Symbol
+setToIntName, bitVecToIntName, mapToIntName, boolToIntName, strToIntName, realToIntName:: Symbol
 setToIntName    = "set_to_int"
 bitVecToIntName = "bitvec_to_int"
 mapToIntName    = "map_to_int"
 boolToIntName   = "bool_to_int"
+strToIntName    = "str_to_int"
 realToIntName   = "real_to_int"
 
 
-setApplyName, bitVecApplyName, mapApplyName, boolApplyName, realApplyName, intApplyName :: Int -> Symbol
+setApplyName, bitVecApplyName, mapApplyName, boolApplyName, strApplyName, realApplyName, intApplyName :: Int -> Symbol
 setApplyName    = intSymbol "set_apply_"
 bitVecApplyName = intSymbol "bitvec_apply"
 mapApplyName    = intSymbol "map_apply_"
 boolApplyName   = intSymbol "bool_apply_"
+strApplyName    = intSymbol "str_apply_"
 realApplyName   = intSymbol "real_apply_"
 intApplyName    = intSymbol "int_apply_"
 

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -88,6 +88,7 @@ module Language.Fixpoint.Types.Refinements (
 
   , symbolSymConst
   , isSymbolSymConst
+  , symConstLenEquality
   ) where
 
 import qualified Data.Binary as B
@@ -322,6 +323,9 @@ symbolSymConst = fromJust . decodeSymConst
 
 isSymbolSymConst :: (Symbol, Sort) -> Bool 
 isSymbolSymConst (x, t) = isString t && isJust (decodeSymConst x)
+
+symConstLenEquality :: Expr -> SymConst -> Expr 
+symConstLenEquality f e@(SL t) = PAtom Eq (EApp f $ ESym e) (ECon $ I (toEnum $ T.length t))
 
 instance Fixpoint SymConst where
   toFix  = toFix . encodeSymConst

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -83,6 +83,11 @@ module Language.Fixpoint.Types.Refinements (
   , pprintReft
 
   , debruijnIndex
+
+  -- * Symbol Constants
+
+  , symbolSymConst
+  , isSymbolSymConst
   ) where
 
 import qualified Data.Binary as B
@@ -95,7 +100,7 @@ import           Data.String
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
 import           Control.DeepSeq
-import           Data.Maybe                (isJust)
+import           Data.Maybe                (isJust, fromJust)
 -- import           Text.Printf               (printf)
 -- import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.Names
@@ -191,7 +196,10 @@ type KVSub       = (KVar, Subst)
 -- | Expressions ---------------------------------------------------------------
 --------------------------------------------------------------------------------
 
--- | Uninterpreted constants that are embedded as  "constant symbol : Str"
+-- | SymConstant: If Config.stringTheory flag is set, 
+-- | SymConsts are interpreted as String by Z3, 
+-- | otherwise, they are uninterpreted constants embedded as  
+-- | "constant symbol : String"
 
 data SymConst = SL !Text
               deriving (Eq, Ord, Show, Data, Typeable, Generic)
@@ -307,6 +315,13 @@ encodeSymConst (SL s) = litSymbol $ symbol s
 
 decodeSymConst :: Symbol -> Maybe SymConst
 decodeSymConst = fmap (SL . symbolText) . unLitSymbol
+
+
+symbolSymConst :: Symbol -> SymConst
+symbolSymConst = fromJust . decodeSymConst 
+
+isSymbolSymConst :: (Symbol, Sort) -> Bool 
+isSymbolSymConst (x, t) = isString t && isJust (decodeSymConst x)
 
 instance Fixpoint SymConst where
   toFix  = toFix . encodeSymConst

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -24,9 +24,9 @@ module Language.Fixpoint.Types.Sorts (
   , Sub (..)
   , FTycon, TCEmb
   , sortFTycon
-  , intFTyCon, boolFTyCon, realFTyCon, numFTyCon  -- TODO: hide these
+  , intFTyCon, boolFTyCon, realFTyCon, numFTyCon, charFTyCon  -- TODO: hide these
 
-  , intSort, realSort, boolSort, strSort, funcSort
+  , intSort, realSort, boolSort, strSort, funcSort, charSort
   , setSort, bitVecSort, mapSort
   , listFTyCon
   , isListTC
@@ -40,7 +40,7 @@ module Language.Fixpoint.Types.Sorts (
   , mkFFunc
   , bkFFunc
 
-  , isNumeric, isReal
+  , isNumeric, isReal, isString 
   ) where
 
 import qualified Data.Binary as B
@@ -66,32 +66,35 @@ type TCEmb a  = M.HashMap a FTycon
 
 
 instance Eq FTycon where
-  (TC s _) == (TC s' _) = s == s'
+  (TC s _) == (TC s' _) = val s == val s'
 
-data TCInfo = TCInfo { tc_isNum :: Bool, tc_isReal :: Bool }
+data TCInfo = TCInfo { tc_isNum :: Bool, tc_isReal :: Bool, tc_isString :: Bool }
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
 mappendFTC :: FTycon -> FTycon -> FTycon
 mappendFTC (TC x i1) (TC _ i2) = TC x (mappend i1 i2) 
 
 instance Monoid TCInfo where
-  mempty                                   = TCInfo False False
-  mappend (TCInfo i1 i2)  (TCInfo i1' i2') = TCInfo (i1 || i1') (i2 || i2')
+  mempty                                          = TCInfo False False False 
+  mappend (TCInfo i1 i2 i3)  (TCInfo i1' i2' i3') = TCInfo (i1 || i1') (i2 || i2') (i3 || i3')
 
-defTcInfo  = TCInfo defNumInfo defRealInfo 
-numTcInfo  = TCInfo True       defRealInfo 
-realTcInfo = TCInfo True       True 
+defTcInfo  = TCInfo defNumInfo defRealInfo defStringInfo 
+numTcInfo  = TCInfo True       defRealInfo defStringInfo 
+realTcInfo = TCInfo True       True        defStringInfo
+strTcInfo  = TCInfo defNumInfo defRealInfo True  
 
-defNumInfo  = False 
-defRealInfo = False 
+defNumInfo    = False 
+defRealInfo   = False 
+defStringInfo = False 
 
 intFTyCon, boolFTyCon, realFTyCon, funcFTyCon, numFTyCon, strFTyCon, listFTyCon :: FTycon
 intFTyCon  = TC (dummyLoc "int"      ) numTcInfo
 boolFTyCon = TC (dummyLoc "bool"     ) defTcInfo
 realFTyCon = TC (dummyLoc "real"     ) realTcInfo
 numFTyCon  = TC (dummyLoc "num"      ) numTcInfo
+charFTyCon = TC (dummyLoc "Char"     ) defTcInfo
 funcFTyCon = TC (dummyLoc "function" ) defTcInfo
-strFTyCon  = TC (dummyLoc strConName ) defTcInfo
+strFTyCon  = TC (dummyLoc strConName ) strTcInfo
 listFTyCon = TC (dummyLoc listConName) defTcInfo
 
 isListConName :: LocSymbol -> Bool
@@ -186,6 +189,21 @@ isReal (FTC (TC _ i)) = tc_isReal i
 isReal (FAbs _ s)     = isReal s 
 isReal _              = False 
 
+
+isString :: Sort -> Bool 
+isString (FApp l c)     = (isList l && isChar c) || isString l  
+isString (FTC (TC _ i)) = tc_isString i 
+isString (FAbs _ s)     = isString s 
+isString s              = False 
+
+isList :: Sort -> Bool
+isList (FTC c) = isListTC c
+isList s       = False 
+
+isChar :: Sort -> Bool 
+isChar (FTC c) = c == charFTyCon
+isChar s       = False
+
 {-@ FFunc :: Nat -> ListNE Sort -> Sort @-}
 
 mkFFunc :: Int -> [Sort] -> Sort
@@ -263,6 +281,7 @@ strSort  = fTyconSort strFTyCon
 intSort  = fTyconSort intFTyCon
 realSort = fTyconSort realFTyCon
 funcSort = fTyconSort funcFTyCon
+charSort = fTyconSort charFTyCon
 
 setSort :: Sort -> Sort
 setSort    = FApp (FTC $ symbolFTycon' "Set_Set")

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -24,7 +24,7 @@ module Language.Fixpoint.Types.Sorts (
   , Sub (..)
   , FTycon, TCEmb
   , sortFTycon
-  , intFTyCon, boolFTyCon, realFTyCon, numFTyCon, charFTyCon  -- TODO: hide these
+  , intFTyCon, boolFTyCon, realFTyCon, numFTyCon, charFTyCon, strFTyCon -- TODO: hide these
 
   , intSort, realSort, boolSort, strSort, funcSort, charSort
   , setSort, bitVecSort, mapSort
@@ -192,17 +192,17 @@ isReal _              = False
 
 isString :: Sort -> Bool 
 isString (FApp l c)     = (isList l && isChar c) || isString l  
-isString (FTC (TC _ i)) = tc_isString i 
+isString (FTC (TC _ i)) = tc_isString i  
 isString (FAbs _ s)     = isString s 
-isString s              = False 
+isString _              = False 
 
 isList :: Sort -> Bool
-isList (FTC c) = isListTC c
-isList s       = False 
+isList (FTC c) = isListTC c 
+isList _       = False 
 
 isChar :: Sort -> Bool 
 isChar (FTC c) = c == charFTyCon
-isChar s       = False
+isChar _       = False
 
 {-@ FFunc :: Nat -> ListNE Sort -> Sort @-}
 


### PR DESCRIPTION
`--stringtheory` flag enables interpretation of string constants by z3 (with interpreted functions `str.len` and `str.substr`). 

NOTE: this requires the `Z3` installed from their github repo: current released versions do not support string interpretations. 