### PR TITLE
Simplify PLE (Instantiate) with ADTs

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -30,7 +30,6 @@ module Language.Fixpoint.Smt.Interface (
     , makeContext
     , makeContextNoLog
     , makeContextWithSEnv
-    -- , makeSmtContext
     , cleanupContext
 
     -- * Execute Queries
@@ -115,29 +114,6 @@ runCommands cmds
        return zs
 -}
 
-
--- TODO: DEPRECATE `makeSmtContext`; instead use just `makeContextWithSEnv`
---       which should call `declare` inside it. Currently broken as the use
---       case is in `instantiate` which needs it BEFORE we `Sanitize` and
---       hence before we can call `symbolEnv` to find the set of all symbols etc...
-
--- makeSmtContext :: Config -> FilePath -> [DataDecl] -> [(Symbol, Sort)] -> [Sort]
---                -> IO Context
--- makeSmtContext cfg f dds xts ts = do
-  -- let env = makeSmtEnv dds xts ts
-  -- me     <- makeContextWithSEnv cfg f env
-  -- smtDecls me (theoryDecls env)
-  -- smtDecls me xts
-  -- return me
-
--- makeSmtEnv :: [DataDecl] -> [(Symbol, Sort)] -> [Sort] -> SymEnv
--- makeSmtEnv dds xts ts = symEnv (fromListSEnv xts) (Thy.theorySymbols dds) dds ts
-
-_theoryDecls :: SymEnv -> [(Symbol, Sort)]
-_theoryDecls env = [ (x, tsSort ty) | (x, ty) <- theorySyms, Uninterp == tsInterp ty]
-  where
-    theorySyms  = toListSEnv (seTheory env)
-
 checkValidWithContext :: Context -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
 checkValidWithContext me xts p q =
   smtBracket me "checkValidWithContext" $
@@ -171,14 +147,13 @@ checkValids cfg f xts ps
 -- debugFile :: FilePath
 -- debugFile = "DEBUG.smt2"
 
---------------------------------------------------------------------------
--- | SMT IO --------------------------------------------------------------
---------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+-- | SMT IO --------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
-
---------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 command              :: Context -> Command -> IO Response
---------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 command me !cmd       = say cmd >> hear cmd
   where
     env               = ctxSymEnv me
@@ -301,7 +276,7 @@ makeProcess cfg
                   , ctxAeq     = alphaEquivalence cfg
                   , ctxBeq     = betaEquivalence  cfg
                   , ctxNorm    = normalForm       cfg
-                  , ctxSymEnv  = mempty -- tsSort <$> Thy.theorySymbols -- Thy.theorySEnv
+                  , ctxSymEnv  = mempty
                   }
 
 --------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -251,21 +251,6 @@ smt2App env (EVar f) (d:ds)
   = Just $ build "({} {})" (tsRaw s, d <> mconcat [ " " <> d | d <- ds])
 smt2App _ _ _    = Nothing
 
