### PR TITLE
Eliminate: None, Some, All

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -93,7 +93,6 @@ Library
                    Language.Fixpoint.Utils.Progress,
                    Language.Fixpoint.Utils.Files,
                    Language.Fixpoint.Solver.Solution,
-                   Language.Fixpoint.Solver.Index,
                    Language.Fixpoint.Solver.Worklist,
                    Language.Fixpoint.Solver.Monad,
                    Language.Fixpoint.Solver.TrivialSort,

--- a/src/Language/Fixpoint/Defunctionalize/Defunctionalize.hs
+++ b/src/Language/Fixpoint/Defunctionalize/Defunctionalize.hs
@@ -39,6 +39,7 @@ class Defunc a where
 instance Defunc Sort where
   defunc s = defuncSort s
 
+defuncSort :: Sort -> DF Sort
 defuncSort s = do
   hoFlag <- dfHO <$> get
   return $ if hoFlag then go s else s
@@ -323,7 +324,8 @@ normalize = snd . go
 normalizeLams :: Expr -> Expr
 normalizeLams e = snd $ normalizeLamsFromTo 1 e
 
-normalizeLamsFromTo i e = go e
+normalizeLamsFromTo :: Int -> Expr -> (Int, Expr)
+normalizeLamsFromTo i   = go
   where
     go (ELam (y, sy) e) = let (i', e') = go e
                               y'      = makeLamArg sy i'

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -154,6 +154,7 @@ snd3 (_,x,_) = x
 thd3 ::  (a, b, c) -> c
 thd3 (_,_,x) = x
 
+secondM :: Functor f => (b -> f c) -> (a, b) -> f (a, c)
 secondM act (x, y) = (x,) <$> act y
 
 #ifdef MIN_VERSION_located_base

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -41,7 +41,6 @@ import           Language.Fixpoint.Types
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
 import           Control.DeepSeq
 
-
 ---------------------------------------------------------------------------
 -- | Solve an .fq file ----------------------------------------------------
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -30,7 +30,7 @@ import           Language.Fixpoint.Solver.UniqifyBinds (renameAll)
 import           Language.Fixpoint.Defunctionalize.Defunctionalize (defunctionalize)
 import           Language.Fixpoint.Solver.UniqifyKVars (wfcUniqify)
 import qualified Language.Fixpoint.Solver.Solve     as Sol
-import           Language.Fixpoint.Types.Config           (queryFile, multicore, Config (..), withPragmas)
+import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files            hiding (Result)
 import           Language.Fixpoint.Misc
@@ -63,8 +63,8 @@ solveFQ cfg = do
 
 ignoreQualifiers :: Config -> FInfo a -> FInfo a
 ignoreQualifiers cfg fi
-  | ignoreQuals cfg = fi { quals = [] }
-  | otherwise       = fi
+  | eliminate cfg == All = fi { quals = [] }
+  | otherwise            = fi
 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -28,11 +28,10 @@ solverInfo cfg sI = SI sHyp sI' cD cKs
   where
     cD             = elimDeps     sI es nKs
     sI'            = cutSInfo     sI kI cKs
-    sHyp           = Sol.fromList    [] kHyps kS Nothing -- idx
+    sHyp           = Sol.fromList    [] kHyps kS
     kHyps          = nonCutHyps   sI kI nKs
     kI             = kIndex       sI
     (es, cKs, nKs) = kutVars cfg  sI
-    -- idx            = solverIndex cfg sI kHyps cD
     kS             = kvScopes     sI es
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -41,7 +41,7 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Smt.Serialize (initSMTEnv)
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Smt.Interface
-import qualified Language.Fixpoint.Solver.Index as Index
+-- import qualified Language.Fixpoint.Solver.Index as Index
 import           Language.Fixpoint.Solver.Validate
 import           Language.Fixpoint.Graph.Types (SolverInfo (..))
 -- import           Language.Fixpoint.Solver.Solution
@@ -90,7 +90,7 @@ instance F.PTable Stats where
 --------------------------------------------------------------------------------
 runSolverM :: Config -> SolverInfo b -> Int -> F.Solution -> SolveM a -> IO a
 --------------------------------------------------------------------------------
-runSolverM cfg sI _ s0 act =
+runSolverM cfg sI _ _ act =
   bracket acquire release $ \ctx -> do
     res <- runStateT act' (SS ctx be $ stats0 fi)
     smtWrite ctx "(exit)"
@@ -100,7 +100,7 @@ runSolverM cfg sI _ s0 act =
     acquire  = makeContextWithSEnv cfg file (F.fromListSEnv xts) -- env
     release  = cleanupContext
     ess      = distinctLiterals fi
