### PR TITLE
Add Sorts to Equations

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -733,7 +733,7 @@ defineP = do
   name   <- symbolP
   params <- parens        $ sepBy (symBindP sortP) comma
   sort   <- colon        *> sortP
-  body   <- reserved "=" *> exprP
+  body   <- reserved "=" *> predP 
   return  $ Equ name params body sort
 
 matchP :: Parser Rewrite

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -727,14 +727,12 @@ pairP xP sepP yP = (,) <$> xP <* sepP <*> yP
 ---------------------------------------------------------------------
 
 defineP :: Parser Equation
--- defineP = Equ <$> symbolP <*> many symbolP <*> (reserved "=" >> exprP)
-
 defineP = do
   name   <- symbolP
   params <- parens        $ sepBy (symBindP sortP) comma
   sort   <- colon        *> sortP
-  body   <- reserved "=" *> predP 
-  return  $ Equ name params body sort
+  body   <- reserved "=" *> predP
+  return  $ mkEquation name params body sort
 
 matchP :: Parser Rewrite
 matchP = SMeasure <$> symbolP <*> symbolP <*> many symbolP <*> (reserved "=" >> exprP)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -706,12 +706,13 @@ qualifierP :: Parser Sort -> Parser Qualifier
 qualifierP tP = do
   pos    <- getPosition
   n      <- upperIdP
-  params <- parens $ sepBy1 (sortBindP tP) comma
+  params <- parens $ sepBy1 (symBindP tP) comma
   _      <- colon
   body   <- predP
   return  $ mkQual n params body pos
-  where
-    sortBindP = pairP symbolP colon
+
+symBindP :: Parser a -> Parser (Symbol, a)
+symBindP = pairP symbolP colon
 
 pairP :: Parser a -> Parser z -> Parser b -> Parser (a, b)
 pairP xP sepP yP = (,) <$> xP <* sepP <*> yP
@@ -726,7 +727,14 @@ pairP xP sepP yP = (,) <$> xP <* sepP <*> yP
 ---------------------------------------------------------------------
 
 defineP :: Parser Equation
-defineP = Equ <$> symbolP <*> many symbolP <*> (reserved "=" >> exprP)
+-- defineP = Equ <$> symbolP <*> many symbolP <*> (reserved "=" >> exprP)
+
+defineP = do
+  name   <- symbolP
+  params <- parens        $ sepBy (symBindP sortP) comma
+  sort   <- colon        *> sortP
+  body   <- reserved "=" *> exprP
+  return  $ Equ name params body sort
 
 matchP :: Parser Rewrite
 matchP = SMeasure <$> symbolP <*> symbolP <*> many symbolP <*> (reserved "=" >> exprP)

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -54,11 +54,11 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
+                        (i,) . notracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi
-    aenv            = tracepp "AXIOM-ENV" (ae fi)
+    aenv            = {- tracepp "AXIOM-ENV" -} (ae fi)
 
 sInfo :: Config -> GInfo SimpC a -> SymEnv -> [(SubcId, Expr)] -> SInfo a
 sInfo cfg fi env ips = strengthenHyp fi' (notracepp "ELAB-INST:  " $ zip is ps'')
@@ -294,7 +294,7 @@ evaluate cfg ctx facts aenv einit
     -- no test needs it
     -- TODO: add a flag to enable it
     evalOne :: Expr -> IO [(Expr, Expr)]
-    evalOne e = tracepp ("evalOne e = " ++ showpp e) <$> do
+    evalOne e = {- notracepp ("evalOne e = " ++ showpp e) <$> -} do
       (e', st) <- runStateT (eval γ e) initEvalSt
       if e' == e then return [] else return ((e, e'):evSequence st)
 

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -397,18 +397,18 @@ evalApp _ _ (f, es)
 --   as coercions. See tests/proof/ple1.fq
 --------------------------------------------------------------------------------
 substEq :: SubstOp -> Equation -> [Expr] -> Expr -> EvalST Expr
