### PR TITLE
Clean up the parser (a bit)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3,],sources: [hvr-ghc]}}
     - env: SMT="z3" CABAL=1.24 GHC=8.0.1
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1,],sources: [hvr-ghc]}}
+    - env: SMT="z3" CABAL=1.24 GHC=8.0.2
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2,],sources: [hvr-ghc]}}
     - env: CABALVER=head GHCVER=head
       addons: {apt: {packages: [cabal-install-head,ghc-head],  sources: [hvr-ghc]}}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ branches:
   only:
   - master
   - develop
+  - parser-az
 
 matrix:
   include:

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -167,3 +167,59 @@ test-suite test
                     tasty-hunit,
                     tasty-rerun >= 1.1,
                     text
+
+test-suite testparser
+  default-language: Haskell98
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  ghc-options:      -threaded
+  if flag(devel)
+    ghc-options:    -Werror
+  main-is:          testParser.hs
+  build-depends:    base,
+                    directory,
+                    filepath,
+                    tasty >= 0.10,
+                    tasty-hunit,
+                    tasty-rerun >= 1.1,
+                    text
+  if flag(devel)
+    hs-source-dirs:   tests src
+    build-depends:
+                 array
+               , async
+               , attoparsec
+               , syb
+               , cmdargs
+               , ansi-terminal
+               , bifunctors
+               , binary
+               , bytestring
+               , containers
+               , deepseq
+               , directory
+               , filemanip
+               , filepath
+               , ghc-prim
+               , intern
+               , mtl
+               , parsec
+               , pretty
+               , boxes
+               , parallel
+               , process
+               , syb
+               , text
+               , transformers
+               , hashable
+               , unordered-containers
+               , cereal
+               , text-format
+               , fgl
+               , fgl-visualize
+               , dotgen
+               , time
+    if impl(ghc >= 7.10.2)
+      Build-Depends: located-base
+  else
+    build-depends: liquid-fixpoint

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -30,29 +30,29 @@ module Language.Fixpoint.Parse (
   -- * Parsing basic entities
 
   --   fTyConP  -- Type constructors
-  , lowerIdP    -- Lower-case identifiers
-  , upperIdP    -- Upper-case identifiers
-  , infixIdP    -- String Haskell infix Id
-  , symbolP     -- Arbitrary Symbols
-  , constantP   -- (Integer) Constants
-  , integer     -- Integer
-  , bindP       -- Binder (lowerIdP <* colon)
-  , sortP       -- Sort
-  , mkQual      -- constructing qualifiers
+  , lowerIdP    -- ^ Lower-case identifiers
+  , upperIdP    -- ^ Upper-case identifiers
+  , infixIdP    -- ^ String Haskell infix Id
+  , symbolP     -- ^ Arbitrary Symbols
+  , constantP   -- ^ (Integer) Constants
+  , integer     -- ^ Integer
+  , bindP       -- ^ Binder (lowerIdP <* colon)
+  , sortP       -- ^ Sort
+  , mkQual      -- ^ constructing qualifiers
 
   -- * Parsing recursive entities
-  , exprP       -- Expressions
-  , predP       -- Refinement Predicates
-  , funAppP     -- Function Applications
-  , qualifierP  -- Qualifiers
-  , refaP       -- Refa
-  , refP        -- (Sorted) Refinements
-  , refDefP     -- (Sorted) Refinements with default binder
-  , refBindP    -- (Sorted) Refinements with configurable sub-parsers
-  , bvSortP     -- Bit-Vector Sort
+  , exprP       -- ^ Expressions
+  , predP       -- ^ Refinement Predicates
+  , funAppP     -- ^ Function Applications
+  , qualifierP  -- ^ Qualifiers
+  , refaP       -- ^ Refa
+  , refP        -- ^ (Sorted) Refinements
+  , refDefP     -- ^ (Sorted) Refinements with default binder
+  , refBindP    -- ^ (Sorted) Refinements with configurable sub-parsers
+  , bvSortP     -- ^ Bit-Vector Sort
 
   -- * Some Combinators
-  , condIdP     -- condIdP  :: [Char] -> (Text -> Bool) -> Parser Text
+  , condIdP     -- ^ condIdP  :: [Char] -> (Text -> Bool) -> Parser Text
 
   -- * Add a Location to a parsed value
   , locParserP
@@ -193,6 +193,7 @@ double        = Token.float         lexer
 
 -- identifier = Token.identifier lexer
 
+-- TODO:AZ: pretty sure there is already a whitespace eater in parsec,
 blanks :: Parser String
 blanks  = many (satisfy (`elem` [' ', '\t']))
 
@@ -444,7 +445,7 @@ fTyConP
   =   (reserved "int"     >> return intFTyCon)
   <|> (reserved "Integer" >> return intFTyCon)
   <|> (reserved "Int"     >> return intFTyCon)
-  <|> (reserved "int"     >> return intFTyCon)
+  <|> (reserved "int"     >> return intFTyCon) -- TODO:AZ duplicate?
   <|> (reserved "real"    >> return realFTyCon)
   <|> (reserved "bool"    >> return boolFTyCon)
   <|> (reserved "num"     >> return numFTyCon)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -285,9 +285,18 @@ expr0P
  <|> (ECon <$> constantP)
  <|> (reserved "_|_" >> return EBot)
  <|> lamP
- <|> try (parens  exprP)
- <|> try (parens  exprCastP)
+  -- TODO:AZ get rid of these try, after the rest
+ <|> try (parens exprP)
+ <|> try (parens exprCastP)
  <|> (charsExpr <$> symCharsP)
+  where
+
+exprCastP :: Parser Expr
+exprCastP
+  = do e  <- exprP
+       (try dcolon) <|> colon
+       so <- sortP
+       return $ ECst e so
 
 charsExpr :: Symbol -> Expr
 charsExpr cs
@@ -387,6 +396,7 @@ funAppP            =  litP <|> exprFunP <|> simpleAppP
     innerP =   brackets (sepBy exprP semi)
            <|> sepBy exprP comma
 
+    -- TODO:AZ the parens here should be superfluous, but it hits an infinite loop if removed
     simpleAppP     = EApp <$> parens exprP <*> parens exprP
     funSymbolP     = locParserP symbolP
 
@@ -405,13 +415,6 @@ parenBrackets  = parens . brackets
 -- eMinus     = EBin Minus (expr (0 :: Integer))
 -- eCons x xs = EApp (dummyLoc consName) [x, xs]
 -- eNil       = EVar nilName
-
-exprCastP :: Parser Expr
-exprCastP
-  = do e  <- exprP
-       (try dcolon) <|> colon
-       so <- sortP
-       return $ ECst e so
 
 lamP :: Parser Expr
 lamP
@@ -463,7 +466,7 @@ single x = [x]
 
 tvarP :: Parser Sort
 tvarP
-   =  try (string "@" >> varSortP)
+   =  (string "@" >> varSortP)
   <|> (FObj . symbol <$> lowerIdP)
 
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -384,6 +384,7 @@ funAppP            =  (try litP) <|> (try exprFunSpacesP) <|> (try exprFunSemisP
     funSymbolP     = locParserP symbolP
 
 
+-- TODO:AZ: The comment says BitVector literal, but it accepts any @Sort@
 -- | BitVector literal: lit "#x00000001" (BitVec (Size32 obj))
 litP :: Parser Expr
 litP = do reserved "lit"

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -242,7 +242,7 @@ upperIdP = do
 -- | Lower-case identifiers
 lowerIdP :: Parser Symbol
 lowerIdP = do
-  c <- lower
+  c <- satisfy (\c -> isLower c || c == '_' )
   cs <- many (satisfy (`S.member` symChars))
   blanks
   return (symbol $ c:cs)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -73,6 +73,9 @@ module Language.Fixpoint.Parse (
   , initPState, PState
 
   , Fixity(..), Assoc(..), addOperatorP
+
+  -- * For testing
+  , expr0P
   ) where
 
 import qualified Data.HashMap.Strict         as M
@@ -312,6 +315,7 @@ qmIfP f bodyP
       return $ f p b1 b2
 -}
 
+-- | Used as input to @Text.Parsec.Expr.buildExpressionParser@ to create @exprP@
 expr1P :: Parser Expr
 expr1P
   =  try funAppP

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -498,16 +498,16 @@ bvSortP = mkSort <$> (bvSizeP "Size32" S32 <|> bvSizeP "Size64" S64)
 pred0P :: Parser Expr
 pred0P =  trueP
       <|> falseP
-      <|> try (reserved "??" >> makeUniquePGrad)
-      <|> try kvarPredP
-      <|> try (fastIfP pIte predP)
+      <|> (reserved "??" >> makeUniquePGrad)
+      <|> kvarPredP
+      <|> (fastIfP pIte predP)
       <|> try predrP
-      <|> try (parens predP)
-      <|> try (reserved "?" *> exprP)
+      <|> (parens predP)
+      <|> (reserved "?" *> exprP)
       <|> try funAppP
-      <|> try (eVar <$> symbolP)
-      <|> try (reservedOp "&&" >> pGAnds <$> predsP)
-      <|> try (reservedOp "||" >> POr  <$> predsP)
+      <|> (eVar <$> symbolP)
+      <|> (reservedOp "&&" >> pGAnds <$> predsP)
+      <|> (reservedOp "||" >> POr  <$> predsP)
 
 makeUniquePGrad :: Parser Expr 
 makeUniquePGrad

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -375,11 +375,14 @@ bops = foldl (flip addOperator) initOpTable buildinOps
 
 -- | Function Applications
 funAppP :: Parser Expr
-funAppP            =  (try litP) <|> (try exprFunSpacesP) <|> (try exprFunSemisP) <|> exprFunCommasP <|> simpleAppP
+funAppP            =  litP <|> exprFunP <|> simpleAppP
   where
-    exprFunSpacesP = mkEApp <$> funSymbolP <*> sepBy1 expr0P blanks
-    exprFunCommasP = mkEApp <$> funSymbolP <*> parens        (sepBy exprP comma)
-    exprFunSemisP  = mkEApp <$> funSymbolP <*> parenBrackets (sepBy exprP semi)
+    exprFunP = mkEApp <$> funSymbolP <*> funRhsP
+    funRhsP  =  sepBy1 expr0P blanks
+            <|> parens innerP
+    innerP =   brackets (sepBy exprP semi)
+           <|> sepBy exprP comma
+
     simpleAppP     = EApp <$> parens exprP <*> parens exprP
     funSymbolP     = locParserP symbolP
 

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -396,6 +396,7 @@ envSort l lEnv tEnv x i
 remakeQual :: Qualifier -> Qualifier
 remakeQual q = {- traceShow msg $ -} mkQual (qName q) (qParams q) (qBody q) (qPos q)
 
+-- | constructing qualifiers
 mkQual :: Symbol -> [(Symbol, Sort)] -> Expr -> SourcePos -> Qualifier
 mkQual n xts p = Q n ((v, t) : yts) (subst su p)
   where

--- a/src/Language/Fixpoint/Types/PrettyPrint.hs
+++ b/src/Language/Fixpoint/Types/PrettyPrint.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -131,8 +132,10 @@ instance PPrint Float where
 instance PPrint () where
   pprintTidy _ = text . show
 
+#if !(defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,0,1,1)))
 instance PPrint String where
   pprintTidy _ = text
+#endif
 
 instance PPrint Int where
   pprintTidy _ = tshow

--- a/src/Language/Fixpoint/Types/Spans.hs
+++ b/src/Language/Fixpoint/Types/Spans.hs
@@ -116,7 +116,9 @@ instance Traversable Located where
   traverse f (Loc l l' x) = Loc l l' <$> f x
 
 instance Show a => Show (Located a) where
-  show (Loc l l' x) = show x ++ " defined from: " ++ show l ++ " to: " ++ show l'
+  show (Loc l l' x)
+    | l == l' && l == dummyPos "Fixpoint.Types.dummyLoc" = "dummyLoc"
+    | otherwise  = show x ++ " defined from: " ++ show l ++ " to: " ++ show l'
 
 instance PPrint a => PPrint (Located a) where
   pprintTidy k (Loc _ _ x) = pprintTidy k x

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,4 +8,5 @@ extra-deps:
 - fgl-visualize-0.1.0.1
 - intern-0.9.1.4
 - located-base-0.1.1.0
-resolver: lts-6.27
+
+resolver: nightly-2016-05-21

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -112,6 +112,9 @@ testSortP =
 
     , testCase "FObj " $
         show (doParse' sortP "test" "foo") @?= "FObj \"foo\""
+
+    , testCase "FObj " $
+        show (doParse' sortP "test" "_foo") @?= "FObj \"_foo\""
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -2,17 +2,9 @@
 
 module Main where
 
--- import Control.Applicative
 import Language.Fixpoint.Parse
--- import System.Directory
--- import System.Environment
--- import System.Exit
--- import System.FilePath
--- import System.IO
--- import System.IO.Error
 import Test.Tasty
 import Test.Tasty.HUnit
--- import Text.Printf
 
 main :: IO ()
 main = defaultMain $ parserTests
@@ -24,15 +16,7 @@ parserTests =
       testSortP
     , testFunAppP
     , testExpr0P
-      -- testExprP
     , testPredP
-    ]
-
-testExprP :: TestTree
-testExprP =
-  testGroup "exprP"
-    [ testCase "aa" $
-        (show $ doParse' exprP "test" "x >= -1") @=? ""
     ]
 
 -- ---------------------------------------------------------------------

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Applicative
+import Language.Fixpoint.Parse
+import System.Directory
+import System.Environment
+import System.Exit
+import System.FilePath
+import System.IO
+import System.IO.Error
+import Test.Tasty
+import Test.Tasty.HUnit
+import Text.Printf
+
+main :: IO ()
+main = defaultMain $ parserTests
+
+parserTests =
+  testGroup "Tests"
+    [
+      testSortP
+      -- testExprP
+    ]
+
+testExprP =
+  testGroup "exprP"
+    [ testCase "aa" $
+        (show $ doParse' exprP "test" "x >= -1") @=? ""
+    ]
+
+-- ---------------------------------------------------------------------
+{-
+
+sort = '(' sort ')'
+     | 'func' funcSort
+     | '[' sort ']'
+     | bvsort
+     | fTyCon
+     | tVar
+
+sorts = '[' sortslist ']'
+
+sortslist = sort
+          | sort `;` sortslist
+
+funcSort = '(' int `,` sorts ')'
+
+     e.g.(func(1, [int; @(0)]))
+
+bvsort = '(' 'BitVec' 'Size32' ')'
+       | '(' 'BitVec' 'Size64' ')'
+
+fTyCon = 'int' | 'Integer' | 'Int' | 'real' | 'num' | 'Str'
+       | SYMBOL
+
+SYMBOL = upper case char or _, followed by many of '%' '#' '$' '\'
+
+tVar = '@' varSort
+     | LOWERID
+
+varSort = '(' INT ')'
+-}
+
+testSortP =
+  testGroup "SortP"
+    [ testCase "FAbs" $
+        show (doParse' sortP "test" "(func(1, [int; @(0)]))") @?= "FAbs 0 (FFunc FInt (FVar 0))"
+
+    , testCase "(FAbs)" $
+        show (doParse' sortP "test" "((func(1, [int; @(0)])))") @?= "FAbs 0 (FFunc FInt (FVar 0))"
+
+    , testCase "FApp FInt" $
+        show (doParse' sortP "test" "[int]") @?=
+              "FApp (FTC (TC dummyLoc (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt"
+
+    , testCase "bv32" $
+        show (doParse' sortP "test" "BitVec Size32") @?=
+              "FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 8) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined from: \"test\" (line 1, column 8) to: \"test\" (line 1, column 14) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
+
+    , testCase "bv64" $
+        show (doParse' sortP "test" "BitVec Size64") @?=
+              "FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 8) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size64\" defined from: \"test\" (line 1, column 8) to: \"test\" (line 1, column 14) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
+
+    , testCase "FInt int" $
+        show (doParse' sortP "test" "int") @?= "FInt"
+
+    , testCase "FInt Integer" $
+        show (doParse' sortP "test" "Integer") @?= "FInt"
+
+    , testCase "FInt Int" $
+        show (doParse' sortP "test" "Int") @?= "FInt"
+
+    , testCase "FReal real" $
+        show (doParse' sortP "test" "real") @?= "FReal"
+
+    , testCase "FNum num" $
+        show (doParse' sortP "test" "num") @?= "FNum"
+
+    , testCase "FStr" $
+        show (doParse' sortP "test" "Str") @?=
+             "FTC (TC dummyLoc (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = True}))"
+
+    , testCase "SYMBOL" $
+        show (doParse' sortP "test" "F#y") @?=
+             "FTC (TC \"F#y\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 4) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))"
+
+    , testCase "FVar 3" $
+        show (doParse' sortP "test" "@(3)") @?= "FVar 3"
+
+    , testCase "FObj " $
+        show (doParse' sortP "test" "foo") @?= "FObj \"foo\""
+    ]

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -21,6 +21,7 @@ parserTests =
   testGroup "Tests"
     [
       testSortP
+    , testFunAppP
       -- testExprP
     ]
 
@@ -111,4 +112,42 @@ testSortP =
 
     , testCase "FObj " $
         show (doParse' sortP "test" "foo") @?= "FObj \"foo\""
+    ]
+
+-- ---------------------------------------------------------------------
+{-
+
+funApp = lit
+       | exprFunSpaces
+       | expFunSemis
+       | expFunCommas
+       | simpleApp
+
+lit = 'lit' stringLiteral sort
+
+exprFunSpaces =
+
+exprFunSemis =
+
+exprFunCommas =
+
+simpleApp = 
+-}
+testFunAppP =
+  testGroup "FunAppP"
+    [ testCase "ECon (litP)" $
+        show (doParse' funAppP "test" "lit \"#x00000008\" (BitVec  Size32)") @?=
+          "ECon (L \"#x00000008\" (FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 19) to: \"test\" (line 1, column 27) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined from: \"test\" (line 1, column 27) to: \"test\" (line 1, column 33) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))))"
+
+    , testCase "ECon (exprFunSpacesP)" $
+        show (doParse' funAppP "test" "fooBar baz qux") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
+
+    , testCase "ECon (exprFunCommasP)" $
+        show (doParse' funAppP "test" "fooBar (baz, qux)") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
+
+    , testCase "ECon (exprFunSemisP)" $
+        show (doParse' funAppP "test" "fooBar ([baz; qux])") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
+
+    , testCase "ECon (simpleAppP)" $
+        show (doParse' funAppP "test" "fooBar (baz + 1)") @?= "EApp (EVar \"fooBar\") (EBin Plus (EVar \"baz\") (ECon (I 1)))"
     ]


### PR DESCRIPTION
Adds a testsuite for the parser, and removes a number of `try` uses.

The main `liquidhaskell` tests also pass using this version, as seen [here](https://circleci.com/gh/alanz/liquidhaskell/26)