-    (xts, p) = background cfg fi s0
+    (xts, p) = background cfg fi
     be       = F.SolEnv (F.bs fi) -- (getPacks cfg fi)
     file     = C.srcFile cfg
     -- env      = F.fromListSEnv (F.toListSEnv (F.lits fi) ++ binds)
@@ -114,11 +114,11 @@ runSolverM cfg sI _ s0 act =
 -- /   | C.pack cfg = F.packs fi
 -- /   | otherwise  = mempty
 
-background :: F.TaggedC c a => Config -> F.GInfo c a -> F.Solution -> ([(F.Symbol, F.Sort)], F.Pred)
-background cfg fi s0 = (bts ++ xts, p)
+background :: F.TaggedC c a => Config -> F.GInfo c a -> ([(F.Symbol, F.Sort)], F.Pred)
+background cfg fi = (bts ++ xts, p)
   where
-    xts              = symbolSorts cfg fi
-    (bts, p)         = maybe ([], F.PTrue) Index.bgPred (F.sIdx s0)
+    xts           = symbolSorts cfg fi
+    (bts, p)      = ([], F.PTrue) -- maybe ([], F.PTrue) Index.bgPred (F.sIdx s0)
 
 --------------------------------------------------------------------------------
 getBinds :: SolveM F.SolEnv

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -32,7 +32,7 @@ import           Language.Fixpoint.Types.Constraints  hiding (ws, bs)
 import           Prelude                              hiding (init, lookup)
 
 -- DEBUG
-import Text.Printf (printf)
+-- import Text.Printf (printf)
 -- import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -94,7 +94,7 @@ refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')
    where
     eqs                     = instK ho env v t qs
     eqs'                    = filter (okInst env v t) eqs
-    _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
+    -- _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
 
 --------------------------------------------------------------------------------
 instK :: Bool

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -154,8 +154,8 @@ okInst env v t eq = isNothing tc
   where
     sr            = F.RR t (F.Reft (v, p))
     p             = F.eqPred eq
-    tc            = So.checkSorted env (F.tracepp _msg sr)
-    _msg          = printf "okInst: t = %s, eq = %s" (F.showpp t) (F.showpp eq)
+    tc            = So.checkSorted env ({- F.tracepp _msg -} sr)
+    --  _msg          = printf "okInst: t = %s, eq = %s" (F.showpp t) (F.showpp eq)
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -28,7 +28,7 @@ import qualified Language.Fixpoint.Types              as F
 import           Language.Fixpoint.Types                 ((&.&))
 import qualified Language.Fixpoint.Types.Solutions    as Sol
 import           Language.Fixpoint.Types.Constraints  hiding (ws, bs)
-import qualified Language.Fixpoint.Solver.Index       as Index
+-- import qualified Language.Fixpoint.Solver.Index       as Index
 import           Prelude                              hiding (init, lookup)
 
 -- DEBUG
@@ -39,7 +39,7 @@ import Text.Printf (printf)
 -- | Update Solution -----------------------------------------------------------
 --------------------------------------------------------------------------------
 update :: Sol.Solution -> [F.KVar] -> [(F.KVar, F.EQual)] -> (Bool, Sol.Solution)