-substEq o eq es bd = substEqVal o eq es <$> substEqSort eq es bd 
+substEq o eq es bd = substEqVal o eq es <$> substEqSort eq es bd
 
 substEqSort :: Equation -> [Expr] -> Expr -> EvalST Expr
-substEqSort = _fixme
+substEqSort eq es bd = return bd -- _fixme
 
 substEqVal :: SubstOp -> Equation -> [Expr] -> Expr -> Expr
 substEqVal o eq es bd = case o of
     PopIf  -> substPopIf     xes  bd
     Normal -> subst (mkSubst xes) bd
   where
-    xes     = zip xs es
-    xs      = eqArgNames eq
+    xes    =  zip xs es
+    xs     =  eqArgNames eq
 
 data SubstOp = PopIf | Normal
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -81,9 +81,9 @@ instSimpC :: Config -> SMT.Context -> BindEnv -> AxiomEnv
           -> IO Expr
 instSimpC _ _ _ aenv sid _
   | not (M.lookupDefault False sid (aenvExpand aenv))
-  = return PTrue
+  = return (tracepp "instSimpC 0:" PTrue)
 instSimpC cfg ctx bds aenv _ sub
-  = -- tracepp ("instSimpC " ++ show sid) .
+  = -- tracepp ("instSimpC 1: " ++ show sid) .
     pAnd . (is0 ++) <$>
     if rewriteAxioms cfg then evalEqs else return []
   where
@@ -278,8 +278,8 @@ data EvalEnv = EvalEnv { evId        :: Int
 type EvalST a = StateT EvalEnv IO a
 
 evaluate :: Config -> SMT.Context -> [(Symbol, SortedReft)] -> AxiomEnv
-            -> [Expr]
-            -> IO [(Expr, Expr)]
+         -> [Expr]
+         -> IO [(Expr, Expr)]
 evaluate cfg ctx facts aenv einit
   = (eqs ++) <$>
     (fmap join . sequence)
@@ -291,7 +291,7 @@ evaluate cfg ctx facts aenv einit
     -- no test needs it
     -- TODO: add a flag to enable it
     evalOne :: Expr -> IO [(Expr, Expr)]
-    evalOne e = do
+    evalOne e = tracepp ("evalOne e = " ++ showpp e) <$> do
       (e', st) <- runStateT (eval γ e) initEvalSt
       if e' == e then return [] else return ((e, e'):evSequence st)
 

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -54,7 +54,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) . notracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
+                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) (ae fi) i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -383,14 +383,14 @@ elab f@(_, g) e@(EBin o e1 e2) = do
 elab f (EApp e1@(EApp _ _) e2) = do
   (e1', _, e2', s2, s) <- notracepp "ELAB-EAPP" <$> elabEApp f e1 e2
   let e = eAppC s e1' (ECst e2' s2)
-  let θ = unifyExpr (snd f) e 
-  return (applyExpr θ e, maybe s (`apply` s) θ) 
+  let θ = unifyExpr (snd f) e
+  return (applyExpr θ e, maybe s (`apply` s) θ)
 
 elab f (EApp e1 e2) = do
   (e1', s1, e2', s2, s) <- elabEApp f e1 e2
   let e = eAppC s (ECst e1' s1) (ECst e2' s2)
-  let θ = unifyExpr (snd f) e 
-  return (applyExpr θ e, maybe s (`apply` s) θ) 
+  let θ = unifyExpr (snd f) e
+  return (applyExpr θ e, maybe s (`apply` s) θ)
 
 elab _ e@(ESym _) =
   return (e, strSort)
@@ -640,10 +640,13 @@ applySorts = {- tracepp "applySorts" . -} (defs ++) . Vis.fold vis () []
 -- | Expressions sort  ---------------------------------------------------------
 --------------------------------------------------------------------------------
 exprSort :: String -> Expr -> Sort