--- isSmt2App :: Expr -> [a] -> Bool
--- isSmt2App e xs = tracepp ("isSmt2App e := " ++ show e) (isSmt2App' e xs)
-
---------------------------------------------------------------------------------
--- / isSmt2App :: SEnv TheorySymbol -> Expr -> [a] -> Bool
--- / --------------------------------------------------------------------------------
--- / isSmt2App _ (EVar f) [_]
-  -- / | f == setEmpty = True
-  -- / | f == setEmp   = True
-  -- / | f == setSng   = True
--- / isSmt2App env (EVar f) _
-  -- / =  isJust (lookupSEnv f env)
--- / isSmt2App _ _ _
-  -- / = False
-
 --------------------------------------------------------------------------------
 isSmt2App :: SEnv TheorySymbol -> Expr -> Maybe Int
 --------------------------------------------------------------------------------
@@ -283,38 +268,6 @@ preamble :: Config -> SMTSolver -> [T.Text]
 preamble u Z3   = z3Preamble u
 preamble u Cvc4 = cvc4Preamble u
 preamble u _    = smtlibPreamble u
-
---------------------------------------------------------------------------------
--- | Converting Non-Int types to Int -------------------------------------------
---------------------------------------------------------------------------------
--- toInt :: Expr -> Sort -> Expr
--- toInt e s = tracepp msg (toInt' e s)
-  -- where
-    -- msg   = "toInt e = " ++ show e ++ ", t = " ++ show s
-
-_toInt :: Expr -> Sort -> Expr
-_toInt e s
-  |  (FApp (FTC c) _) <- s
-  , setConName == symbol c
-  = castWith setToIntName e
-  | (FApp (FApp (FTC c) _) _) <- s
-  , mapConName == symbol c
-  = castWith mapToIntName e
-  | (FApp (FTC bv) (FTC s)) <- s
-  , bitVecName == symbol bv
-  , Just _ <- sizeBv s
-  = castWith bitVecToIntName e
-  | FTC c <- s
-  , c == boolFTyCon
-  = castWith boolToIntName e
-  | FTC c <- s
-  , c == realFTyCon
-  = castWith realToIntName e
-  | otherwise
-  = e
-
-castWith :: Symbol -> Expr -> Expr
-castWith s = eAppC intSort (EVar s)
 
 --------------------------------------------------------------------------------
 -- | Theory Symbols : `uninterpSEnv` should be disjoint from see `interpSEnv`

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -22,6 +22,7 @@ module Language.Fixpoint.Smt.Theories
 
        -- * Theory Symbols
      , theorySymbols
+     , dataDeclSymbols
 
 
        -- * Theories
@@ -424,7 +425,7 @@ axiomLiterals lts = catMaybes [ lenAxiom l <$> litLen l | (l, t) <- lts, isStrin
 -- | Constructors, Selectors and Tests from 'DataDecl'arations.
 --------------------------------------------------------------------------------
 dataDeclSymbols :: DataDecl -> [(Symbol, TheorySymbol)]
-dataDeclSymbols d = {- tracepp "dataDeclSymbols" $ -} ctorSymbols d ++ testSymbols d ++ selectSymbols d
+dataDeclSymbols d = ctorSymbols d ++ testSymbols d ++ selectSymbols d
 
 -- | 'selfSort d' returns the _self-sort_ of 'd' :: 'DataDecl'.
 --   See [NOTE:DataDecl] for details.

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -190,9 +190,11 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
     -- 1. when e2 is a data con and can lead to further reductions
     -- 2. when size e2 < size e1
     -- @TODO: Can this be generalized?
-    atms = splitPAnd =<< (expr <$> filter isProof es)
-    simpleEqs = tracepp "SIMPLEEQS" $ makeSimplifications (aenvSimpl aenv) =<<
-                L.nub (catMaybes [getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
+    simpleEqs = []
+    -- ADT simpleEqs = {- tracepp "SIMPLEEQS" $ -} makeSimplifications (aenvSimpl aenv) =<<
+    -- ADT           L.nub (catMaybes [getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
+    -- ADT atms = splitPAnd =<< (expr <$> filter isProof es)
+    -- ADT isProof (_, RR s _) = showpp s == "Tuple"
     sels = (go . expr) =<< es
     go e = let es   = splitPAnd e
                su   = mkSubst [(x, EVar y)  | PAtom Eq (EVar x) (EVar y) <- es ]
@@ -224,10 +226,9 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
     -- TODO: Stringy hacks
     isSelector :: Symbol -> Bool
     isSelector  = L.isPrefixOf "select" . symbolString
-    isProof (_, RR s _) = showpp s == "Tuple"
 
-makeSimplifications :: [Rewrite] -> (Symbol, [Expr], Expr) -> [(Expr, Expr)]
-makeSimplifications sis (dc, es, e)
+_makeSimplifications :: [Rewrite] -> (Symbol, [Expr], Expr) -> [(Expr, Expr)]
+_makeSimplifications sis (dc, es, e)
  = go =<< sis
  where
    go (SMeasure f dc' xs bd)
@@ -236,8 +237,8 @@ makeSimplifications sis (dc, es, e)
    go _
      = []
 
-getDCEquality :: Expr -> Expr -> Maybe (Symbol, [Expr], Expr)
-getDCEquality e1 e2
+_getDCEquality :: Expr -> Expr -> Maybe (Symbol, [Expr], Expr)
+_getDCEquality e1 e2
     | Just dc1 <- f1
     , Just dc2 <- f2
     = if dc1 == dc2

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -384,7 +384,15 @@ eval γ (PImp e1 e2)
   = PImp <$> eval γ e1 <*> eval γ e2
 eval γ (PIff e1 e2)
   = PIff <$> eval γ e1 <*> eval γ e2
+eval γ (PAnd es)
+  = PAnd <$> (eval γ <$$> es)
+eval γ (POr es)
+  = POr  <$> (eval γ <$$> es)
 eval _ e = return e
+
+(<$$>) :: (Monad m) => (a -> m b) -> [a] -> m [b]
+f <$$> xs = f Misc.<$$> xs
+
 
 evalArgs :: Knowledge -> Expr -> EvalST (Expr, [Expr])
 evalArgs γ = go []

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -190,11 +190,11 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
     -- 1. when e2 is a data con and can lead to further reductions
     -- 2. when size e2 < size e1
     -- @TODO: Can this be generalized?
-    simpleEqs = []
-    -- ADT simpleEqs = {- tracepp "SIMPLEEQS" $ -} makeSimplifications (aenvSimpl aenv) =<<
-    -- ADT           L.nub (catMaybes [getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
-    -- ADT atms = splitPAnd =<< (expr <$> filter isProof es)
-    -- ADT isProof (_, RR s _) = showpp s == "Tuple"
+    -- simpleEqs = []
+    simpleEqs = {- tracepp "SIMPLEEQS" $ -} _makeSimplifications (aenvSimpl aenv) =<<
+               L.nub (catMaybes [_getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
+    atms = splitPAnd =<< (expr <$> filter isProof es)
+    isProof (_, RR s _) = showpp s == "Tuple"
     sels = (go . expr) =<< es
     go e = let es   = splitPAnd e
                su   = mkSubst [(x, EVar y)  | PAtom Eq (EVar x) (EVar y) <- es ]

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -66,7 +66,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) {- . tracepp ("INSTANTIATE i = " ++ show i) -} <$> instSimpC cfg ctx (bs fi) (ae fi) i c
+                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -33,7 +33,7 @@ import qualified Data.HashMap.Strict  as M
 import qualified Data.List            as L
 import           Data.Maybe           (catMaybes, fromMaybe)
 import           Data.Char            (isUpper)
-import           Data.Foldable        (foldlM)
+-- import           Data.Foldable        (foldlM)
 
 (~>) :: (Expr, String) -> Expr -> EvalST Expr
 (_e,_str) ~> e' = do
@@ -66,7 +66,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
+                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi
@@ -174,10 +174,6 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
                                      , knPreds  = \bs e c -> askSMT c bs e
                                      }
   where
-    -- (xv, sv) = (vv Nothing, sr_sort $ snd $ head es)
-    -- fbinds   = toListSEnv fenv ++ [(x, s) | (x, RR s _) <- es]
-    -- senv     = senvCtx { seSort = fromListSEnv fbinds }
-    -- thySyms  = seTheory senvCtx
     senv = SMT.ctxSymEnv ctx
     context :: IO SMT.Context
     context = do
@@ -195,7 +191,7 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
     -- 2. when size e2 < size e1
     -- @TODO: Can this be generalized?
     atms = splitPAnd =<< (expr <$> filter isProof es)
-    simpleEqs = makeSimplifications (aenvSimpl aenv) =<<
+    simpleEqs = tracepp "SIMPLEEQS" $ makeSimplifications (aenvSimpl aenv) =<<
                 L.nub (catMaybes [getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
     sels = (go . expr) =<< es
     go e = let es   = splitPAnd e
@@ -228,7 +224,7 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
     -- TODO: Stringy hacks
     isSelector :: Symbol -> Bool
     isSelector  = L.isPrefixOf "select" . symbolString
-    isProof (_, RR s _) =  showpp s == "Tuple"
+    isProof (_, RR s _) = showpp s == "Tuple"
 
 makeSimplifications :: [Rewrite] -> (Symbol, [Expr], Expr) -> [(Expr, Expr)]
 makeSimplifications sis (dc, es, e)
@@ -260,8 +256,8 @@ getDCEquality e1 e2
     -- TODO: Stringy hacks
     getDC (EVar x)
       = if isUpper $ head $ symbolString $ dropModuleNames x
-           then Just x
-           else Nothing
+          then Just x
+          else Nothing
     getDC _
       = Nothing
 
@@ -287,25 +283,27 @@ splitPAnd e         = [e]
 -- that appears in the expression e
 -- required by PMEquivalence.mconcatChunk
 assertSelectors :: Knowledge -> Expr -> EvalST ()
-assertSelectors γ e = do
-   EvalEnv _ _ evaenv <- get
-   let sims = aenvSimpl evaenv
-   _ <- foldlM (\_ s -> Vis.mapMExpr (go s) e) e sims
-   return ()
-  where
-    go :: Rewrite -> Expr -> EvalST Expr
-    go (SMeasure f dc xs bd) e@(EApp _ _)
-      | (EVar dc', es) <- splitEApp e
-      , dc == dc', length xs == length es
-      = addSMTEquality γ (EApp (EVar f) e) (subst (mkSubst $ zip xs es) bd)
-      >> return e
-    go _ e
-      = return e
+assertSelectors _ _ = return ()
+-- ADT/DATACONS TAKES CARE OF THIS
+-- assertSelectors γ e = do
+   -- EvalEnv _ _ evaenv <- get
+   -- let sims = aenvSimpl evaenv
+   -- _ <- foldlM (\_ s -> Vis.mapMExpr (go s) e) e sims
+   -- return ()
+  -- where
+    -- go :: Rewrite -> Expr -> EvalST Expr
+    -- go (SMeasure f dc xs bd) e@(EApp _ _)
+      -- | (EVar dc', es) <- splitEApp e
+      -- , dc == dc', length xs == length es
+      -- = addSMTEquality γ (EApp (EVar f) e) (subst (mkSubst $ zip xs es) bd)
+      -- >> return e
+    -- go _ e
+      -- = return e
 
-addSMTEquality :: Knowledge -> Expr -> Expr -> EvalST (IO ())
-addSMTEquality γ e1 e2 =
-  return $ do ctx <- knContext γ
-              SMT.smtAssert ctx (PAtom Eq (makeLam γ e1) (makeLam γ e2))
+-- addSMTEquality :: Knowledge -> Expr -> Expr -> EvalST (IO ())
+-- addSMTEquality γ e1 e2 =
+--  return $ do ctx <- knContext γ
+--              SMT.smtAssert ctx (PAtom Eq (makeLam γ e1) (makeLam γ e2))
 
 --------------------------------------------------------------------------------
 -- | Symbolic Evaluation with SMT
@@ -426,19 +424,19 @@ substPopIf xes e = η $ foldl go e xes
     go e (x, EIte b e1 e2) = EIte b (subst1 e (x, e1)) (subst1 e (x, e2))
     go e (x, ex)           = subst1 e (x, ex)
 
-evalRecApplication :: Knowledge ->  Expr -> Expr -> EvalST Expr
+evalRecApplication :: Knowledge -> Expr -> Expr -> EvalST Expr
 evalRecApplication γ e (EIte b e1 e2)
   = do b' <- eval γ b
        b'' <- liftIO (isValid γ b')
        if b''
           then addApplicationEq γ e e1 >>
-               assertSelectors γ e1 >>
+               ({-# SCC "assertSelectors-1" #-} assertSelectors γ e1) >>
                eval γ e1 >>=
                ((e, "App") ~>)
           else do b''' <- liftIO (isValid γ (PNot b'))
                   if b'''
                      then addApplicationEq γ e e2 >>
-                          assertSelectors γ e2 >>
+                          ({-# SCC "assertSelectors-1" #-} assertSelectors γ e2) >>
                           eval γ e2 >>=
                           ((e, "App") ~>)
                      else return e

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -66,7 +66,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
+                        (i,) {- . tracepp ("INSTANTIATE i = " ++ show i) -} <$> instSimpC cfg ctx (bs fi) (ae fi) i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -37,7 +37,8 @@ type SanitizeM a = Either E.Error a
 sanitize :: F.SInfo a -> SanitizeM (F.SInfo a)
 --------------------------------------------------------------------------------
 sanitize =    -- banIllScopedKvars
-             Misc.fM dropFuncSortedShadowedBinders
+             Misc.fM dropAdtMeasures
+         >=> Misc.fM dropFuncSortedShadowedBinders
          >=> Misc.fM sanitizeWfC
          >=> Misc.fM replaceDeadKvars
          >=> Misc.fM (dropDeadSubsts . restrictKVarDomain)
@@ -46,6 +47,23 @@ sanitize =    -- banIllScopedKvars
          >=>         banConstraintFreeVars
          >=> Misc.fM addLiterals
 
+
+--------------------------------------------------------------------------------
+-- | 'dropAdtMeasures' removes all the measure definitions that correspond to
+--   constructor, selector or test names for declared datatypes, as these are
+--   now "natively" handled by the SMT solver.
+--------------------------------------------------------------------------------
+dropAdtMeasures :: F.SInfo a -> F.SInfo a
+dropAdtMeasures si = si { F.ae = dropAdtAenv (F.ddecls si) (F.ae si) }
+
+dropAdtAenv :: [F.DataDecl] -> F.AxiomEnv -> F.AxiomEnv
+dropAdtAenv ds ae = ae { F.aenvSimpl = filter (not . isAdt) (F.aenvSimpl ae) }
+  where
+    isAdt         = (`S.member` adtSyms) . F.smName
+    adtSyms       = adtSymbols ds
+
+adtSymbols :: [F.DataDecl] -> S.HashSet F.Symbol
+adtSymbols = S.fromList . map fst . concatMap Thy.dataDeclSymbols
 
 --------------------------------------------------------------------------------
 -- | `addLiterals` traverses the constraints to find (string) literals that

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -37,8 +37,9 @@ type SanitizeM a = Either E.Error a
 sanitize :: F.SInfo a -> SanitizeM (F.SInfo a)
 --------------------------------------------------------------------------------
 sanitize =    -- banIllScopedKvars
-             Misc.fM dropAdtMeasures
-         >=> Misc.fM dropFuncSortedShadowedBinders
+        --      Misc.fM dropAdtMeasures
+        --      >=>
+             Misc.fM dropFuncSortedShadowedBinders
          >=> Misc.fM sanitizeWfC
          >=> Misc.fM replaceDeadKvars
          >=> Misc.fM (dropDeadSubsts . restrictKVarDomain)
@@ -53,8 +54,8 @@ sanitize =    -- banIllScopedKvars
 --   constructor, selector or test names for declared datatypes, as these are
 --   now "natively" handled by the SMT solver.
 --------------------------------------------------------------------------------
-dropAdtMeasures :: F.SInfo a -> F.SInfo a
-dropAdtMeasures si = si { F.ae = dropAdtAenv (F.ddecls si) (F.ae si) }
+_dropAdtMeasures :: F.SInfo a -> F.SInfo a
+_dropAdtMeasures si = si { F.ae = dropAdtAenv (F.ddecls si) (F.ae si) }
 
 dropAdtAenv :: [F.DataDecl] -> F.AxiomEnv -> F.AxiomEnv
 dropAdtAenv ds ae = ae { F.aenvSimpl = filter (not . isAdt) (F.aenvSimpl ae) }

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -635,6 +635,8 @@ instance PTable (SInfo a) where
 toFixpoint :: (Fixpoint a, Fixpoint (c a)) => Config -> GInfo c a -> Doc
 --------------------------------------------------------------------------
 toFixpoint cfg x' =    cfgDoc   cfg
+                  $++$ declsDoc x'
+                  $++$ aeDoc    x'
                   $++$ qualsDoc x'
                   $++$ kutsDoc  x'
                 --   $++$ packsDoc x'
@@ -644,7 +646,6 @@ toFixpoint cfg x' =    cfgDoc   cfg
                   $++$ csDoc    x'
                   $++$ wsDoc    x'
                   $++$ binfoDoc x'
-                  $++$ aeDoc    x'
                   $++$ text "\n"
   where
     cfgDoc cfg    = text ("// " ++ show cfg)
@@ -654,6 +655,7 @@ toFixpoint cfg x' =    cfgDoc   cfg
     wsDoc         = vcat     . map toFix . M.elems . ws
     kutsDoc       = toFix    . kuts
     -- packsDoc      = toFix    . packs
+    declsDoc      = toFix    . ddecls
     bindsDoc      = toFix    . bs
     qualsDoc      = vcat     . map toFix . quals
     aeDoc         = toFix    . ae
@@ -790,7 +792,6 @@ instance Fixpoint AxiomEnv where
               $+$ text "expand" <+> toFix (pairdoc <$> M.toList(aenvExpand axe))
     where pairdoc (x,y) = text $ show x ++ " : " ++ show y
 
--- teehee
 instance Fixpoint Doc where
   toFix = id
 
@@ -798,6 +799,7 @@ instance Fixpoint Equation where
   toFix (Equ f xs e)  = text "define"
                      <+> toFix f <+> hsep (toFix <$> xs) <+> text " = "
                      <+> lparen <> toFix e <> rparen
+
 instance Fixpoint Rewrite where
   toFix (SMeasure f d xs e)
     = text "match"


### PR DESCRIPTION
A lot of the measure instantiation stuff is not needed when using ADTs.

This PR ensures selectors and tests are the same as those used for ADT fields,

and then eliminates a bunch of the code corresponding to the selectors and test measures.

Matching PR for https://github.com/ucsd-progsys/liquidhaskell/pull/1084