--------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 update s ks kqs = {- tracepp msg -} (or bs, s')
   where
     kqss        = groupKs ks kqs
@@ -59,7 +59,7 @@ groupKs ks kqs = M.toList $ groupBase m0 kqs
     m0         = M.fromList $ (,[]) <$> ks
 
 update1 :: Sol.Solution -> (F.KVar, Sol.QBind) -> (Bool, Sol.Solution)
-update1 s (k, qs) = (change, Sol.insert k qs s)
+update1 s (k, qs) = (change, Sol.updateK k qs s)
   where
     oldQs         = Sol.lookupQBind s k
     change        = length oldQs /= length qs
@@ -69,7 +69,7 @@ update1 s (k, qs) = (change, Sol.insert k qs s)
 --------------------------------------------------------------------------------
 init :: F.SInfo a -> S.HashSet F.KVar -> Sol.Solution
 --------------------------------------------------------------------------------
-init si ks = Sol.fromList keqs [] mempty Nothing
+init si ks = Sol.fromList keqs [] mempty
   where
     keqs   = map (refine si qs genv) ws `using` parList rdeepseq
     qs     = F.quals si
@@ -162,12 +162,7 @@ okInst env v t eq = isNothing tc
 -- | Predicate corresponding to LHS of constraint in current solution
 --------------------------------------------------------------------------------
 lhsPred :: F.SolEnv -> Sol.Solution -> F.SimpC a -> F.Expr
-lhsPred be s c = case Sol.sIdx s of
-                   Just _  -> Index.lhsPred     s c
-                   Nothing ->       lhsPred' be s c
-
-lhsPred' :: F.SolEnv -> Sol.Solution -> F.SimpC a -> F.Expr
-lhsPred' be s c = {- F.tracepp _msg $ -} fst $ apply g s bs
+lhsPred be s c = {- F.tracepp _msg $ -} fst $ apply g s bs
   where
     g          = (ci, be, bs)
     bs         = F.senv c
@@ -193,51 +188,11 @@ envConcKVars g bs = (concat pss, concat kss)
     be            = F.soeBinds (snd3 g)
 
 applyKVars :: CombinedEnv -> Sol.Solution -> [F.KVSub] -> ExprInfo
-applyKVars g s = mrExprInfos (applyKVars' g s) F.pAnd mconcat . packKVars g
+applyKVars g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
 
---   where
--- PACK applyPack :: CombinedEnv -> Sol.Solution -> [F.KVSub] -> ExprInfo
--- PACK applyPack g s kvs = applyKVars' g s kvs
--- PACK -- case packable s kvs of
--- PACK --   Nothing           -> applyKVars' g s kvs
--- PACK -- Just (p, [])      -> (p, mempty)
--- PACK -- Just (p, kcs)     -> applyPackCubes g s p kcs
--- PACK    _tr kvs kcs
--- PACK       | length kvs > 1 = trace ("PACKING" ++ F.showpp kvs) kcs
--- PACK       | otherwise      = kcs
-
--- --------------------------------------------------------------------------------
--- applyPackCubes :: CombinedEnv -> Sol.Solution -> F.Expr -> ListNE (F.KVSub, Sol.Cube) -> ExprInfo
--- --------------------------------------------------------------------------------
--- applyPackCubes g s p kcs = mrExprInfos (applyPackCube g'' s) conjF catF kcs
-  -- where
-    -- conjF                = (p &.&) . conjCube yts'' p''
-    -- catF kIs             = mconcat (kI : kIs)
-    -- yts''                = symSorts g bs''
-    -- (p'', kI)            = apply g'' s bs''
-    -- g''                  = addCEnv g bs''
-    -- bs''                 = foldr1 F.intersectionIBindEnv bs's
-    -- bs's                 = [ delCEnv bs g | bs <- Sol.cuBinds . snd <$> kcs ]
-
--- conjCube :: Binders -> F.Pred -> [(Binders, F.Pred, F.Pred)] -> F.Pred
--- conjCube yts'' p'' z     = foldr wrap inP xtSuPs
-  -- where
-    -- wrap (xts, suP) q    = F.pExist xts (suP &.& q)
-    -- xtSuPs               = [ (xts, psu) | (xts, psu, _) <- z ]
-    -- inP                  = F.pExist yts'' (F.pAnd (p'' : (thd3 <$> z)))
---
--- applyPackCube :: CombinedEnv
-              -- -> Sol.Solution
-              -- -> (F.KVSub, Sol.Cube)
-              -- -> ((Binders, F.Pred, F.Pred), KInfo)
--- applyPackCube g s kc = cubePredExc g s k su c bs'
-  -- where
-    -- ((k, su), c)     = kc
-    -- bs'              = delCEnv bs g
-    -- bs               = Sol.cuBinds c
-
-applyKVars' :: CombinedEnv -> Sol.Solution -> [F.KVSub] -> ExprInfo
-applyKVars' g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
+-- applyKVars g s  = mrExprInfos (applyKVars' g s) F.pAnd mconcat . map singleton
+-- applyKVars' :: CombinedEnv -> Sol.Solution -> [F.KVSub] -> ExprInfo
+-- applyKVars' g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
 
 applyKVar :: CombinedEnv -> Sol.Solution -> F.KVSub -> ExprInfo
 applyKVar g s (k, su) = case Sol.lookup s k of
@@ -289,7 +244,6 @@ cubePredExc g s k su c bs' = (cubeP, extendKInfo kI (Sol.cuTag c))
     (xts, psu)      = substElim g  k su
     su'             = Sol.cuSubst c
     bs              = Sol.cuBinds c
-
 
 
 -- TODO: SUPER SLOW! Decorate all substitutions with Sorts in a SINGLE pass.
@@ -371,38 +325,6 @@ symSorts (_, se, _) bs = second F.sr_sort <$> F.envCs be  bs
 
 _noKvars :: F.Expr -> Bool
 _noKvars = null . V.kvars
-
---------------------------------------------------------------------------------
-packKVars :: CombinedEnv -> [F.KVSub] -> [[F.KVSub]]
---------------------------------------------------------------------------------
-packKVars _ = map singleton
-
--- TODO: nuke PACK
--- packKVars (_, se, _)   = concatMap eF . M.toList . groupMap kF
-  -- where
-    -- sm                 = F.soePacks se
-    -- kF (k, _)          = F.getPack k sm
-    -- eF (Just _,  xs)   = [xs]
-    -- eF (Nothing, xs)   = singleton <$> xs
-
---------------------------------------------------------------------------------
--- TODO: nuke PACK
--- packable :: Sol.Solution -> [F.KVSub] -> Maybe (F.Expr, [(F.KVSub, Sol.Cube)])
--- --------------------------------------------------------------------------------
--- packable s = fmap reduceCubes . sequence . fmap (getCube s)
---
--- reduceCubes :: [Either F.Expr (F.KVSub, Sol.Cube)] -> (F.Expr, [(F.KVSub, Sol.Cube)])
--- reduceCubes zs = (F.pAnd ps, cs)
-  -- where
-    -- ps         = lefts  zs
-    -- cs         = rights zs
---
--- getCube :: Sol.Solution -> F.KVSub -> Maybe (Either F.Expr (F.KVSub, Sol.Cube))
--- getCube s (k, su) = case Sol.lookup s k of
-  -- Left []   -> Just (Left F.PFalse)
-  -- Left [c]  -> Just (Right ((k, su), c))
-  -- Right eqs -> Just (Left  (Sol.qBindPred su eqs))
-  -- _         -> Nothing
 
 --------------------------------------------------------------------------------
 -- | Information about size of formula corresponding to an "eliminated" KVar.

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -32,7 +32,7 @@ import qualified Language.Fixpoint.Solver.Index       as Index
 import           Prelude                              hiding (init, lookup)
 
 -- DEBUG
--- import Text.Printf (printf)
+import Text.Printf (printf)
 -- import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
@@ -44,7 +44,7 @@ update s ks kqs = {- tracepp msg -} (or bs, s')
   where
     kqss        = groupKs ks kqs
     (bs, s')    = folds update1 s kqss
-    -- msg         = printf "ks = %s, s = %s" (showpp ks) (showpp s)
+    -- msg      = printf "ks = %s, s = %s" (showpp ks) (showpp s)
 
 folds   :: (a -> b -> (c, a)) -> a -> [b] -> ([c], a)
 folds f b = L.foldl' step ([], b)
@@ -91,11 +91,11 @@ instConstants = F.fromListSEnv . filter notLit . F.toListSEnv . F.gLits
 
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
-refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')
+refineK ho env qs (v, t, k) = F.tracepp _msg (k, eqs')
    where
     eqs                     = instK ho env v t qs
     eqs'                    = filter (okInst env v t) eqs
-    -- _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
+    _msg                    = printf "refineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
 
 --------------------------------------------------------------------------------
 instK :: Bool
@@ -155,7 +155,8 @@ okInst env v t eq = isNothing tc
   where
     sr            = F.RR t (F.Reft (v, p))
     p             = F.eqPred eq
-    tc            = So.checkSorted env sr
+    tc            = So.checkSorted env (F.tracepp _msg sr)
+    _msg          = printf "okInst: t = %s, eq = %s" (F.showpp t) (F.showpp eq)
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -84,7 +84,6 @@ refine fi qs genv w = refineK (allowHOquals fi) env qs $ F.wrft w
     wenv            = F.sr_sort <$> F.fromListSEnv (F.envCs (F.bs fi) (F.wenv w))
 
 instConstants :: F.SInfo a -> F.SEnv F.Sort
--- instConstants fi = F.gLits fi
 instConstants = F.fromListSEnv . filter notLit . F.toListSEnv . F.gLits
   where
     notLit    = not . F.isLitSymbol . fst

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -90,7 +90,7 @@ instConstants = F.fromListSEnv . filter notLit . F.toListSEnv . F.gLits
 
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
-refineK ho env qs (v, t, k) = F.tracepp _msg (k, eqs')
+refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')
    where
     eqs                     = instK ho env v t qs
     eqs'                    = filter (okInst env v t) eqs

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -67,10 +67,10 @@ printStats fi w s = putStrLn "\n" >> ppTs [ ptable fi, ptable s, ptable w ]
 solverInfo :: Config -> F.SInfo a -> SolverInfo a
 --------------------------------------------------------------------------------
 solverInfo cfg fI
-  | eliminate cfg = E.solverInfo cfg fI
-  | otherwise     = SI mempty fI cD (siKvars fI)
+  | useElim cfg = E.solverInfo cfg fI
+  | otherwise   = SI mempty fI cD (siKvars fI)
   where
-    cD            = elimDeps fI (kvEdges fI) mempty
+    cD          = elimDeps fI (kvEdges fI) mempty
 
 siKvars :: F.SInfo a -> S.HashSet F.KVar
 siKvars = S.fromList . M.keys . F.ws

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -115,7 +115,7 @@ data Eliminate
   deriving (Eq, Data, Typeable, Generic)
 
 instance Default Eliminate where
-  def = Cuts
+  def = None
 
 instance Show Eliminate where
   show None = "none"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -26,6 +26,7 @@ module Language.Fixpoint.Types.Config (
   , queryFile
 ) where
 
+import Data.Serialize                (Serialize (..))
 import Control.Monad
 import GHC.Generics
 import System.Console.CmdArgs
@@ -110,9 +111,11 @@ instance Show SMTSolver where
 ---------------------------------------------------------------------------------------
 data Eliminate
   = None
-  | Some 
+  | Some
   | All
   deriving (Eq, Data, Typeable, Generic)
+
+instance Serialize Eliminate
 
 instance Default Eliminate where
   def = None
@@ -121,6 +124,7 @@ instance Show Eliminate where
   show None = "none"
   show Some = "some"
   show All  = "all"
+
 
 useElim :: Config -> Bool
 useElim cfg = eliminate cfg /= None

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -107,10 +107,10 @@ instance Show SMTSolver where
 --   None = use PA/Quals for ALL k-vars, i.e. no eliminate
 --   Some = use PA/Quals for CUT k-vars, i.e. eliminate non-cuts
 --   All  = eliminate ALL k-vars, solve cut-vars to TRUE
-
+---------------------------------------------------------------------------------------
 data Eliminate
   = None
-  | Cuts
+  | Some 
   | All
   deriving (Eq, Data, Typeable, Generic)
 
@@ -119,7 +119,7 @@ instance Default Eliminate where
 
 instance Show Eliminate where
   show None = "none"
-  show Cuts = "cuts"
+  show Some = "some"
   show All  = "all"
 
 useElim :: Config -> Bool

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -26,17 +26,18 @@ import System.Environment
 import Language.Fixpoint.Utils.Files
 
 
+--------------------------------------------------------------------------------
 withPragmas :: Config -> [String] -> IO Config
----------------------------------------------------------------------------------------
-withPragmas cfg ps = foldM withPragma cfg ps
+--------------------------------------------------------------------------------
+withPragmas = foldM withPragma
 
 withPragma :: Config -> String -> IO Config
 withPragma c s = withArgs [s] $ cmdArgsRun
           config { modeValue = (modeValue config) { cmdArgsValue = c } }
 
-------------------------------------------------------------------------
--- Configuration Options -----------------------------------------------
-------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- | Configuration Options -----------------------------------------------------
+--------------------------------------------------------------------------------
 
 defaultMinPartSize :: Int
 defaultMinPartSize = 500
@@ -57,7 +58,6 @@ data Config
     , allowHO     :: Bool                -- ^ allow higher order binders in the logic environment
     , allowHOqs   :: Bool                -- ^ allow higher order qualifiers
     , eliminate   :: Bool                -- ^ eliminate non-cut KVars
-    -- , oldElim     :: Bool                -- ^ use old eliminate algorithm (deprecate)
     , elimBound   :: Maybe Int           -- ^ maximum length of KVar chain to eliminate
     , elimStats   :: Bool                -- ^ print eliminate stats
     , solverStats :: Bool                -- ^ print solver stats
@@ -68,15 +68,14 @@ data Config
     , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
     , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
     , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
-    -- , nontriv     :: Bool             -- ^ simplify using non-trivial sorts
     , gradual     :: Bool                -- ^ solve "gradual" constraints
     , extensionality   :: Bool           -- ^ allow function extensionality
     , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
     , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
     , normalForm       :: Bool           -- ^ allow lambda normal-form equivalence axioms
-    , autoKuts    :: Bool                -- ^ ignore given kut variables
-    -- , pack        :: Bool                -- ^ Use pack annotations
-    , nonLinCuts  :: Bool                -- ^ Treat non-linear vars as cuts
+    , autoKuts         :: Bool           -- ^ ignore given kut variables
+    , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
+    , ignoreQuals      :: Bool           -- ^ Ignore qualifiers, solve using --eliminate ONLY.
     } deriving (Eq,Data,Typeable,Show)
 
 instance Default Config where
@@ -99,39 +98,35 @@ instance Show SMTSolver where
 
 defConfig :: Config
 defConfig = Config {
-    srcFile     = "out"   &= args    &= typFile
-  , defunction  = False
-           &= help "Allow higher order binders into fixpoint environment"
-  , solver      = def     &= help "Name of SMT Solver"
-  , linear      = False   &= help "Use uninterpreted integer multiplication and division"
-  , stringTheory = False  &= help "Interpretation of String Theory by SMT"
-  , allowHO     = False
-          &= help "Allow higher order binders into fixpoint environment"
-  , allowHOqs   = False   &= help "Allow higher order qualifiers"
-  , eliminate   = False   &= help "Eliminate non-cut KVars"
-  -- , oldElim     = True    &= help "(default) Use old eliminate algorithm"
-  , elimBound   = Nothing &= name "elimBound"
-                          &= help "(alpha) Maximum eliminate-chain depth"
-  , elimStats   = False   &= help "(alpha) Print eliminate stats"
-  , solverStats = False   &= help "Print solver stats"
-  , save        = False   &= help "Save Query as .fq and .bfq files"
-  , metadata    = False   &= help "Print meta-data associated with constraints"
-  , stats       = False   &= help "Compute constraint statistics"
-  , parts       = False   &= help "Partition constraints into indepdendent .fq files"
-  , cores       = def     &= help "(numeric) Number of threads to use"
-  , minPartSize = defaultMinPartSize &= help "(numeric) Minimum partition size when solving in parallel"
-  , maxPartSize = defaultMaxPartSize &= help "(numeric) Maximum partiton size when solving in parallel."
-  , minimize    = False &= help "Delta debug to minimize fq file (unsat with min constraints)"
-  , minimizeQs  = False &= help "Delta debug to minimize fq file (sat with min qualifiers)"
-  , minimizeKs  = False &= help "Delta debug to minimize fq file (sat with max kvars replaced by True)"
-  , gradual     = False &= help "Solve gradual-refinement typing constraints"
-  , extensionality = False &= help "Allow function extensionality axioms"
+    srcFile          = "out"   &= args    &= typFile
+  , defunction       = False   &= help "Allow higher order binders into fixpoint environment"
+  , solver           = def     &= help "Name of SMT Solver"
+  , linear           = False   &= help "Use uninterpreted integer multiplication and division"
+  , stringTheory     = False   &= help "Interpretation of String Theory by SMT"
+  , allowHO          = False   &= help "Allow higher order binders into fixpoint environment"
+  , allowHOqs        = False   &= help "Allow higher order qualifiers"
+  , eliminate        = False   &= help "Eliminate non-cut KVars"
+  , elimBound        = Nothing &= name "elimBound"  &= help "(alpha) Maximum eliminate-chain depth"
+  , elimStats        = False   &= help "(alpha) Print eliminate stats"
+  , solverStats      = False   &= help "Print solver stats"
+  , save             = False   &= help "Save Query as .fq and .bfq files"
+  , metadata         = False   &= help "Print meta-data associated with constraints"
+  , stats            = False   &= help "Compute constraint statistics"
+  , parts            = False   &= help "Partition constraints into indepdendent .fq files"
+  , cores            = def     &= help "(numeric) Number of threads to use"
+  , minPartSize      = defaultMinPartSize &= help "(numeric) Minimum partition size when solving in parallel"
+  , maxPartSize      = defaultMaxPartSize &= help "(numeric) Maximum partiton size when solving in parallel."
+  , minimize         = False &= help "Delta debug to minimize fq file (unsat with min constraints)"
+  , minimizeQs       = False &= help "Delta debug to minimize fq file (sat with min qualifiers)"
+  , minimizeKs       = False &= help "Delta debug to minimize fq file (sat with max kvars replaced by True)"
+  , gradual          = False &= help "Solve gradual-refinement typing constraints"
+  , extensionality   = False &= help "Allow function extensionality axioms"
   , alphaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
-  , betaEquivalence = False &= help "Allow lambda alpha equivalence axioms"
-  , normalForm     = False  &= help "Allow lambda normal-form equivalence axioms"
-  , autoKuts       = False &= help "Ignore given Kut vars, compute from scratch"
-  -- , pack           = False &= help "Use pack annotations"
-  , nonLinCuts     = False &= help "Treat non-linear kvars as cuts"
+  , betaEquivalence  = False &= help "Allow lambda alpha equivalence axioms"
+  , normalForm       = False  &= help "Allow lambda normal-form equivalence axioms"
+  , autoKuts         = False &= help "Ignore given Kut vars, compute from scratch"
+  , nonLinCuts       = False &= help "Treat non-linear kvars as cuts"
+  , ignoreQuals      = False &= help "Ignore given qualifiers, use eliminate to solve constraints"
   }
   &= verbosity
   &= program "fixpoint"
@@ -144,7 +139,7 @@ defConfig = Config {
              ]
 
 config :: Mode (CmdArgs Config)
-config = cmdArgsMode $ defConfig
+config = cmdArgsMode defConfig
 
 getOpts :: IO Config
 getOpts = do md <- cmdArgs defConfig

--- a/src/Language/Fixpoint/Types/Solutions.hs
+++ b/src/Language/Fixpoint/Types/Solutions.hs
@@ -132,7 +132,7 @@ qBindPred su = subst su . pAnd . fmap eqPred
 --------------------------------------------------------------------------------
 lookupQBind :: Solution -> KVar -> QBind
 --------------------------------------------------------------------------------
-lookupQBind s k = tracepp ("lookupQB: k = " ++ show k) $ M.lookupDefault [] k (sMap s)
+lookupQBind s k = {- tracepp ("lookupQB: k = " ++ show k) $ -} M.lookupDefault [] k (sMap s)
 
 --------------------------------------------------------------------------------
 lookup :: Solution -> KVar -> Either Hyp QBind

--- a/src/Language/Fixpoint/Types/Solutions.hs
+++ b/src/Language/Fixpoint/Types/Solutions.hs
@@ -17,7 +17,6 @@ module Language.Fixpoint.Types.Solutions (
   -- * Solution tables
     Solution
   , Sol
-  , sIdx
   , sScp
   , CMap
 
@@ -31,7 +30,7 @@ module Language.Fixpoint.Types.Solutions (
   , fromList
 
   -- * Update
-  , insert
+  , updateK
 
   -- * Lookup
   , lookupQBind
@@ -73,22 +72,22 @@ type QBind    = [EQual]
 --   in particular, to compute `lhsPred` for any given constraint.
 --------------------------------------------------------------------------------
 data Sol a = Sol
-  { sMap  :: !(M.HashMap KVar a)
-  , sHyp  :: !(M.HashMap KVar Hyp)
+  { sMap  :: !(M.HashMap KVar a)         -- ^ actual solution (for cut kvar)
+  , sHyp  :: !(M.HashMap KVar Hyp)       -- ^ defining cubes  (for non-cut kvar)
+  , sBot  :: !(M.HashMap KVar ())        -- ^ set of BOT (cut kvars)
   , sScp  :: !(M.HashMap KVar IBindEnv)  -- ^ set of allowed binders for kvar
-  , sIdx  :: !(Maybe Index)
   }
 
 instance Monoid (Sol a) where
-  mempty        = Sol mempty mempty mempty Nothing
+  mempty        = Sol mempty mempty mempty mempty
   mappend s1 s2 = Sol { sMap  = mappend (sMap s1) (sMap s2)
                       , sHyp  = mappend (sHyp s1) (sHyp s2)
+                      , sBot  = mappend (sBot s1) (sBot s2)
                       , sScp  = mappend (sScp s1) (sScp s2)
-                      , sIdx  = sIdx s1
                       }
 
 instance Functor Sol where
-  fmap f (Sol s m1 m2 z) = Sol (f <$> s) m1 m2 z
+  fmap f (Sol s m1 m2 x) = Sol (f <$> s) m1 m2 x
 
 instance PPrint a => PPrint (Sol a) where
   pprintTidy k = pprintTidy k . sMap
@@ -114,13 +113,15 @@ result :: Solution -> M.HashMap KVar Expr
 --------------------------------------------------------------------------------
 result s = sMap $ (pAnd . fmap eqPred) <$> s
 
-
 --------------------------------------------------------------------------------
 -- | Create a Solution ---------------------------------------------------------
 --------------------------------------------------------------------------------
-fromList :: [(KVar, a)] -> [(KVar, Hyp)] -> M.HashMap KVar IBindEnv -> Maybe Index -> Sol a
-fromList kXs kYs = Sol (M.fromList kXs) (M.fromList kYs)
-
+fromList :: [(KVar, a)] -> [(KVar, Hyp)] -> M.HashMap KVar IBindEnv -> Sol a
+fromList kXs kYs = Sol kXm kYm kBm
+  where
+    kXm          = M.fromList   kXs
+    kYm          = M.fromList   kYs
+    kBm          = const () <$> kXm
 --------------------------------------------------------------------------------
 qBindPred :: Subst -> QBind -> Pred
 --------------------------------------------------------------------------------
@@ -131,23 +132,36 @@ qBindPred su = subst su . pAnd . fmap eqPred
 --------------------------------------------------------------------------------
 lookupQBind :: Solution -> KVar -> QBind
 --------------------------------------------------------------------------------
-lookupQBind s k = M.lookupDefault [] k (sMap s)
+lookupQBind s k = tracepp ("lookupQB: k = " ++ show k) $ M.lookupDefault [] k (sMap s)
 
 --------------------------------------------------------------------------------
 lookup :: Solution -> KVar -> Either Hyp QBind
 --------------------------------------------------------------------------------
-lookup s k
-  | Just cs  <- M.lookup k (sHyp s)
-  = Left cs
-  | Just eqs <- M.lookup k (sMap s)
-  = Right eqs -- TODO: don't initialize kvars that have a hyp solution
-  | otherwise
-  = errorstar $ "solLookup: Unknown kvar " ++ show k
+lookup s k =
+  case M.lookup k (sHyp s) of
+    Just cs -> Left cs
+    Nothing -> if M.member k (sBot s)
+                then Left []
+                else case M.lookup (tracepp "AHA k is not in BOT" k) (sMap s) of
+                       Just eqs -> Right eqs
+                       Nothing  -> errorstar $ "solLookup: Unknown kvar " ++ show k
+
+-- lookup s k
+  -- | Just cs  <- M.lookup k (sHyp s)               -- non-cut variable, return its cubes
+  -- = Left cs
+  -- | M.member k (tracepp "lookup:sBot" $ sBot s)   -- cut-variable, but currently BOT
+  -- = Left []
+  -- | Just eqs <- M.lookup k (sMap s)
+  -- = Right eqs                                     -- TODO: don't initialize kvars that have a hyp solution
+  -- | otherwise
+  -- = errorstar $ "solLookup: Unknown kvar " ++ show k
 
 --------------------------------------------------------------------------------
-insert :: KVar -> a -> Sol a -> Sol a
+updateK :: KVar -> a -> Sol a -> Sol a
 --------------------------------------------------------------------------------
-insert k qs s = s { sMap = M.insert k qs (sMap s) }
+updateK k qs s = s { sMap = M.insert k qs (sMap s)
+                   , sBot = M.delete k    (sBot s)
+                   }
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -90,7 +90,7 @@ defNumInfo  = False
 defRealInfo = False
 defStrInfo  = False
 
-intFTyCon, boolFTyCon, realFTyCon, funcFTyCon, numFTyCon, strFTyCon, listFTyCon :: FTycon
+charFTyCon, intFTyCon, boolFTyCon, realFTyCon, funcFTyCon, numFTyCon, strFTyCon, listFTyCon :: FTycon
 intFTyCon  = TC (dummyLoc "int"      ) numTcInfo
 boolFTyCon = TC (dummyLoc "bool"     ) defTcInfo
 realFTyCon = TC (dummyLoc "real"     ) realTcInfo

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -76,7 +76,7 @@ nativeCmd :: TestCmd
 nativeCmd bin dir file = printf "cd %s && %s %s" dir bin file
 
 elimCmd :: TestCmd
-elimCmd bin dir file = printf "cd %s && %s --eliminate=cuts %s" dir bin file
+elimCmd bin dir file = printf "cd %s && %s --eliminate=some %s" dir bin file
 
 
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -30,7 +30,7 @@ unitTests
    ]
 
 skipNativePos :: [FilePath]
-skipNativePos = ["NonLinear-pack.fq"] 
+skipNativePos = ["NonLinear-pack.fq"]
 
 ---------------------------------------------------------------------------
 dirTests :: TestCmd -> FilePath -> [FilePath] -> ExitCode -> IO [TestTree]
@@ -76,7 +76,7 @@ nativeCmd :: TestCmd
 nativeCmd bin dir file = printf "cd %s && %s %s" dir bin file
 
 elimCmd :: TestCmd
-elimCmd bin dir file = printf "cd %s && %s --eliminate %s" dir bin file
+elimCmd bin dir file = printf "cd %s && %s --eliminate=cuts %s" dir bin file
 
 
 


### PR DESCRIPTION
matching PR for https://github.com/ucsd-progsys/liquidhaskell/pull/879

New modes for `--eliminate` which eliminates ALL variables by solving *cut* vars to `true`.

That is, `--eliminate=all` **ignores all qualifiers**.

Pros. 
+ super fast, esp. for prover benchmarks (set to default in higher order case)

Cons
- some mysteries due to extra cuts (e.g. non-linear cuts) e.g. why does `pldi17/pos/Unification.hs` need qualifiers?