-exprSort msg e =
-  case exprSort_maybe e of
-    Nothing -> errorstar ("\nexprSort [" ++ msg ++ "] on unexpected expressions " ++ show e)
-    Just s  -> s 
+exprSort msg e = fromMaybe (panic err) (exprSort_maybe e)
+  where
+    err        = printf "exprSort [%s] on unexpected expression %s" msg (show e)
+
+  -- case exprSort_maybe e of
+  --  Nothing -> errorstar ("\nexprSort [" ++ msg ++ "] on unexpected expressions " ++ show e)
+  --  Just s  -> s
 
 
 exprSort_maybe :: Expr -> Maybe Sort
@@ -668,10 +671,9 @@ unite f e t1 t2 = do
 
 -- | Helper for checking symbol occurrences
 checkSym :: Env -> Symbol -> CheckM Sort
-checkSym f x
-  = case f x of
-     Found s -> instantiate s
-     Alts xs -> throwError $ errUnboundAlts x xs
+checkSym f x = case f x of
+  Found s -> instantiate s
+  Alts xs -> throwError (errUnboundAlts x xs)
 
 -- | Helper for checking if-then-else expressions
 checkIte :: Env -> Expr -> Expr -> Expr -> CheckM Sort
@@ -781,7 +783,7 @@ checkEqConstr _ _  θ a (FObj b)
   | a == b
   = return θ
 checkEqConstr f e θ a t = do
-  case f a of 
+  case f a of
     Found tA -> do unless (tA == t) (throwError $ errUnify e tA t)
                    return θ
     _        -> throwError $ errUnify e (FObj a) t
@@ -842,22 +844,22 @@ checkRelTy _ e _  t1 t2      = unless (t1 == t2) (throwError $ errRel e t1 t2)
 unifyExpr :: Env -> Expr -> Maybe TVSubst
 unifyExpr f (EApp e1 e2) = Just $ mconcat $ catMaybes [θ1, θ2, θ]
   where
-   θ1 = unifyExpr f e1 
-   θ2 = unifyExpr f e2 
-   θ  = unifyExprApp f e1 e2 
+   θ1 = unifyExpr f e1
+   θ2 = unifyExpr f e2
+   θ  = unifyExprApp f e1 e2
 unifyExpr f (ECst e _)
-  = unifyExpr f e 
-unifyExpr _ _ 
+  = unifyExpr f e
+unifyExpr _ _
   = Nothing
 
 unifyExprApp :: Env -> Expr -> Expr -> Maybe TVSubst
-unifyExprApp f e1 e2 = do 
-  t1 <- getArg $ exprSort_maybe e1 
-  t2 <- exprSort_maybe e2 
-  unify f (Just $ EApp e1 e2) t1 t2 
+unifyExprApp f e1 e2 = do
+  t1 <- getArg $ exprSort_maybe e1
+  t2 <- exprSort_maybe e2
+  unify f (Just $ EApp e1 e2) t1 t2
   where
-    getArg (Just (FFunc t1 _)) = Just t1 
-    getArg _                   = Nothing 
+    getArg (Just (FFunc t1 _)) = Just t1
+    getArg _                   = Nothing
 
 
 --------------------------------------------------------------------------------
@@ -1009,18 +1011,18 @@ apply θ          = Vis.mapSort f
 applyExpr :: Maybe TVSubst -> Expr -> Expr
 applyExpr Nothing e  = e
 applyExpr (Just θ) e = Vis.mapExpr f e
-  where 
+  where
     f (ECst e s) = ECst e (apply θ s)
-    f e          = e 
+    f e          = e
 
 --------------------------------------------------------------------------------
-applyCoercion :: Symbol -> Sort -> Sort -> Sort 
+applyCoercion :: Symbol -> Sort -> Sort -> Sort
 --------------------------------------------------------------------------------
-applyCoercion a t = Vis.mapSort f 
-  where 
-    f (FObj b)  
-      | a == b    = t 
-    f s           = s 
+applyCoercion a t = Vis.mapSort f
+  where
+    f (FObj b)
+      | a == b    = t
+    f s           = s
 
 
 --------------------------------------------------------------------------------
@@ -1042,7 +1044,7 @@ newtype TVSubst = Th (M.HashMap Int Sort) deriving (Show)
 
 instance Monoid TVSubst where
   mempty                  = Th mempty
