### PR TITLE
removed all trailing whitespace

### DIFF
--- a/src/Language/Fixpoint/Defunctionalize/Defunctionalize.hs
+++ b/src/Language/Fixpoint/Defunctionalize/Defunctionalize.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE PatternGuards        #-}
 {-# LANGUAGE OverloadedStrings    #-}
 
--- Defunctionalization of higher order logic 
+-- Defunctionalization of higher order logic
 
 module Language.Fixpoint.Defunctionalize.Defunctionalize (defunctionalize) where
 
@@ -14,8 +14,8 @@ import           Language.Fixpoint.Misc            (secondM, errorstar, mapSnd)
 import           Language.Fixpoint.Solver.Validate (symbolSorts)
 import           Language.Fixpoint.Types        hiding (allowHO)
 import           Language.Fixpoint.Types.Config hiding (eliminate)
-import           Language.Fixpoint.SortCheck       
-import           Language.Fixpoint.Types.Visitor   (mapExpr, mapMExpr) 
+import           Language.Fixpoint.SortCheck
+import           Language.Fixpoint.Types.Visitor   (mapExpr, mapMExpr)
 
 import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Control.Monad.State
@@ -25,72 +25,72 @@ import qualified Data.List           as L
 
 import qualified Data.Text                 as T
 
-defunctionalize :: (Fixpoint a) => Config -> SInfo a -> SInfo a 
+defunctionalize :: (Fixpoint a) => Config -> SInfo a -> SInfo a
 defunctionalize cfg si = evalState (defunc si) (makeInitDFState cfg si)
 
 
 class Defunc a where
-  defunc :: a -> DF a 
+  defunc :: a -> DF a
 
 -------------------------------------------------------------------------------
 --------  Sort defunctionalization --------------------------------------------
 -------------------------------------------------------------------------------
 
 instance Defunc Sort where
-  defunc s = defuncSort s 
+  defunc s = defuncSort s
 
-defuncSort s = do   
+defuncSort s = do
   hoFlag <- dfHO <$> get
-  return $ if hoFlag then go s else s 
+  return $ if hoFlag then go s else s
   where
     go s | isString s = strSort
-    go (FAbs i s)    = FAbs i $ go s 
+    go (FAbs i s)    = FAbs i $ go s
     go (FFunc s1 s2) = funSort (go s1) (go s2)
-    go (FApp s1 s2)  = FApp    (go s1) (go s2)  
-    go s             = s 
+    go (FApp s1 s2)  = FApp    (go s1) (go s2)
+    go s             = s
 
-funSort :: Sort -> Sort -> Sort 
-funSort s1 s2 = FApp (FApp funcSort s1) s2 
+funSort :: Sort -> Sort -> Sort
+funSort s1 s2 = FApp (FApp funcSort s1) s2
 
 -------------------------------------------------------------------------------
 --------  Expressions defunctionalization -------------------------------------
 -------------------------------------------------------------------------------
 
 instance Defunc Expr where
-  defunc = txExpr True  
+  defunc = txExpr True
 
 
 
 txCastedExpr :: Expr -> DF Expr
 txCastedExpr = txExpr False
 
-txExpr :: Bool -> Expr -> DF Expr 
-txExpr b e = do env    <- dfenv <$> get 
+txExpr :: Bool -> Expr -> DF Expr
+txExpr b e = do env    <- dfenv <$> get
                 hoFlag <- dfHO  <$> get
-                exFlag <- f_ext <$> get  
-                stFlag <- dfStr <$> get 
-                tx stFlag hoFlag exFlag $ if b then elaborate env e else e 
-   where 
+                exFlag <- f_ext <$> get
+                stFlag <- dfStr <$> get
+                tx stFlag hoFlag exFlag $ if b then elaborate env e else e
+   where
      tx stFlag hoFlag exFlag e
        | exFlag && hoFlag
        = (txExtensionality . txnumOverloading <$> (txStr stFlag $ e)) >>= defuncExpr
-       | hoFlag 
+       | hoFlag
        = (txnumOverloading <$> (txStr stFlag $ e)) >>= defuncExpr
-       | otherwise 
+       | otherwise
        = txnumOverloading <$> (txStr stFlag $ e)
 
 
 defuncExpr :: Expr -> DF Expr
-defuncExpr e = writeLog ("DEFUNC EXPR " ++ showpp (eliminate e)) >> go Nothing e 
+defuncExpr e = writeLog ("DEFUNC EXPR " ++ showpp (eliminate e)) >> go Nothing e
   where
     go _ e@(ESym _)       = return e
     go _ e@(ECon _)       = return e
     go _ e@(EVar _)       = return e
-    go _ e@(PKVar _ _)    = return e 
-    go s e@(EApp e1 e2)   = logRedex e >> defuncEApp s e1 e2 
+    go _ e@(PKVar _ _)    = return e
+    go s e@(EApp e1 e2)   = logRedex e >> defuncEApp s e1 e2
     go s (ENeg e)         = ENeg <$> go s e
     go _ (EBin o e1 e2)   = EBin o <$> go Nothing e1 <*> go Nothing e2
-    go s (EIte e1 e2 e3)  = EIte <$> go (Just boolSort) e1 <*> go s e2 <*> go s e3 
+    go s (EIte e1 e2 e3)  = EIte <$> go (Just boolSort) e1 <*> go s e2 <*> go s e3
     go _ (ECst e t)       = (`ECst` t) <$> go (Just t) e
     go _ (PTrue)          = return PTrue
     go _ (PFalse)         = return PFalse
@@ -107,24 +107,24 @@ defuncExpr e = writeLog ("DEFUNC EXPR " ++ showpp (eliminate e)) >> go Nothing e
     go _ (PAll   bs p)    = do bs' <- mapM defunc bs
                                p'  <- withExtendedEnv bs $ go (Just boolSort) p
                                return $ PAll bs' p'
-    go _ (PAtom r e1 e2)  = PAtom r <$> go Nothing e1 <*> go Nothing e2 
+    go _ (PAtom r e1 e2)  = PAtom r <$> go Nothing e1 <*> go Nothing e2
     go _ PGrad            = return PGrad
     go _ (ELam x ex)      = (df_lam <$> get) >>= defuncELam x ex
     go _ e                = errorstar ("defunc Pred: " ++ show e)
 
 
 
-defuncELam :: (Symbol, Sort) -> Expr -> Bool -> DF Expr 
-defuncELam (x, s) e aeq | aeq 
+defuncELam :: (Symbol, Sort) -> Expr -> Bool -> DF Expr
+defuncELam (x, s) e aeq | aeq
   = do y  <- freshSym
        de <- defuncExpr $ subst1 e (x, EVar y)
-       logLam (y, s) (subst1 e (x, EVar y))  
+       logLam (y, s) (subst1 e (x, EVar y))
        return $ normalizeLams $ ELam (y, s) de
-defuncELam xs e _ 
-  = ELam xs <$> defuncExpr e 
+defuncELam xs e _
+  = ELam xs <$> defuncExpr e
 
 
-maxLamArg :: Int 
+maxLamArg :: Int
 maxLamArg = 7
 
 -- NIKI TODO: allow non integer lambda arguments
@@ -134,44 +134,44 @@ makeLamArg _ i = intArgName i
 
 
 defuncEApp :: Maybe Sort -> Expr -> Expr -> DF Expr
-defuncEApp ms e1 e2 
-  | Thy.isSmt2App (eliminate f) es 
-  = eApps f <$> mapM defuncExpr es 
+defuncEApp ms e1 e2
+  | Thy.isSmt2App (eliminate f) es
+  = eApps f <$> mapM defuncExpr es
   | otherwise
   = makeApplication ms <$> (dfLog <$> get) <*> defuncExpr e1 <*> defuncExpr e2
   where
-    (f, es) = splitArgs $ EApp e1 e2 
+    (f, es) = splitArgs $ EApp e1 e2
 
 
--- e1 e2 => App (App runFun e1) (toInt e2) 
+-- e1 e2 => App (App runFun e1) (toInt e2)
 makeApplication :: Maybe Sort -> String -> Expr -> Expr -> Expr
 makeApplication Nothing str e1 e2 = ECst (EApp (EApp (EVar f) e1') (toInt e2')) s
   where
-    f   = makeFunSymbol $ specify s 
-    s   = resultType str e1 e2  
-    e1' = e1 
-    e2' = e2 
+    f   = makeFunSymbol $ specify s
+    s   = resultType str e1 e2
+    e1' = e1
+    e2' = e2
 makeApplication (Just s) _ e1 e2 = ECst (EApp (EApp (EVar f) e1') (toInt e2')) s
   where
-    f   = makeFunSymbol $ specify s 
-    e1' = e1 
-    e2' = e2 
+    f   = makeFunSymbol $ specify s
+    e1' = e1
+    e2' = e2
 
-specify :: Sort -> Sort 
+specify :: Sort -> Sort
 specify (FAbs _ s) = specify s
-specify s          = s 
+specify s          = s
 
 resultType :: String -> Expr -> Expr -> Sort
-resultType str e _ = go $ exprSort e 
+resultType str e _ = go $ exprSort e
   where
-    go (FAbs i s)               = FAbs i $ go s 
+    go (FAbs i s)               = FAbs i $ go s
     go (FFunc (FFunc s1 s2) sx) = FFunc (go (FFunc s1 s2)) sx
     go (FFunc _ sx)             = sx
     go sj          = errorstar (str ++ "\nmakeFunSymbol on non Fun " ++ showpp (eliminate e, sj) ++ "\nuneliminated\n" ++ showpp e)
 
 
 makeFunSymbol :: Sort -> Symbol
-makeFunSymbol s 
+makeFunSymbol s
   | (FApp (FTC c) _)          <- s, fTyconSymbol c == "Set_Set"
   = setApplyName 1
   | (FApp (FApp (FTC c) _) _) <- s, fTyconSymbol c == "Map_t"
@@ -208,26 +208,26 @@ castWith :: Symbol -> Expr -> Expr
 castWith s = EApp (EVar s)
 
 eliminate :: Expr -> Expr
-eliminate = mapExpr go 
+eliminate = mapExpr go
   where
-    go (ECst e _) = e 
-    go e          = e 
+    go (ECst e _) = e
+    go e          = e
 
 splitArgs :: Expr -> (Expr, [Expr])
-splitArgs = go [] 
+splitArgs = go []
   where
-    go acc (EApp e1 e) = go (e:acc) e1 
-    go acc (ECst e _)  = go acc e 
+    go acc (EApp e1 e) = go (e:acc) e1
+    go acc (ECst e _)  = go acc e
     go acc e           = (e, acc)
 
 
 makeAxioms :: DF [Expr]
-makeAxioms = do 
-  alphaFlag <- a_eq <$> get 
-  betaFlag  <- b_eq <$> get 
+makeAxioms = do
+  alphaFlag <- a_eq <$> get
+  betaFlag  <- b_eq <$> get
   asyms     <- makeSymbolAxioms
   asb       <- if betaFlag  then withNoLambdaNormalization $ withNoEquivalence makeBetaAxioms   else return []
-  asa       <- if alphaFlag then withNoLambdaNormalization $ withNoEquivalence makeAlphaAxioms  else return [] 
+  asa       <- if alphaFlag then withNoLambdaNormalization $ withNoEquivalence makeAlphaAxioms  else return []
   return (asa ++ asb ++ asyms)
 
 -------------------------------------------------------------------------------
@@ -238,18 +238,18 @@ logSym :: SymConst -> DF ()
 logSym x = modify $ \s -> s{dfSyms = x:dfSyms s}
 
 makeSymbolAxioms :: DF [Expr]
-makeSymbolAxioms = ((map go . dfSyms) <$> get) >>= mapM txCastedExpr 
+makeSymbolAxioms = ((map go . dfSyms) <$> get) >>= mapM txCastedExpr
   where
     go (SL s) = EEq (makeGenStringLen $ symbolExpr $ SL s) ((expr $ T.length s) `ECst` intSort)
 
-symbolExpr :: SymConst -> Expr 
+symbolExpr :: SymConst -> Expr
 symbolExpr = EVar . symbol
 
-makeStringLen :: Expr -> Expr 
+makeStringLen :: Expr -> Expr
 makeStringLen = EApp (EVar Thy.strLen)
 
-makeGenStringLen :: Expr -> Expr 
-makeGenStringLen e 
+makeGenStringLen :: Expr -> Expr
+makeGenStringLen e
  = EApp (ECst (EVar Thy.genLen) (FFunc strSort intSort)) (ECst e strSort)
    `ECst` intSort
 
@@ -257,37 +257,37 @@ makeGenStringLen e
 --------  Alpha Equivalence  --------------------------------------------------
 -------------------------------------------------------------------------------
 
-logLam :: (Symbol, Sort) -> Expr -> DF Expr 
-logLam xs bd 
-  = do aEq <- a_eq <$> get 
+logLam :: (Symbol, Sort) -> Expr -> DF Expr
+logLam xs bd
+  = do aEq <- a_eq <$> get
        modify $ \s -> s{dfRedex = closeLams xs <$> dfRedex s}
        modify $ \s -> s{dfLams  = closeLams xs <$> dfLams s}
-       if aEq 
-         then modify $ \s -> s{dfLams = e:dfLams s} 
+       if aEq
+         then modify $ \s -> s{dfLams = e:dfLams s}
          else return ()
-       return $ normalizeLams e 
-  where 
-    e = ELam xs bd  
+       return $ normalizeLams e
+  where
+    e = ELam xs bd
     closeLams (x, s) e = if x `elem` (syms e) then PAll [(x, s)] e else e
 
 makeAlphaAxioms :: DF [Expr]
-makeAlphaAxioms = do 
-  lams <- dfLams <$> get 
+makeAlphaAxioms = do
+  lams <- dfLams <$> get
   mapM defuncExpr $ concatMap makeAlphaEq $ L.nub (normalizeLams <$> lams)
 
 
 
 makeAlphaEq :: Expr -> [Expr]
 makeAlphaEq e = go e ++ go' e
-  where 
+  where
     go ee
-      = makeEqForAll ee (normalize ee) 
+      = makeEqForAll ee (normalize ee)
     go' ee@(ELam (x, s) e)
-      = [makeEq ee ee' 
+      = [makeEq ee ee'
          | (i, ee') <- map (\j -> normalizeLamsFromTo j (ELam (x, s) e)) [1..maxLamArg-1]
-         , i <= maxLamArg ]  
-    go' _ 
-      = [] 
+         , i <= maxLamArg ]
+    go' _
+      = []
 
 
 -------------------------------------------------------------------------------
@@ -295,19 +295,19 @@ makeAlphaEq e = go e ++ go' e
 -------------------------------------------------------------------------------
 
 
--- head normal form 
+-- head normal form
 
-normalize :: Expr -> Expr 
-normalize = snd . go 
+normalize :: Expr -> Expr
+normalize = snd . go
   where
     go (ELam (y, sy) e) = let (i', e') = go e
                               y'      = makeLamArg sy i'
                           in (i'+1, ELam (y', sy) (e' `subst1` (y, EVar y')))
