### PR TITLE
Elaborate

### DIFF
--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -833,7 +833,7 @@ checkRelTy _ e _  t1 t2      = unless (t1 == t2) (throwError $ errRel e t1 t2)
 --------------------------------------------------------------------------------
 
 unifyExpr :: Env -> Expr -> Maybe TVSubst
-unifyExpr f ee@(EApp e1 e2) = Just $ mconcat $ catMaybes [θ1, θ2, θ]
+unifyExpr f (EApp e1 e2) = Just $ mconcat $ catMaybes [θ1, θ2, θ]
   where
    θ1 = unifyExpr f e1 
    θ2 = unifyExpr f e2 
@@ -845,11 +845,12 @@ unifyExpr _ _
 
 unifyExprApp :: Env -> Expr -> Expr -> Maybe TVSubst
 unifyExprApp f e1 e2 = do 
-  t1 <- getArg <$> exprSort_maybe e1 
+  t1 <- getArg $ exprSort_maybe e1 
   t2 <- exprSort_maybe e2 
   unify f (Just $ EApp e1 e2) t1 t2 
   where
-    getArg (FFunc t1 _) = t1 
+    getArg (Just (FFunc t1 _)) = Just t1 
+    getArg _                   = Nothing 
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -59,7 +59,7 @@ import           Control.Monad.State.Strict
 
 import qualified Data.HashMap.Strict       as M
 import qualified Data.List                 as L
-import           Data.Maybe                (mapMaybe, fromMaybe)
+import           Data.Maybe                (mapMaybe, fromMaybe, catMaybes)
 
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Misc
@@ -380,11 +380,15 @@ elab f@(_, g) e@(EBin o e1 e2) = do
 
 elab f (EApp e1@(EApp _ _) e2) = do
   (e1', _, e2', s2, s) <- notracepp "ELAB-EAPP" <$> elabEApp f e1 e2
-  return (eAppC s e1'          (ECst e2' s2), s)
+  let e = eAppC s e1' (ECst e2' s2)
+  let θ = unifyExpr (snd f) e 
+  return (applyExpr θ e, maybe s (`apply` s) θ) 
 
 elab f (EApp e1 e2) = do
   (e1', s1, e2', s2, s) <- elabEApp f e1 e2
-  return (eAppC s (ECst e1' s1) (ECst e2' s2), s)
+  let e = eAppC s (ECst e1' s1) (ECst e2' s2)
+  let θ = unifyExpr (snd f) e 
+  return (applyExpr θ e, maybe s (`apply` s) θ) 
 
 elab _ e@(ESym _) =
   return (e, strSort)
