### PR TITLE
Minimize solution

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,34 @@
+
+
 # TODO
+
+
+## Minimize Solutions
+
+```haskell
+minmizeSol :: Solution -> SolveM Solution
+minimizeSol = undefined
+ 
+minimizeConjuncts :: [(Pred, a)] -> [(Pred, a)]
+minimizeConjuncts ps = go ps []
+  where
+    go []     acc = acc
+    go (p:ps) acc = do b <- alreadyImplied ps acc q
+                       if b then go ps acc
+                            else go ps (p:acc)
+
+alreadyImplied ps acc q = checkValid (pAnd [ p | (p, _) <- ps ++ acc] ) q
+```
+
+
+## Beta-Equivalence
 
 * tests/pos/NormalForm.hs.fq
 
 ```haskell
 (\x y -> meraki x) == \x -> ((\z -> (\y -> meraki x)) (meraki x))
 ```
+
 
 BETA 1:
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,25 +2,6 @@
 
 # TODO
 
-
-## Minimize Solutions
-
-```haskell
-minmizeSol :: Solution -> SolveM Solution
-minimizeSol = undefined
-
-minimizeConjuncts :: [(Pred, a)] -> [(Pred, a)]
-minimizeConjuncts ps = go ps []
-  where
-    go []     acc = acc
-    go (p:ps) acc = do b <- alreadyImplied ps acc q
-                       if b then go ps acc
-                            else go ps (p:acc)
-
-alreadyImplied ps acc q = checkValid (pAnd [ p | (p, _) <- ps ++ acc] ) q
-```
-
-
 ## Beta-Equivalence
 
 * tests/pos/NormalForm.hs.fq

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 ```haskell
 minmizeSol :: Solution -> SolveM Solution
 minimizeSol = undefined
- 
+
 minimizeConjuncts :: [(Pred, a)] -> [(Pred, a)]
 minimizeConjuncts ps = go ps []
   where

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -180,6 +180,16 @@ result_  w s = res <$> filterM (isUnsat s) cs
     res []   = F.Safe
     res cs'  = F.Unsafe cs'
 
+
+--------------------------------------------------------------------------------
+-- | `minimizeResult` transforms each KVar's result to minimize it by removing
+--   predicates that are implied by others. That is,
+--
+--      minimizeConjuncts :: ps:[Pred] -> {qs:[Pred] | subset qs ps}
+--
+--   such that `minimizeConjuncts ps` is a minimal subset of ps where no
+--   is implied by /\_{q' in qs \ qs}
+--
 --------------------------------------------------------------------------------
 minimizeResult :: Config -> M.HashMap F.KVar F.Expr
                -> SolveM (M.HashMap F.KVar F.Expr)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -98,7 +98,6 @@ solve_ cfg fi s0 ks wkl = do
 -- | tidyResult ensures we replace the temporary kVarArg names introduced to
 --   ensure uniqueness with the original names in the given WF constraints.
 --------------------------------------------------------------------------------
-
 tidyResult :: F.Result a -> F.Result a
 tidyResult r = r { F.resSolution = tidySolution (F.resSolution r) }
 
@@ -166,6 +165,7 @@ result _ wkl s = do
   stat    <- result_ wkl s
   -- stat'   <- gradualSolve cfg stat
   lift $ whenNormal $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
+  -- s' <- minimizeSolution s
   return   $  F.Result (ci <$> stat) (Sol.result s)
   where
     ci c = (F.subcId c, F.sinfo c)

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -55,6 +55,7 @@ defaultMinPartSize = 500
 defaultMaxPartSize :: Int
 defaultMaxPartSize = 700
 
+
 data Config
   = Config {
       srcFile     :: FilePath            -- ^ src file (*.hs, *.ts, *.c, or even *.fq or *.bfq)
@@ -78,6 +79,7 @@ data Config
     , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
     , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
     , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
+    , minimalSol  :: Bool                -- ^ shrink final solution by pruning redundant qualfiers from fixpoint
     , gradual     :: Bool                -- ^ solve "gradual" constraints
     , extensionality   :: Bool           -- ^ allow function extensionality
     , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
@@ -154,6 +156,7 @@ defConfig = Config {
   , minimize         = False &= help "Delta debug to minimize fq file (unsat with min constraints)"
   , minimizeQs       = False &= help "Delta debug to minimize fq file (sat with min qualifiers)"
   , minimizeKs       = False &= help "Delta debug to minimize fq file (sat with max kvars replaced by True)"
+  , minimalSol       = False &= help "Shrink fixpoint by removing implied qualifiers"
   , gradual          = False &= help "Solve gradual-refinement typing constraints"
   , extensionality   = False &= help "Allow function extensionality axioms"
   , alphaEquivalence = False &= help "Allow lambda alpha equivalence axioms"

--- a/src/Language/Fixpoint/Types/Triggers.hs
+++ b/src/Language/Fixpoint/Types/Triggers.hs
@@ -4,9 +4,9 @@
 
 module Language.Fixpoint.Types.Triggers (
 
-    Triggered (..), Trigger(..), 
+    Triggered (..), Trigger(..),
 
-    noTrigger, defaultTrigger, 
+    noTrigger, defaultTrigger,
 
     makeTriggers
 
@@ -20,7 +20,7 @@ import Language.Fixpoint.Types.Refinements
 import Language.Fixpoint.Misc              (errorstar)
 
 
-data Triggered a = TR Trigger a 
+data Triggered a = TR Trigger a
   deriving (Eq, Show, Functor, Generic)
 
 data Trigger = NoTrigger | LeftHandSide
@@ -30,33 +30,31 @@ data Trigger = NoTrigger | LeftHandSide
 noTrigger :: e -> Triggered e
 noTrigger = TR NoTrigger
 
-defaultTrigger :: e -> Triggered e 
+defaultTrigger :: e -> Triggered e
 defaultTrigger = TR LeftHandSide
-
-
 
 makeTriggers :: Triggered Expr -> [Expr]
 makeTriggers (TR LeftHandSide e) = [getLeftHandSide e]
 makeTriggers (TR NoTrigger    _) = errorstar "makeTriggers on NoTrigger"
 
 
-getLeftHandSide :: Expr -> Expr 
+getLeftHandSide :: Expr -> Expr
 getLeftHandSide (ECst e _)
-  = getLeftHandSide e 
-getLeftHandSide (PAll _ e)   
-  = getLeftHandSide e 
-getLeftHandSide (PExist _ e) 
-  = getLeftHandSide e 
-getLeftHandSide (PAtom eq lhs _) 
+  = getLeftHandSide e
+getLeftHandSide (PAll _ e)
+  = getLeftHandSide e
+getLeftHandSide (PExist _ e)
+  = getLeftHandSide e
+getLeftHandSide (PAtom eq lhs _)
   | eq == Eq || eq == Ueq
   = lhs
 getLeftHandSide (PIff lhs _)
   = lhs
-getLeftHandSide _ 
- = defaltPatter 
+getLeftHandSide _
+ = defaltPatter
 
 -- NV TODO find out a valid, default pattern that does not instantiate the axiom
-defaltPatter :: Expr 
+defaltPatter :: Expr
 defaltPatter = PFalse
 
 instance B.Binary Trigger

--- a/tests/pos/min00.fq
+++ b/tests/pos/min00.fq
@@ -1,0 +1,22 @@
+
+qualif Zog(v:a) : (10 <= v)
+qualif Zog(v:a) : (9 <= v)
+qualif Zog(v:a) : (8 <= v)
+qualif Zog(v:a) : (99 <= v)
+
+constraint:
+  env []
+  lhs {v : int | (v = 100)}
+  rhs {v : int | $k0}
+  id 1 tag []
+
+constraint:
+  env []
+  lhs {v : int | $k0}
+  rhs {v : int | (15 <= v) }
+  id 1 tag []
+
+
+wf:
+  env [ ]
+  reft {v: int | $k0}


### PR DESCRIPTION
Add option `--minimalsol` to compute "minimal solutions" which remove redundant quals (e.g. those implied by others.) For example, compare the `.liquid/min00.fq.fqout` files produced by:

```
fixpoint tests/pos/min00.fq --save
fixpoint tests/pos/min00.fq --save --minimal
```