-  mappend (Th s1) (Th s2) = Th (mappend s1 s2) 
+  mappend (Th s1) (Th s2) = Th (mappend s1 s2)
 
 lookupVar :: Int -> TVSubst -> Maybe Sort
 lookupVar i (Th m)   = M.lookup i m

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -766,11 +766,15 @@ instance NFData SMTSolver
 instance NFData Eliminate
 
 instance Monoid AxiomEnv where
-  mempty = AEnv [] [] (M.fromList [])
-  mappend a1 a2 = AEnv aenvEqs' aenvSimpl' aenvExpand'
-    where aenvEqs'     = mappend (aenvEqs a1) (aenvEqs a2)
-          aenvSimpl'   = mappend (aenvSimpl a1) (aenvSimpl a2)
-          aenvExpand'  = mappend (aenvExpand a1) (aenvExpand a2)
+  mempty           = AEnv [] [] (M.fromList [])
+  mappend a1 a2    = AEnv aenvEqs' aenvSimpl' aenvExpand'
+    where
+      aenvEqs'     = mappend (aenvEqs a1) (aenvEqs a2)
+      aenvSimpl'   = mappend (aenvSimpl a1) (aenvSimpl a2)
+      aenvExpand'  = mappend (aenvExpand a1) (aenvExpand a2)
+
+instance PPrint AxiomEnv where
+  pprintTidy _ = text . show
 
 data Equation = Equ { eqName :: Symbol            -- ^ name of reflected function
                     , eqArgs :: [(Symbol, Sort)]  -- ^ names of parameters

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -779,6 +779,15 @@ data Equation = Equ { eqName :: Symbol            -- ^ name of reflected functio
                     }
   deriving (Eq, Show, Generic)
 
+instance Subable Equation where
+  syms   a = syms (eqBody a) -- ++ F.syms (axiomEq a)
+  subst su = mapEqBody (subst su)
+  substf f = mapEqBody (substf f)
+  substa f = mapEqBody (substa f)
+
+mapEqBody :: (Expr -> Expr) -> Equation -> Equation
+mapEqBody f a = a { eqBody = f (eqBody a) }
+
 instance PPrint Equation where
   pprintTidy k (Equ f xs e _) = "def" <+> pprint f <+> ppArgs xs <+> ":=" <+> pprintTidy k e
     where

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -266,8 +266,8 @@ unsafe, safe :: Result a
 unsafe = mempty {resStatus = Unsafe []}
 safe   = mempty {resStatus = Safe}
 
-isSafe :: Result a -> Bool 
-isSafe (Result Safe _ _) = True 
+isSafe :: Result a -> Bool
+isSafe (Result Safe _ _) = True
 isSafe _                 = False
 
 isUnsafe :: Result a -> Bool
@@ -773,8 +773,8 @@ instance Monoid AxiomEnv where
           aenvExpand'  = mappend (aenvExpand a1) (aenvExpand a2)
 
 data Equation = Equ { eqName :: Symbol
-                    , eqArgs :: [Symbol]
-                    , eqBody :: Expr
+                    , eqArgs :: [(Symbol, Sort)]
+                    , eqBody :: (Expr, Sort)
                     }
   deriving (Eq, Show, Generic)
 

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -70,7 +70,6 @@ module Language.Fixpoint.Types.Constraints (
   , AxiomEnv (..)
   , Equation (..)
   , Rewrite  (..)
-  , getEqBody
 
   -- * Misc  [should be elsewhere but here due to dependencies]
   , substVars
@@ -826,14 +825,3 @@ instance Fixpoint Rewrite where
    <+> parens (toFix d <+> hsep (toFix <$> xs))
    <+> text " = "
    <+> lparen <> toFix e <> rparen
-
-getEqBody :: Equation -> Maybe Expr
-getEqBody (Equ  x xts (PAnd ((PAtom Eq fxs e):_)) _)
-  | (EVar f, es) <- splitEApp fxs
-  , f == x
-  , es == (EVar . fst <$> xts)
-  = Just e
-  where
-
-getEqBody _
-  = Nothing

--- a/src/Language/Fixpoint/Types/Spans.hs
+++ b/src/Language/Fixpoint/Types/Spans.hs
@@ -16,6 +16,7 @@ module Language.Fixpoint.Types.Spans (
 
   -- * Constructing spans
   , dummySpan
+  , panicSpan
   , locAt
   , dummyLoc
   , dummyPos
@@ -174,8 +175,11 @@ instance Loc () where
   srcSpan _ = dummySpan
 
 dummySpan :: SrcSpan
-dummySpan = SS l l
-  where l = initialPos ""
+dummySpan = panicSpan ""
+
+panicSpan :: String -> SrcSpan
+panicSpan s = SS l l
+  where l = initialPos s
 
 -- atLoc :: Located a -> b -> Located b
 -- atLoc (Loc l l' _) = Loc l l'

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -39,10 +39,10 @@ catSubst (Su s1) θ2@(Su s2) = Su $ M.union s1' s2
 
 mkSubst :: [(Symbol, Expr)] -> Subst
 
-mkSubst = Su . M.fromList . reverse . filter notTrivial 
+mkSubst = Su . M.fromList . reverse . filter notTrivial
   where
     notTrivial (x, EVar y) = x /= y
-    notTrivial _           = True  
+    notTrivial _           = True
 
 isEmptySubst :: Subst -> Bool
 isEmptySubst (Su xes) = M.null xes
@@ -128,7 +128,7 @@ instance Subable Expr where
 
   subst su (EApp f e)      = EApp (subst su f) (subst su e)
   subst su (ELam x e)      = ELam x (subst (removeSubst su (fst x)) e)
-  subst su (ECoerc a t e)  = ECoerc a t (subst su e) 
+  subst su (ECoerc a t e)  = ECoerc a t (subst su e)
   subst su (ENeg e)        = ENeg (subst su e)
   subst su (EBin op e1 e2) = EBin op (subst su e1) (subst su e2)
   subst su (EIte p e1 e2)  = EIte (subst su p) (subst su e1) (subst su e2)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
+
+resolver: lts-8.9
+
 flags:
   liquid-fixpoint:
     devel: true 
@@ -9,7 +12,5 @@ extra-deps:
 - fgl-visualize-0.1.0.1
 - intern-0.9.1.4
 - located-base-0.1.1.0
-
-resolver: lts-8.9
 
 # resolver: nightly-2016-05-21

--- a/tests/proof/ple0.fq
+++ b/tests/proof/ple0.fq
@@ -1,0 +1,13 @@
+fixpoint "--rewrite"
+
+constant adder: (func(0, [int; int; int]))
+
+define adder(x : int, y : int) : int = ((adder x y) = (x + y))
+
+expand [1 : True]
+
+constraint:
+  env []
+  lhs {v : int | true }
+  rhs {v : int | (adder 5 6) = 11 }
+  id 1 tag []

--- a/tests/proof/ple1.fq
+++ b/tests/proof/ple1.fq
@@ -1,0 +1,17 @@
+fixpoint "--rewrite"
+
+constant foo: (func(1, [@(0)  ; int]))
+constant bar: (func(0, [Bob   ; int]))
+
+define foo(x : alpha) : int = (foo x = coerce (alpha ~ Bob) (bar x))
+define bar(y : Bob)   : int = (bar y = 22)
+
+expand [1 : True]
+
+bind 0 z : {v: beta | true }
+
+constraint:
+  env []
+  lhs {v : int | true }
+  rhs {v : int | (foo z) = 22 }
+  id 1 tag []


### PR DESCRIPTION
Add the input/output `Sort`s for equations, e.g. see:

- `tests/proof/ple0.fq`
- `tests/proof/ple1.fq`


We need the `Sort` to properly update the `coerce a ~ t in e` terms when doing PLE, e.g. as needed to support GADTs as in ucsd-progsys/liquidhaskell#1089