@@ -822,6 +826,32 @@ checkRelTy f e Ne t1 t2      = void (unifys f (Just e) [t1] [t2] `withError` (er
 
 checkRelTy _ e _  t1 t2      = unless (t1 == t2) (throwError $ errRel e t1 t2)
 
+
+
+--------------------------------------------------------------------------------
+-- | Sort Unification on Expressions
+--------------------------------------------------------------------------------
+
+unifyExpr :: Env -> Expr -> Maybe TVSubst
+unifyExpr f ee@(EApp e1 e2) = Just $ mconcat $ catMaybes [θ1, θ2, θ]
+  where
+   θ1 = unifyExpr f e1 
+   θ2 = unifyExpr f e2 
+   θ  = unifyExprApp f e1 e2 
+unifyExpr f (ECst e _)
+  = unifyExpr f e 
+unifyExpr _ _ 
+  = Nothing
+
+unifyExprApp :: Env -> Expr -> Expr -> Maybe TVSubst
+unifyExprApp f e1 e2 = do 
+  t1 <- getArg <$> exprSort_maybe e1 
+  t2 <- exprSort_maybe e2 
+  unify f (Just $ EApp e1 e2) t1 t2 
+  where
+    getArg (FFunc t1 _) = t1 
+
+
 --------------------------------------------------------------------------------
 -- | Sort Unification
 --------------------------------------------------------------------------------
@@ -968,6 +998,13 @@ apply θ          = Vis.mapSort f
     f t@(FVar i) = fromMaybe t (lookupVar i θ)
     f t          = t
 
+applyExpr :: Maybe TVSubst -> Expr -> Expr
+applyExpr Nothing e  = e
+applyExpr (Just θ) e = Vis.mapExpr f e
+  where 
+    f (ECst e s) = ECst e (apply θ s)
+    f e          = e 
+
 --------------------------------------------------------------------------------
 -- | Deconstruct a function-sort -----------------------------------------------
 --------------------------------------------------------------------------------
@@ -984,6 +1021,10 @@ checkFunSort t             = throwError $ errNonFunction 1 t
 --------------------------------------------------------------------------------
 
 newtype TVSubst = Th (M.HashMap Int Sort) deriving (Show)
+
+instance Monoid TVSubst where
+  mempty                  = Th mempty
+  mappend (Th s1) (Th s2) = Th (mappend s1 s2) 
 
 lookupVar :: Int -> TVSubst -> Maybe Sort
 lookupVar i (Th m)   = M.lookup i m
@@ -1003,11 +1044,11 @@ errElabExpr e  = printf "Elaborate fails on %s" (showpp e)
 
 errUnify :: Maybe Expr -> Sort -> Sort -> String
 errUnify eo t1 t2 = printf "Cannot unify %s with %s %s"
-                      (showpp t1) (showpp t2) (unifyExpr eo)
+                      (showpp t1) (showpp t2) (errUnifyExpr eo)
 
-unifyExpr :: Maybe Expr -> String
-unifyExpr Nothing  = ""
-unifyExpr (Just e) = "in expression: " ++ showpp e
+errUnifyExpr :: Maybe Expr -> String
+errUnifyExpr Nothing  = ""
+errUnifyExpr (Just e) = "in expression: " ++ showpp e
 
 errUnifyMany :: [Sort] -> [Sort] -> String
 errUnifyMany ts ts'  = printf "Cannot unify types with different cardinalities %s and %s"

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -80,11 +80,11 @@ import           Text.PrettyPrint.HughesPJ
 import qualified Data.HashMap.Strict       as M
 
 
-data FTycon   = TC LocSymbol TCInfo deriving (Ord, Data, Typeable, Generic)
+data FTycon   = TC LocSymbol TCInfo deriving (Ord, Data, Typeable, Generic, Show)
 type TCEmb a  = M.HashMap a FTycon
 
-instance Show FTycon where
-  show (TC s _) = show (val s) 
+-- instance Show FTycon where
+--   show (TC s _) = show (val s) 
 
 instance Symbolic FTycon where
   symbol (TC s _) = symbol s

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -80,8 +80,11 @@ import           Text.PrettyPrint.HughesPJ
 import qualified Data.HashMap.Strict       as M
 
 
-data FTycon   = TC LocSymbol TCInfo deriving (Ord, Show, Data, Typeable, Generic)
+data FTycon   = TC LocSymbol TCInfo deriving (Ord, Data, Typeable, Generic)
 type TCEmb a  = M.HashMap a FTycon
+
+instance Show FTycon where
+  show (TC s _) = show (val s) 
 
 instance Symbolic FTycon where
   symbol (TC s _) = symbol s

--- a/tests/pos/adt_pair_cast.fq
+++ b/tests/pos/adt_pair_cast.fq
@@ -1,6 +1,4 @@
 
-DELIBERATELY BREAKING PARSE TO APPEASE CIRCLE 
-
 data P 2 = [
    | P {pfst : @(0), psnd : @(1)}
    ]


### PR DESCRIPTION
Fix in elaborate: 

The following LH program was crashing z3 before : 

```
{-@ LIQUID "--exactdc" @-}

module Programs where

data Term = Val Int | TApp Term Term  

{-@ measure isValue @-} 
isValue :: Term -> Bool 
isValue (Val _) = True 
isValue _       = False


data Program =
      Pg {pTerm :: Term}
    | PgHole

{-@ data Program <p :: Term -> Bool>
  = Pg { pTerm      :: (Term<p>)
       }
    | PgHole
 @-}

data LPair a b = LPairr a b 


{-@ reflect evalProgram @-}
evalProgram :: Program -> LPair Int Program

evalProgram (Pg (TApp t1 t2)) = 
    case evalProgramStar (LPairr 5000 (Pg t1)) of
        (LPairr n (Pg t')) -> 
            LPairr n (Pg (TApp t2 t'))
        (LPairr n PgHole) ->
            LPairr n PgHole

{-@ reflect evalProgramStar @-}
{-@ evalProgramStar :: LPair Int Program -> LPair  Int (Program<{\v -> isValue v}>) @-} 
evalProgramStar :: LPair Int Program -> LPair Int Program
evalProgramStar (LPairr n p) =
    let (LPairr n' p') = evalProgramStar (evalProgram p) in
    LPairr (n + n') p'
```