-    go (EApp e e2) 
-      |  (ELam (x, _) bd) <- unECst e 
-                        = let (i1, e1') = go bd 
+    go (EApp e e2)
+      |  (ELam (x, _) bd) <- unECst e
+                        = let (i1, e1') = go bd
                               (i2, e2') = go e2
-                          in (max i1 i2, e1' `subst1` (x, e2'))                      
+                          in (max i1 i2, e1' `subst1` (x, e2'))
     go (EApp e1 e2)     = let (i1, e1') = go e1
                               (i2, e2') = go e2
                           in (max i1 i2, EApp e1' e2')
@@ -315,10 +315,10 @@ normalize = snd . go
     go (PAll bs e)      = mapSnd (PAll bs)  (go e)
     go e                = (1, e)
 
-    unECst (ECst e _) = unECst e 
-    unECst e          = e 
+    unECst (ECst e _) = unECst e
+    unECst e          = e
 
--- normalize lambda arguments 
+-- normalize lambda arguments
 
 normalizeLams :: Expr -> Expr
 normalizeLams e = snd $ normalizeLamsFromTo 1 e
@@ -340,16 +340,16 @@ normalizeLamsFromTo i e = go e
 -------------------------------------------------------------------------------
 
 logRedex :: Expr -> DF ()
-logRedex e@(EApp f _) 
+logRedex e@(EApp f _)
   | (ELam _ _) <- eliminate f
-  = do bEq <- b_eq <$> get 
+  = do bEq <- b_eq <$> get
        if bEq then modify $ \s -> s{dfRedex = e:dfRedex s} else return ()
 logRedex _
   = return ()
 
 makeBetaAxioms :: DF [Expr]
-makeBetaAxioms = do 
-  red <- dfRedex <$> get 
+makeBetaAxioms = do
+  red <- dfRedex <$> get
   concat <$> mapM makeBetaEq red
 
 
@@ -360,11 +360,11 @@ makeBetaEq e = mapM defuncExpr $ makeEqForAll (normalizeLams e) (normalize e)
 makeEq :: Expr -> Expr -> Expr
 makeEq e1 e2
   | e1 == e2  = PTrue
-  | otherwise = EEq e1 e2 
+  | otherwise = EEq e1 e2
 
 
 makeEqForAll :: Expr -> Expr -> [Expr]
-makeEqForAll e1 e2 = 
+makeEqForAll e1 e2 =
   [ makeEq (closeLam su e1') (closeLam su e2') | su <- instantiate xs] -- , su2 <- instantiate xs]
   where
     (xs1, e1') = splitPAll [] e1
@@ -372,62 +372,62 @@ makeEqForAll e1 e2 =
     xs         = L.nub (xs1 ++ xs2)
 
     closeLam ((x, (y,s)):su) e = ELam (y,s) (subst1 (closeLam su e) (x, EVar y))
-    closeLam []              e = e 
+    closeLam []              e = e
 
-    splitPAll acc (PAll xs e) = splitPAll (acc ++ xs) e 
+    splitPAll acc (PAll xs e) = splitPAll (acc ++ xs) e
     splitPAll acc e           = (acc, e)
 
 instantiate :: [(Symbol, Sort)] -> [[(Symbol, (Symbol,Sort))]]
-instantiate [] = [[]] 
-instantiate xs = go [] xs 
+instantiate [] = [[]]
+instantiate xs = go [] xs
   where
-    go acc [] = acc 
+    go acc [] = acc
     go acc (x:xs) = go (combine (instOne x) acc) xs
 
     instOne (x, s) = [(x, (makeLamArg s i, s)) | i <- [1..maxLamArg]]
 
-    combine xs []  = [[x] | x <- xs] 
+    combine xs []  = [[x] | x <- xs]
     combine xs acc =  concat [(x:) <$> acc | x <- xs]
 
 -------------------------------------------------------------------------------
 --------  Numeric Overloading  ------------------------------------------------
 -------------------------------------------------------------------------------
 
-txnumOverloading :: Expr -> Expr 
-txnumOverloading = mapExpr go 
+txnumOverloading :: Expr -> Expr
+txnumOverloading = mapExpr go
   where
     go (ETimes e1 e2)
       | exprSort e1 == FReal, exprSort e2 == FReal
-      = ERTimes e1 e2  
+      = ERTimes e1 e2
     go (EDiv   e1 e2)
       | exprSort e1 == FReal, exprSort e2 == FReal
-      = ERDiv   e1 e2 
-    go e 
-      = e 
+      = ERDiv   e1 e2
+    go e
+      = e
 
-txStr :: Bool -> Expr -> DF Expr 
-txStr flag e = if flag then return $ mapExpr goStr e else mapMExpr goNoStr e 
+txStr :: Bool -> Expr -> DF Expr
+txStr flag e = if flag then return $ mapExpr goStr e else mapMExpr goNoStr e
   where
     goStr e@(EApp _ _)
-      | Just a <- isStringLen e 
+      | Just a <- isStringLen e
       = makeStringLen a
-    goStr e 
-       = e  
+    goStr e
+       = e
     goNoStr (ESym s)
-      = logSym s >> (return $ symbolExpr s) 
-    goNoStr e 
-      = return e 
+      = logSym s >> (return $ symbolExpr s)
+    goNoStr e
+      = return e
 
 
-isStringLen :: Expr -> Maybe Expr 
-isStringLen e 
-  = case eliminate e of 
-     EApp (EVar f) a | Thy.genLen == f && hasStringArg e 
-                     -> Just a 
-     _               -> Nothing 
+isStringLen :: Expr -> Maybe Expr
+isStringLen e
+  = case eliminate e of
+     EApp (EVar f) a | Thy.genLen == f && hasStringArg e
+                     -> Just a
+     _               -> Nothing
   where
-    hasStringArg (ECst e _) = hasStringArg e 
-    hasStringArg (EApp _ a) = isString $ exprSort a 
+    hasStringArg (ECst e _) = hasStringArg e
+    hasStringArg (EApp _ a) = isString $ exprSort a
     hasStringArg _          = False
 
 -------------------------------------------------------------------------------
@@ -435,15 +435,15 @@ isStringLen e
 -------------------------------------------------------------------------------
 
 txExtensionality :: Expr -> Expr
-txExtensionality = mapExpr' go 
+txExtensionality = mapExpr' go
   where
     go (EEq e1 e2)
       | FFunc _ _ <- exprSort e1, FFunc _ _ <- exprSort e2
-      = mkExFunEq e1 e2 
-    go e 
-      = e 
+      = mkExFunEq e1 e2
+    go e
+      = e
 
-mkExFunEq :: Expr -> Expr -> Expr 
+mkExFunEq :: Expr -> Expr -> Expr
 mkExFunEq e1 e2 = PAnd [PAll (zip xs ss)
                              (EEq
                                 (ECst (eApps e1' es) s)
@@ -452,29 +452,29 @@ mkExFunEq e1 e2 = PAnd [PAll (zip xs ss)
   where
     es      = zipWith (\x s -> ECst (EVar x) s) xs ss
     xs      = (\i -> symbol ("local_fun_arg" ++ show i)) <$> [1..length ss]
-    (s, ss) = splitFun [] s1 
+    (s, ss) = splitFun [] s1
     s1      = exprSort e1
 
     splitFun acc (FFunc s ss) = splitFun (s:acc) ss
     splitFun acc s            = (s, reverse acc)
 
-    e1' = ECst e1 s1 
-    e2' = ECst e2 s1 
+    e1' = ECst e1 s1
+    e2' = ECst e2 s1
 
 
 -------------------------------------------------------------------------------
 --------  Expressions sort  ---------------------------------------------------
 -------------------------------------------------------------------------------
-exprSort :: Expr -> Sort 
-exprSort (ECst _ s)      
-  = s 
-exprSort (ELam (_,sx) e) 
+exprSort :: Expr -> Sort
+exprSort (ECst _ s)
+  = s
+exprSort (ELam (_,sx) e)
   = FFunc sx $ exprSort e
 exprSort (EApp e ex) | FFunc sx s <- gen $ exprSort e
   = maybe s (`apply` s) $ unifySorts (exprSort ex) sx
   where
     gen (FAbs _ t) = gen t
-    gen t          = t  
+    gen t          = t
 exprSort e
   = errorstar ("\nexprSort on unexpected expressions" ++ show e)
 
@@ -483,115 +483,115 @@ exprSort e
 -------------------------------------------------------------------------------
 
 instance (Defunc (c a), TaggedC c a) => Defunc (GInfo c a) where
-  defunc fi = do cm'    <- defunc $ cm    fi 
-                 ws'    <- defunc $ ws    fi 
+  defunc fi = do cm'    <- defunc $ cm    fi
+                 ws'    <- defunc $ ws    fi
                  setBinds $ mconcat ((senv <$> (M.elems $ cm fi)) ++ (wenv <$> (M.elems $ ws fi)))
-                 gLits' <- defunc $ gLits fi 
-                 dLits' <- defunc $ dLits fi 
-                 bs'    <- defunc $ bs    fi 
-                 quals' <- defunc $ quals fi 
-                 axioms <- makeAxioms  
+                 gLits' <- defunc $ gLits fi
+                 dLits' <- defunc $ dLits fi
+                 bs'    <- defunc $ bs    fi
+                 quals' <- defunc $ quals fi
+                 axioms <- makeAxioms
                  return $ fi { cm      = cm'
                              , ws      = ws'
                              , gLits   = gLits'
                              , dLits   = dLits'
                              , bs      = bs'
-                             , quals   = quals' 
+                             , quals   = quals'
                              , asserts = axioms
                              }
 
 instance Defunc (SimpC a) where
-  defunc sc = do crhs' <- defunc $ _crhs sc 
+  defunc sc = do crhs' <- defunc $ _crhs sc
                  return $ sc {_crhs = crhs'}
- 
+
 instance Defunc (WfC a)   where
   defunc wf = do wrft' <- defunc $ wrft wf
                  return $ wf {wrft = wrft'}
 
 instance Defunc Qualifier where
-  defunc q = do qParams' <- defunc $ qParams q 
-                withExtendedEnv (qParams q) $ withNoEquivalence $ do 
+  defunc q = do qParams' <- defunc $ qParams q
+                withExtendedEnv (qParams q) $ withNoEquivalence $ do
                 qBody'   <- defunc $ qBody   q
                 return    $ q {qParams = qParams', qBody = qBody'}
 
 instance Defunc SortedReft where
-  defunc (RR s r) = RR <$> defunc s <*> defunc r 
+  defunc (RR s r) = RR <$> defunc s <*> defunc r
 
 instance Defunc (Symbol, SortedReft) where
-  defunc (x, (RR s (Reft (v, e)))) 
-    = (x,) <$> defunc (RR s (Reft (x, subst1 e (v, EVar x)))) 
+  defunc (x, (RR s (Reft (v, e))))
+    = (x,) <$> defunc (RR s (Reft (x, subst1 e (v, EVar x))))
 
 instance Defunc Reft where
-  defunc (Reft (x, e)) = Reft . (x,) <$> defunc e 
+  defunc (Reft (x, e)) = Reft . (x,) <$> defunc e
 
 instance Defunc (a, Sort, c) where
-  defunc (x, y, z) = (x, , z) <$> defunc y 
+  defunc (x, y, z) = (x, , z) <$> defunc y
 
 instance Defunc (a, Sort) where
-  defunc (x, y) = (x, ) <$> defunc y 
+  defunc (x, y) = (x, ) <$> defunc y
 
 instance Defunc a => Defunc (SEnv a) where
   defunc = mapMSEnv defunc
 
 instance Defunc BindEnv   where
   defunc bs = do dfbs <- dfbenv <$> get
-                 let f (i, xs) = if i `memberIBindEnv` dfbs 
-                                       then  (i,) <$> defunc xs 
+                 let f (i, xs) = if i `memberIBindEnv` dfbs
+                                       then  (i,) <$> defunc xs
                                        else  (i,) <$> matchSort xs
-                 mapWithKeyMBindEnv f bs 
+                 mapWithKeyMBindEnv f bs
    where
     -- The refinement cannot be elaborated thus defunc-ed because
-    -- the bind does not appear in any contraint, 
+    -- the bind does not appear in any contraint,
     -- thus unique binders does not perform properly
-    -- The sort should be defunc, to ensure same sort on double binders 
+    -- The sort should be defunc, to ensure same sort on double binders
     matchSort (x, RR s r) = ((x,) . (`RR` r)) <$> defunc s
 
 instance Defunc a => Defunc [a] where
   defunc = mapM defunc
 
 instance (Defunc a, Eq k, Hashable k) => Defunc (M.HashMap k a) where
-  defunc m = M.fromList <$> mapM (secondM defunc) (M.toList m) 
+  defunc m = M.fromList <$> mapM (secondM defunc) (M.toList m)
 
 type DF    = State DFST
 
 type DFEnv = SEnv Sort
 
 data DFST
-  = DFST { fresh   :: !Int 
+  = DFST { fresh   :: !Int
          , dfenv   :: !DFEnv
          , dfbenv  :: !IBindEnv
-         , df_lam  :: !Bool   -- normalize lams 
+         , df_lam  :: !Bool   -- normalize lams
          , f_ext   :: !Bool   -- enable extensionality axioms
          , a_eq    :: !Bool   -- enable alpha equivalence axioms
          , b_eq    :: !Bool   -- enable beta equivalence axioms
          , f_norm  :: !Bool   -- enable normal form axioms
          , dfHO    :: !Bool   -- allow higher order thus defunctionalize
-         , lamNorm :: !Bool 
-         , dfStr   :: !Bool   -- string interpretation 
+         , lamNorm :: !Bool
+         , dfStr   :: !Bool   -- string interpretation
          , dfLams  :: ![Expr] -- lambda expressions appearing in the expressions
          , dfRedex :: ![Expr] -- redexes appearing in the expressions
-         , dfLog   :: !String 
-         , dfSyms  :: ![SymConst] -- symbols in the refinements 
+         , dfLog   :: !String
+         , dfSyms  :: ![SymConst] -- symbols in the refinements
          }
 
 makeInitDFState :: Config -> SInfo a -> DFST
-makeInitDFState cfg si 
-  = DFST { fresh   = 0 
+makeInitDFState cfg si
+  = DFST { fresh   = 0
          , dfenv   = fromListSEnv xs
-         , dfbenv  = mempty 
-         , df_lam  = True 
+         , dfbenv  = mempty
+         , df_lam  = True
          , f_ext   = extensionality   cfg
-         , a_eq    = alphaEquivalence cfg 
-         , b_eq    = betaEquivalence  cfg 
-         , f_norm  = normalForm       cfg  
+         , a_eq    = alphaEquivalence cfg
+         , b_eq    = betaEquivalence  cfg
+         , f_norm  = normalForm       cfg
          , dfHO    = (allowHO         cfg  || defunction cfg)
-         , lamNorm = True 
-         -- INVARIANT: lambads and redexes are not defunctionalized 
-         , dfLams  = [] 
+         , lamNorm = True
+         -- INVARIANT: lambads and redexes are not defunctionalized
+         , dfLams  = []
          , dfRedex = []
-         , dfSyms  = [] 
+         , dfSyms  = []
          , dfLog   = ""
-         , dfStr   = stringTheory cfg 
+         , dfStr   = stringTheory cfg
          }
   where
     xs = symbolSorts cfg si ++ concat [ [(x,s), (y,s)] | (_, x, RR s (Reft (y, _))) <- bindEnvToList $ bs si]
@@ -613,7 +613,7 @@ withExtendedEnv bs act = do
   modify $ \s -> s{dfenv = env}
   return r
 
-withNoLambdaNormalization :: DF a -> DF a 
+withNoLambdaNormalization :: DF a -> DF a
 withNoLambdaNormalization act = do
   lamNorm <- df_lam <$> get
   modify $ \s -> s{df_lam = False}
@@ -639,27 +639,27 @@ freshSym = do
   return $ intSymbol "lambda_fun_" n
 
 
-mapExpr' :: (Expr -> Expr) -> Expr -> Expr 
-mapExpr' f e = go e 
+mapExpr' :: (Expr -> Expr) -> Expr -> Expr
+mapExpr' f e = go e
   where
-    go (ELam bs e)     = f (ELam bs (go e)) 
-    go (ECst e s)      = f (ECst (go e) s) 
+    go (ELam bs e)     = f (ELam bs (go e))
+    go (ECst e s)      = f (ECst (go e) s)
     go (EApp e1 e2)    = f (EApp (go e1) (go e2))
     go e@(ESym _)      = f e
-    go e@(ECon _)      = f e 
+    go e@(ECon _)      = f e
     go e@(EVar _)      = f e
-    go (ENeg e)        = f $ ENeg (go e) 
+    go (ENeg e)        = f $ ENeg (go e)
     go (EBin b e1 e2)  = f $ EBin b (go e1) (go e2)
     go (EIte e e1 e2)  = f $ EIte (go e) (go e1) (go e2)
-    go (ETAbs e t)     = f $ ETAbs (go e) t  
-    go (ETApp e t)     = f $ ETApp (go e) t  
-    go (PAnd es)       = f $ PAnd $ map go es 
-    go (POr es)        = f $ POr  $ map go es  
-    go (PNot e)        = f $ PNot $ go e 
+    go (ETAbs e t)     = f $ ETAbs (go e) t
+    go (ETApp e t)     = f $ ETApp (go e) t
+    go (PAnd es)       = f $ PAnd $ map go es
+    go (POr es)        = f $ POr  $ map go es
+    go (PNot e)        = f $ PNot $ go e
     go (PImp e1 e2)    = f $ PImp (go e1) (go e2)
-    go (PIff e1 e2)    = f $ PIff (go e1) (go e2) 
-    go (PAtom a e1 e2) = f $ PAtom a (go e1) (go e2) 
-    go (PAll bs e)     = f $ PAll bs   $  go e 
-    go (PExist bs e)   = f $ PExist bs $ go e 
-    go e@(PKVar _ _ )  = f e  
-    go e@PGrad         = f e  
+    go (PIff e1 e2)    = f $ PIff (go e1) (go e2)
+    go (PAtom a e1 e2) = f $ PAtom a (go e1) (go e2)
+    go (PAll bs e)     = f $ PAll bs   $  go e
+    go (PExist bs e)   = f $ PExist bs $ go e
+    go e@(PKVar _ _ )  = f e
+    go e@PGrad         = f e

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -61,10 +61,10 @@ hashMapToAscList = L.sortBy (compare `on` fst) . M.toList
 ---------------------------------------------------------------
 
 getUniqueInt :: IO Int
-getUniqueInt = do 
+getUniqueInt = do
   n1 <- hashUnique <$> newUnique
   n2 <- hashUnique <$> newUnique
-  return (n1 * n2) 
+  return (n1 * n2)
 
 ---------------------------------------------------------------
 -- | Edit Distance --------------------------------------------

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -32,7 +32,7 @@ module Language.Fixpoint.Parse (
   --   fTyConP  -- Type constructors
   , lowerIdP    -- Lower-case identifiers
   , upperIdP    -- Upper-case identifiers
-  , infixIdP    -- String Haskell infix Id 
+  , infixIdP    -- String Haskell infix Id
   , symbolP     -- Arbitrary Symbols
   , constantP   -- (Integer) Constants
   , integer     -- Integer
@@ -95,12 +95,12 @@ import           Language.Fixpoint.Smt.Types
 import           Language.Fixpoint.Types hiding    (mapSort)
 import           Text.PrettyPrint.HughesPJ         (text, nest, vcat, (<+>))
 
-import Control.Monad.State 
+import Control.Monad.State
 
 type Parser = ParsecT String Integer (State PState)
 type ParserT u a = ParsecT String u (State PState) a
 
-data PState = PState {fixityTable :: OpTable} 
+data PState = PState {fixityTable :: OpTable}
 
 
 --------------------------------------------------------------------
@@ -122,7 +122,7 @@ emptyDef    = Token.LanguageDef
                }
 
 languageDef :: Monad m => Token.GenLanguageDef String a m
-languageDef = 
+languageDef =
   emptyDef { Token.commentStart    = "/* "
            , Token.commentEnd      = " */"
            , Token.commentLine     = "//"
@@ -227,7 +227,7 @@ condIdP chars f
        blanks
        if f (c:cs) then return (symbol $ c:cs) else parserZero
 
-infixIdP :: Parser String 
+infixIdP :: Parser String
 infixIdP = many (satisfy (`notElem` [' ', '.']))
 
 upperIdP :: Parser Symbol
@@ -303,29 +303,29 @@ expr1P
 exprP :: Parser Expr
 exprP = (fixityTable <$> get) >>= (`buildExpressionParser` expr1P)
 
-data Fixity  
+data Fixity
   = FInfix   {fpred :: Maybe Int, fname :: String, fop2 :: Maybe (Expr -> Expr -> Expr), fassoc :: Assoc}
   | FPrefix  {fpred :: Maybe Int, fname :: String, fop1 :: Maybe (Expr -> Expr)}
   | FPostfix {fpred :: Maybe Int, fname :: String, fop1 :: Maybe (Expr -> Expr)}
 
 
--- Invariant : OpTable has 10 elements 
+-- Invariant : OpTable has 10 elements
 type OpTable = OperatorTable String Integer (State PState) Expr
 
 addOperatorP :: Fixity -> Parser ()
-addOperatorP op 
-  = modify $ \s -> s{fixityTable =  addOperator op (fixityTable s)} 
+addOperatorP op
+  = modify $ \s -> s{fixityTable =  addOperator op (fixityTable s)}
 
 addOperator :: Fixity -> OpTable -> OpTable
-addOperator (FInfix p x f assoc) ops 
+addOperator (FInfix p x f assoc) ops
  = insertOperator (makePrec p) (Infix (reservedOp x >> return (makeInfixFun x f)) assoc) ops
-addOperator (FPrefix p x f) ops 
+addOperator (FPrefix p x f) ops
  = insertOperator (makePrec p) (Prefix (reservedOp x >> return (makePrefixFun x f))) ops
-addOperator (FPostfix p x f) ops 
+addOperator (FPostfix p x f) ops
  = insertOperator (makePrec p) (Postfix (reservedOp x >> return (makePrefixFun x f))) ops
 
-makePrec :: Maybe Int -> Int 
-makePrec = fromMaybe 9 
+makePrec :: Maybe Int -> Int
+makePrec = fromMaybe 9
 
 makeInfixFun :: String -> Maybe (Expr -> Expr -> Expr) -> (Expr -> Expr -> Expr)
 makeInfixFun x = fromMaybe (\e1 e2 -> EApp (EApp (EVar $ symbol x) e1) e2)
@@ -334,7 +334,7 @@ makePrefixFun :: String -> Maybe (Expr -> Expr) -> (Expr -> Expr)
 makePrefixFun x = fromMaybe (\e -> EApp (EVar $ symbol x) e)
 
 insertOperator :: Int -> Operator String Integer (State PState) Expr -> OpTable -> OpTable
-insertOperator i op ops = go (9-i) ops 
+insertOperator i op ops = go (9-i) ops
   where
     go _ []       = die $ err dummySpan (text "insertOperator on empty ops")
     go 0 (xs:xss) = (xs++[op]):xss
@@ -345,7 +345,7 @@ initOpTable = take 10 (repeat [])
 
 bops :: OpTable
 bops = foldl (flip addOperator) initOpTable buildinOps
-  where 
+  where
 -- Build in Haskell ops https://www.haskell.org/onlinereport/decls.html#fixity
     buildinOps = [ FPrefix (Just 9) "-"   (Just ENeg)
                  , FInfix  (Just 7) "*"   (Just $ EBin Times) AssocLeft
@@ -353,7 +353,7 @@ bops = foldl (flip addOperator) initOpTable buildinOps
                  , FInfix  (Just 6) "-"   (Just $ EBin Minus) AssocLeft
                  , FInfix  (Just 6) "+"   (Just $ EBin Plus)  AssocLeft
                  , FInfix  (Just 5) "mod" (Just $ EBin Mod)   AssocLeft -- Haskell gives mod 7
-                 ] 
+                 ]
 
 funAppP :: Parser Expr
 funAppP            =  (try litP) <|> (try exprFunSpacesP) <|> (try exprFunSemisP) <|> exprFunCommasP <|> simpleAppP
@@ -596,7 +596,7 @@ data Def a
   | Kut !KVar
   | Pack !KVar !Int
   | IBind !Int !Symbol !SortedReft
-  | Opt !String 
+  | Opt !String
   deriving (Show, Generic)
   --  Sol of solbind
   --  Dep of FixConstraint.dep
@@ -734,7 +734,7 @@ remainderP p
        return (res, str, pos)
 
 
-initPState :: PState 
+initPState :: PState
 initPState = PState {fixityTable = bops}
 
 doParse' :: Parser a -> SourceName -> String -> a

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -114,7 +114,7 @@ checkValidWithContext :: Context -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
 checkValidWithContext me xts p q =
   smtBracket me $
     checkValid' me xts p q
-    
+
 -- | type ClosedPred E = {v:Pred | subset (vars v) (keys E) }
 -- checkValid :: e:Env -> ClosedPred e -> ClosedPred e -> IO Bool
 checkValid :: Config -> FilePath -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
@@ -270,9 +270,9 @@ makeProcess cfg
                   , cLog    = Nothing
                   , verbose = loud
                   , c_ext   = extensionality cfg
-                  , c_aeq   = alphaEquivalence cfg  
-                  , c_beq   = betaEquivalence  cfg  
-                  , c_norm  = normalForm       cfg 
+                  , c_aeq   = alphaEquivalence cfg
+                  , c_beq   = betaEquivalence  cfg
+                  , c_norm  = normalForm       cfg
                   , smtenv  = initSMTEnv
                   }
 
@@ -307,8 +307,8 @@ smtPreamble cfg s _
   = checkValidStringFlag s "" cfg >> (return $ preamble cfg s)
 
 checkValidStringFlag :: SMTSolver -> T.Text -> Config -> IO ()
-checkValidStringFlag smt v cfg 
-  = if    (stringTheory cfg) 
+checkValidStringFlag smt v cfg
+  = if    (stringTheory cfg)
        && not (smt == Z3 && (T.splitOn "." v `versionGreaterEq` ["4", "4", "2"]))
       then die $ err dummySpan (text $ "stringTheory is only supported by z3 version >=4.2.2")
       else return ()

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -66,7 +66,7 @@ instance SMTLIB2 (Symbol, Sort) where
   smt2 (sym, t) = build "({} {})" (smt2 sym, smt2 t)
 
 instance SMTLIB2 SymConst where
-  smt2 (SL s)  = build "\"{}\"" (Only s) 
+  smt2 (SL s)  = build "\"{}\"" (Only s)
 
 
 instance SMTLIB2 Constant where
@@ -114,9 +114,9 @@ instance SMTLIB2 Expr where
   smt2 (PNot p)         = build "(not {})"   (Only $ smt2  p)
   smt2 (PImp p q)       = build "(=> {} {})" (smt2 p, smt2 q)
   smt2 (PIff p q)       = build "(= {} {})"  (smt2 p, smt2 q)
-  smt2 (PExist [] p)    = smt2 p 
+  smt2 (PExist [] p)    = smt2 p
   smt2 (PExist bs p)    = build "(exists ({}) {})"  (smt2s bs, smt2 p)
-  smt2 (PAll   [] p)    = smt2 p 
+  smt2 (PAll   [] p)    = smt2 p
   smt2 (PAll   bs p)    = build "(forall ({}) {})"  (smt2s bs, smt2 p)
 
   smt2 (PAtom r e1 e2)  = mkRel r e1 e2
@@ -210,7 +210,7 @@ initSMTEnv = fromListSEnv $
   ++ [(makeLamArg s i, s) | i <- [1..maxLamArg], s <- sorts]
 
 
--- THESE ARE DUPLICATED IN DEFUNCTIONALIZATION 
+-- THESE ARE DUPLICATED IN DEFUNCTIONALIZATION
 maxLamArg :: Int
 maxLamArg = 7
 

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -21,7 +21,7 @@ module Language.Fixpoint.Smt.Theories
      , isTheorySymbol
      , theoryEnv
 
-       -- * String 
+       -- * String
      , string
      , strLen, genLen
 
@@ -30,7 +30,7 @@ module Language.Fixpoint.Smt.Theories
      , setEmpty, setEmp, setCap, setSub, setAdd, setMem
      , setCom, setCup, setDif, setSng, mapSel, mapSto
 
-      -- * Query Theories 
+      -- * Query Theories
      , isSmt2App
      ) where
 
@@ -91,7 +91,7 @@ mapSel   = "Map_select"
 mapSto   = "Map_store"
 
 
-strLen, strSubstr, genLen, strConcat :: Symbol 
+strLen, strSubstr, genLen, strConcat :: Symbol
 strLen    = "stringLen"
 strSubstr = "subString"
 strConcat = "concatString"
@@ -99,13 +99,13 @@ strConcat = "concatString"
 genLen = "len"
 
 
-strlen, strsubstr, strconcat :: Raw 
+strlen, strsubstr, strconcat :: Raw
 strlen    = "stringLen"
 strsubstr = "subString"
 strconcat = "concatString"
 
 
-z3strlen, z3strsubstr, z3strconcat :: Raw 
+z3strlen, z3strsubstr, z3strconcat :: Raw
 z3strlen    = "str.len"
 z3strsubstr = "str.substr"
 z3strconcat = "str.++"
@@ -116,11 +116,11 @@ substrSort    = mkFFunc 0 [strSort, intSort, intSort, strSort]
 concatstrSort = mkFFunc 0 [strSort, strSort, strSort]
 
 string :: Raw
-string = "Str" 
+string = "Str"
 
 z3Preamble :: Config -> [T.Text]
 z3Preamble u
-  = stringPrealble u ++ 
+  = stringPrealble u ++
     [ format "(define-sort {} () Int)"
         (Only elt)
     , format "(define-sort {} () (Array {} Bool))"
@@ -197,7 +197,7 @@ smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
     , format "(declare-fun {} ({} {}) {})"    (sel, map, elt, elt)
     , format "(declare-fun {} ({} {} {}) {})" (sto, map, elt, elt, map)
     , format "(declare-fun {} ({} {} {}) {})" (sto, map, elt, elt, map)
-    ] 
+    ]
 
 
 stringPrealble :: Config -> [T.Text]
@@ -210,8 +210,8 @@ stringPrealble cfg | stringTheory cfg
         (strsubstr, string, string, z3strsubstr)
     , format "(define-fun {} ((x {}) (y {})) {} ({} x y))"
         (strconcat, string, string, string, z3strconcat)
-    ] 
-stringPrealble _ 
+    ]
+stringPrealble _
   = [
       format "(define-sort {} () Int)" (Only string)
     , format "(declare-fun {} ({}) Int)"
@@ -311,7 +311,7 @@ smt2Sort (FApp (FApp (FTC c) _) _)
 smt2Sort (FApp (FTC bv) (FTC s))
   | isBv bv
   , Just n <- sizeBv s          = Just $ build "(_ BitVec {})" (Only n)
-smt2Sort s 
+smt2Sort s
   | isString s                  = Just $ build "{}" (Only string)
 smt2Sort _                      = Nothing
 
@@ -325,14 +325,14 @@ smt2App (EVar f) (d:ds)
   = Just $ build "({} {})" (tsRaw s, d <> mconcat [ " " <> d | d <- ds])
 smt2App _ _           = Nothing
 
-isSmt2App :: Expr -> [a] -> Bool 
+isSmt2App :: Expr -> [a] -> Bool
 isSmt2App (EVar f) [_]
-  | f == setEmpty = True 
-  | f == setEmp   = True 
-  | f == setSng   = True 
+  | f == setEmpty = True
+  | f == setEmp   = True
+  | f == setSng   = True
 isSmt2App (EVar f) _
   =  isJust $ M.lookup f theorySymbols
-isSmt2App _ _ 
+isSmt2App _ _
   = False
 
 

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -20,7 +20,7 @@ module Language.Fixpoint.Smt.Types (
     -- * Typeclass for SMTLIB2 conversion
     , SMTLIB2 (..)
     , runSmt2
-    
+
     -- * SMTLIB2 Process Context
     , Context (..)
 
@@ -93,4 +93,4 @@ class SMTLIB2 a where
   smt2 :: a -> LT.Builder
 
 runSmt2 :: (SMTLIB2 a) => a -> LT.Builder
-runSmt2 = smt2 
+runSmt2 = smt2

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -230,8 +230,8 @@ declare xts' ess p = withContext $ \me -> do
     isThy   = isJust . Thy.smt2Symbol
 
 assumes :: [F.Expr] -> SolveM ()
-assumes es = withContext $ \me -> 
-  forM_  es $ smtAssert me 
+assumes es = withContext $ \me ->
+  forM_  es $ smtAssert me
 
 declareInitEnv :: SolveM ()
 declareInitEnv

--- a/src/Language/Fixpoint/Solver/Validate.hs
+++ b/src/Language/Fixpoint/Solver/Validate.hs
@@ -140,7 +140,7 @@ banConstraintFreeVars fi0 = Misc.applyNonNull (Right fi0) (Left . badCs) bads
     bads = [(c, fs) | c <- M.elems $ F.cm fi, Just fs <- [cNoFreeVars fi c]]
 
 cNoFreeVars :: F.SInfo a -> F.SimpC a -> Maybe [F.Symbol]
-cNoFreeVars fi c = if S.null fv then Nothing else Just (S.toList fv)  
+cNoFreeVars fi c = if S.null fv then Nothing else Just (S.toList fv)
   where
     be   = F.bs fi
     lits = fst <$> F.toListSEnv (F.gLits fi)

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -674,8 +674,8 @@ unify1 f e θ t1@(FAbs _ _) t2 = do
 unify1 f e θ t1 t2@(FAbs _ _) = do
   t2' <- generalize t2
   unifyMany f e θ [t1] [t2']
-unify1 _ _ θ s1 s2 
-  | isString s1, isString s2 
+unify1 _ _ θ s1 s2
+  | isString s1, isString s2
   = return θ
 
 unify1 _ _ θ FInt  FReal = return θ

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -28,7 +28,7 @@ import Language.Fixpoint.Utils.Files
 
 withPragmas :: Config -> [String] -> IO Config
 ---------------------------------------------------------------------------------------
-withPragmas cfg ps = foldM withPragma cfg ps 
+withPragmas cfg ps = foldM withPragma cfg ps
 
 withPragma :: Config -> String -> IO Config
 withPragma c s = withArgs [s] $ cmdArgsRun
@@ -52,7 +52,7 @@ data Config
     , maxPartSize :: Int                 -- ^ Maximum size of a partition. Overrides minPartSize
     , solver      :: SMTSolver           -- ^ which SMT solver to use
     , linear      :: Bool                -- ^ not interpret div and mul in SMT
-    , stringTheory :: Bool               -- ^ interpretation of string theory by SMT 
+    , stringTheory :: Bool               -- ^ interpretation of string theory by SMT
     , defunction  :: Bool                -- ^ Allow higher order binders into fixpoint environment
     , allowHO     :: Bool                -- ^ allow higher order binders in the logic environment
     , allowHOqs   :: Bool                -- ^ allow higher order qualifiers
@@ -100,12 +100,12 @@ instance Show SMTSolver where
 defConfig :: Config
 defConfig = Config {
     srcFile     = "out"   &= args    &= typFile
-  , defunction  = False 
+  , defunction  = False
            &= help "Allow higher order binders into fixpoint environment"
   , solver      = def     &= help "Name of SMT Solver"
   , linear      = False   &= help "Use uninterpreted integer multiplication and division"
   , stringTheory = False  &= help "Interpretation of String Theory by SMT"
-  , allowHO     = False   
+  , allowHO     = False
           &= help "Allow higher order binders into fixpoint environment"
   , allowHOqs   = False   &= help "Allow higher order qualifiers"
   , eliminate   = False   &= help "Eliminate non-cut KVars"

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -17,7 +17,7 @@ module Language.Fixpoint.Types.Environments (
   -- * Environments
     SEnv, SESearch(..)
   , emptySEnv, toListSEnv, fromListSEnv, fromMapSEnv
-  , mapSEnvWithKey, mapSEnv, mapMSEnv 
+  , mapSEnvWithKey, mapSEnv, mapMSEnv
   , insertSEnv, deleteSEnv, memberSEnv, lookupSEnv, unionSEnv, unionSEnv'
   , intersectWithSEnv
   , differenceSEnv
@@ -189,7 +189,7 @@ bindEnvFromList bs = BE (1 + maxId) be
     be             = M.fromList [(n, (x, r)) | (n, x, r) <- bs]
 
 elemsBindEnv :: BindEnv -> [BindId]
-elemsBindEnv be = fst3 <$> bindEnvToList be 
+elemsBindEnv be = fst3 <$> bindEnvToList be
 
 bindEnvToList :: BindEnv -> [(BindId, Symbol, SortedReft)]
 bindEnvToList (BE _ be) = [(n, x, r) | (n, (x, r)) <- M.toList be]

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -184,7 +184,7 @@ errFreeVarInConstraint :: (PPrint a) => (Integer, a) -> Error
 errFreeVarInConstraint (i, ss) = err dummySpan $
   vcat [ "Constraint with free vars"
        , pprint i
-       , pprint ss 
+       , pprint ss
        ]
 
 errIllScopedKVar :: (PPrint k, PPrint bs) => (k, Integer, Integer, bs) -> Error

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -28,7 +28,7 @@ module Language.Fixpoint.Types.Refinements (
   , Expr (..), Pred
   , pattern PTrue, pattern PTop, pattern PFalse, pattern EBot
   , pattern ETimes, pattern ERTimes, pattern EDiv, pattern ERDiv
-  , pattern EEq 
+  , pattern EEq
   , KVar (..)
   , Subst (..)
   , KVSub
@@ -241,11 +241,11 @@ pattern PTrue  = PAnd []
 pattern PTop   = PAnd []
 pattern PFalse = POr []
 pattern EBot   = POr []
-pattern EEq e1 e2     = PAtom Eq    e1 e2 
-pattern ETimes e1 e2  = EBin Times  e1 e2 
-pattern ERTimes e1 e2 = EBin RTimes e1 e2 
-pattern EDiv e1 e2    = EBin Div    e1 e2 
-pattern ERDiv e1 e2   = EBin RDiv   e1 e2 
+pattern EEq e1 e2     = PAtom Eq    e1 e2
+pattern ETimes e1 e2  = EBin Times  e1 e2
+pattern ERTimes e1 e2 = EBin RTimes e1 e2
+pattern EDiv e1 e2    = EBin Div    e1 e2
+pattern ERDiv e1 e2   = EBin RDiv   e1 e2
 
 mkEApp :: LocSymbol -> [Expr] -> Expr
 mkEApp f = eApps (EVar $ val f)
@@ -259,30 +259,30 @@ splitEApp = go []
     go acc (EApp f e) = go (e:acc) f
     go acc e          = (e, acc)
 
-debruijnIndex :: Expr -> Int 
-debruijnIndex = go 
+debruijnIndex :: Expr -> Int
+debruijnIndex = go
   where
-    go (ELam _ e)      = 1 + go e 
-    go (ECst e _)      = go e 
+    go (ELam _ e)      = 1 + go e
+    go (ECst e _)      = go e
     go (EApp e1 e2)    = go e1 + go e2
-    go (ESym _)        = 1 
-    go (ECon _)        = 1 
-    go (EVar _)        = 1 
-    go (ENeg e)        = go e 
+    go (ESym _)        = 1
+    go (ECon _)        = 1
+    go (EVar _)        = 1
+    go (ENeg e)        = go e
     go (EBin _ e1 e2)  = go e1 + go e2
     go (EIte e e1 e2)  = go e + go e1 + go e2
-    go (ETAbs e _)     = go e 
-    go (ETApp e _)     = go e 
+    go (ETAbs e _)     = go e
+    go (ETApp e _)     = go e
     go (PAnd es)       = foldl (\n e -> n + go e) 0 es
     go (POr es)        = foldl (\n e -> n + go e) 0 es
-    go (PNot e)        = go e 
+    go (PNot e)        = go e
     go (PImp e1 e2)    = go e1 + go e2
-    go (PIff e1 e2)    = go e1 + go e2 
-    go (PAtom _ e1 e2) = go e1 + go e2 
-    go (PAll _ e)      = go e 
-    go (PExist _ e)    = go e 
-    go (PKVar _ _)     = 1 
-    go PGrad           = 1 
+    go (PIff e1 e2)    = go e1 + go e2
+    go (PAtom _ e1 e2) = go e1 + go e2
+    go (PAll _ e)      = go e
+    go (PExist _ e)    = go e
+    go (PKVar _ _)     = 1
+    go PGrad           = 1
 
 
 newtype Reft = Reft (Symbol, Expr)

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -41,7 +41,7 @@ module Language.Fixpoint.Types.Sorts (
   , mkFFunc
   , bkFFunc
 
-  , isNumeric, isReal, isString 
+  , isNumeric, isReal, isString
   ) where
 
 import qualified Data.Binary as B
@@ -83,12 +83,12 @@ defTcInfo, numTcInfo, realTcInfo, strTcInfo :: TCInfo
 defTcInfo  = TCInfo defNumInfo defRealInfo defStrInfo
 numTcInfo  = TCInfo True       defRealInfo defStrInfo
 realTcInfo = TCInfo True       True        defStrInfo
-strTcInfo  = TCInfo defNumInfo defRealInfo True 
+strTcInfo  = TCInfo defNumInfo defRealInfo True
 
 defNumInfo, defRealInfo, defStrInfo :: Bool
 defNumInfo  = False
 defRealInfo = False
-defStrInfo  = False 
+defStrInfo  = False
 
 intFTyCon, boolFTyCon, realFTyCon, funcFTyCon, numFTyCon, strFTyCon, listFTyCon :: FTycon
 intFTyCon  = TC (dummyLoc "int"      ) numTcInfo
@@ -179,14 +179,14 @@ data Sort = FInt
 
 
 isFirstOrder, isFunction :: Sort -> Bool
- 
-isFirstOrder (FFunc sx s) = not (isFunction sx) && isFirstOrder s 
-isFirstOrder (FAbs _ s)   = isFirstOrder s 
-isFirstOrder (FApp s1 s2) = (not $ isFunction s1) && (not $ isFunction s2)
-isFirstOrder _            = True 
 
-isFunction (FAbs _ s)  = isFunction s 
-isFunction (FFunc _ _) = True 
+isFirstOrder (FFunc sx s) = not (isFunction sx) && isFirstOrder s
+isFirstOrder (FAbs _ s)   = isFirstOrder s
+isFirstOrder (FApp s1 s2) = (not $ isFunction s1) && (not $ isFunction s2)
+isFirstOrder _            = True
+
+isFunction (FAbs _ s)  = isFunction s
+isFunction (FFunc _ _) = True
 isFunction _           = False
 
 isNumeric :: Sort -> Bool
@@ -204,17 +204,17 @@ isReal (FAbs _ s)     = isReal s
 isReal _              = False
 
 
-isString :: Sort -> Bool 
-isString (FApp l c)     = (isList l && isChar c) || isString l  
-isString (FTC (TC c i)) = (val c == strConName || tc_isString i)  
-isString (FAbs _ s)     = isString s 
-isString _              = False 
+isString :: Sort -> Bool
+isString (FApp l c)     = (isList l && isChar c) || isString l
+isString (FTC (TC c i)) = (val c == strConName || tc_isString i)
+isString (FAbs _ s)     = isString s
+isString _              = False
 
 isList :: Sort -> Bool
-isList (FTC c) = isListTC c 
-isList _       = False 
+isList (FTC c) = isListTC c
+isList _       = False
 
-isChar :: Sort -> Bool 
+isChar :: Sort -> Bool
 isChar (FTC c) = c == charFTyCon
 isChar _       = False
 

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -96,14 +96,14 @@ subSymbol (Just (EVar y)) _ = y
 subSymbol Nothing         x = x
 subSymbol a               b = errorstar (printf "Cannot substitute symbol %s with expression %s" (showFix b) (showFix a))
 
-substfLam :: (Symbol -> Expr) -> (Symbol, Sort) -> Expr -> Expr 
+substfLam :: (Symbol -> Expr) -> (Symbol, Sort) -> Expr -> Expr
 substfLam f s@(x, _) e =  ELam s (substf (\y -> if y == x then EVar x else f y) e)
 
 instance Subable Expr where
   syms                     = exprSymbols
   substa f                 = substf (EVar . f)
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
-  substf f (ELam x e)      = substfLam f x e 
+  substf f (ELam x e)      = substfLam f x e
   substf f (ENeg e)        = ENeg (substf f e)
   substf f (EBin op e1 e2) = EBin op (substf f e1) (substf f e2)
   substf f (EIte p e1 e2)  = EIte (substf f p) (substf f e1) (substf f e2)
@@ -143,7 +143,7 @@ instance Subable Expr where
   subst _  p               = p
 
 removeSubst :: Subst -> Symbol -> Subst
-removeSubst (Su su) x = Su $ M.delete x su 
+removeSubst (Su su) x = Su $ M.delete x su
 
 disjoint :: Subst -> [(Symbol, Sort)] -> Bool
 disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -168,7 +168,7 @@ mapKVars' f            = trans kvVis () []
       | Just p' <- f (k, su) = subst su p'
     txK _ p            = p
 
-mapExpr :: (Expr -> Expr) -> Expr -> Expr 
+mapExpr :: (Expr -> Expr) -> Expr -> Expr
 mapExpr f = trans (defaultVisitor {txExpr = const f}) () []
 
 
@@ -180,9 +180,9 @@ mapMExpr f = go
     go e@(EVar _)      = f e
     go (EApp g e)      = (EApp       <$> go g  <*> go e) >>= f
     go (ENeg e)        = (ENeg       <$> go e) >>= f
-    go (EBin o e1 e2)  = (EBin o     <$> go e1 <*> go e2) >>= f 
-    go (EIte p e1 e2)  = (EIte       <$> go p  <*> go e1 <*> go e2) >>= f 
-    go (ECst e t)      = ((`ECst` t) <$> go e) >>= f 
+    go (EBin o e1 e2)  = (EBin o     <$> go e1 <*> go e2) >>= f
+    go (EIte p e1 e2)  = (EIte       <$> go p  <*> go e1 <*> go e2) >>= f
+    go (ECst e t)      = ((`ECst` t) <$> go e) >>= f
     go (PAnd  ps)      = (PAnd       <$> (go <$$> ps)) >>= f
     go (POr  ps)       = (POr        <$> (go <$$> ps)) >>= f
     go (PNot p)        = (PNot       <$> go p) >>= f
@@ -193,7 +193,7 @@ mapMExpr f = go
     go (ELam (x,t) e)  = (ELam (x,t) <$> go e) >>= f
     go (PExist xts p)  = (PExist xts <$> go p) >>= f
     go (ETApp e s)     = ((`ETApp` s) <$> go e) >>= f
-    go (ETAbs e s)     = ((`ETAbs` s) <$> go e) >>= f 
+    go (ETAbs e s)     = ((`ETAbs` s) <$> go e) >>= f
     go p@(PKVar _ _)   = f p
     go PGrad           = f PGrad
 
@@ -225,7 +225,7 @@ lamSize t    = n
     MInt n = fold szV () mempty t
     szV    = (defaultVisitor :: Visitor MInt t) { accExpr = accum }
     accum _ (ELam _ _) = MInt 1
-    accum _ _          = MInt 0 
+    accum _ _          = MInt 0
 
 
 kvars :: Visitable t => t -> [KVar]


### PR DESCRIPTION
So we don't have to mix whitespace fixes added by git with semantic fixes in our patches (polluting our commit history)