### PR TITLE
Restore `assertSelectors` 

### DIFF
--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -399,6 +399,11 @@ allCombinations xs = assert (and . map (((length xs) == ) . length)) $ go xs
 powerset :: [a] -> [[a]]
 powerset xs = filterM (const [False, True]) xs
 
+(=>>) :: Monad m => m b -> (b -> m a) -> m b
+(=>>) m f = m >>= (\x -> f x >> return x)
+
+(<<=) :: Monad m => (b -> m a) -> m b -> m b
+(<<=) = flip (=>>)
 
 (<$$>) ::  (Monad m) => (a -> m b) -> [a] -> m [b]
 _ <$$> []           = return []

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -19,6 +19,7 @@ import           Language.Fixpoint.Types
 import           Language.Fixpoint.Types.Config  as FC
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import qualified Language.Fixpoint.Misc          as Misc -- (mapFst)
+import           Language.Fixpoint.Misc          ((<<=))
 import qualified Language.Fixpoint.Smt.Interface as SMT
 import           Language.Fixpoint.Defunctionalize
 import           Language.Fixpoint.SortCheck
@@ -33,13 +34,12 @@ import qualified Data.HashMap.Strict  as M
 import qualified Data.List            as L
 import           Data.Maybe           (catMaybes, fromMaybe)
 import           Data.Char            (isUpper)
-import           Data.Foldable        (foldlM)
+-- import           Text.Printf (printf)
 
 (~>) :: (Expr, String) -> Expr -> EvalST Expr
 (_e,_str) ~> e' = do
-    modify (\st -> st{evId = evId st + 1})
-    -- traceM $ showpp _str ++ " : " ++ showpp _e ++ showpp e'
-    return (η e')
+    modify (\st -> st {evId = evId st + 1})
+    return (wtf e')
 
 
 --------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) . notracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
+                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi
@@ -116,11 +116,9 @@ unApply = Vis.trans (Vis.defaultVisitor { Vis.txExpr = const go }) () ()
 --------------------------------------------------------------------------------
 -- | Knowledge (SMT Interaction)
 --------------------------------------------------------------------------------
--- AT:@TODO: knSels and knEqs should really just be the same thing. In this way,
--- we should also unify knSims and knAms, as well as their analogues in AxiomEnv
+-- AT:@TODO: should unify knSims and knAms, as well as their analogues in AxiomEnv
 data Knowledge
-  = KN { knSels    :: ![(Expr, Expr)]
-       , knEqs     :: ![(Expr, Expr)]
+  = KN { knEqs     :: ![(Expr, Expr)]
        , knSims    :: ![Rewrite]
        , knAms     :: ![Equation]
        , knContext :: IO SMT.Context
@@ -129,17 +127,12 @@ data Knowledge
        }
 
 emptyKnowledge :: IO SMT.Context -> Knowledge
-emptyKnowledge ctx = KN [] [] [] [] ctx (\_ _ _ -> return False) []
+emptyKnowledge ctx = KN [] [] [] ctx (\_ _ _ -> return False) []
 
+-- | 'lookupKnowledge' is a hack to support 0-ary functions
+--   e.g. `mempty = Emp` in MonoidList.hs
 lookupKnowledge :: Knowledge -> Expr -> Maybe Expr
-lookupKnowledge γ e
-  -- Zero argument axioms like `mempty = N`
-  | Just e' <- L.lookup e (knEqs γ)
-  = Just e'
-  | Just e' <- L.lookup e (knSels γ)
-  = Just e'
-  | otherwise
-  = Nothing
+lookupKnowledge γ e = L.lookup e (knEqs γ)
 
 isValid :: Knowledge -> Expr -> IO Bool
 isValid γ b = knPreds γ (knLams γ) b =<< knContext γ
@@ -148,8 +141,7 @@ makeKnowledge :: Config -> SMT.Context -> AxiomEnv
                  -> [(Symbol, SortedReft)]
                  -> ([(Expr, Expr)], Knowledge)
 makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
-                                     { knSels   = sels
-                                     , knEqs    = eqs
+                                     { knEqs    = eqs ++ sels
                                      , knSims   = aenvSimpl aenv
                                      , knAms    = aenvEqs aenv
                                      , knPreds  = \bs e c -> askSMT c bs e
@@ -166,12 +158,9 @@ makeKnowledge cfg ctx aenv es = (simpleEqs,) $ (emptyKnowledge context)
                               ))
       return ctx
 
-    -- This creates the rewrite rule e1 -> e2
-    -- when should I apply it?
+    -- This creates the rewrite rule e1 -> e2. When should I apply it?
     -- 1. when e2 is a data con and can lead to further reductions
     -- 2. when size e2 < size e1
-    -- @TODO: Can this be generalized?
-    -- simpleEqs = []
     simpleEqs = {- tracepp "SIMPLEEQS" $ -} makeSimplifications (aenvSimpl aenv) =<<
                L.nub (catMaybes [_getDCEquality e1 e2 | PAtom Eq e1 e2 <- atms])
     atms = splitPAnd =<< (expr <$> filter isProof es)
@@ -269,35 +258,50 @@ splitPAnd e         = [e]
    care of it. However, in practice, some constructors, e.g. from
    GADTs cannot be directly encoded in SMT due to the lack of SMTLIB
    support for GADT. Hence, we still need to hang onto this code.
-   TODO: a concrete .fq test that illustrates why this is needed.
+
+   See tests/proof/ple2.fq for a concrete example.
  -}
 
 assertSelectors :: Knowledge -> Expr -> EvalST ()
+assertSelectors _ _ = return ()
+{- TODO: HEREHEREHEREHEREHEREHERE
+  1. DOES this kill Unification.hs? (Guard under --no-adt)
+  2. Use addEquality instead off _addSMTEquality.
+   
 assertSelectors γ e = do
     sims <- aenvSimpl <$> gets evAEnv
-    _    <- foldlM (\_ s -> Vis.mapMExpr (go s) e) e sims
+    -- _    <- foldlM (\_ s -> Vis.mapMExpr (go s) e) (tracepp "assertSelector" e) sims
+    forM_ sims $ \s -> do
+      Vis.mapMExpr (go s) (tracepp "assertSelectors" e)
     return ()
   where
     go :: Rewrite -> Expr -> EvalST Expr
     go (SMeasure f dc xs bd) e@(EApp _ _)
-      | (EVar dc', es) <- splitEApp e
-      , dc == dc', length xs == length es
-      = addSMTEquality γ (EApp (EVar f) e) (subst (mkSubst $ zip xs es) bd)
-      >> return e
+      | (EVar dc', es) <- mySplitEApp e
+      , tracepp (printf "DC-check %s %s" (show dc) (show dc')) $ dc == dc'
+      , tracepp (printf "len-check %s %s" (show xs) (show es)) $ length xs == length es
+      = do let e1 = (EApp (EVar f) e)
+           let e2 = (subst (mkSubst $ zip xs es) bd)
+           addEquality γ e1 e2
+           return e
     go _ e
       = return e
 
-addSMTEquality :: Knowledge -> Expr -> Expr -> EvalST (IO ())
-addSMTEquality γ e1 e2 = return $ do
+mySplitEApp :: Expr -> (Expr, [Expr])
+mySplitEApp e = tracepp "mySplitEApp" $ splitEApp e
+-}
+
+_addSMTEquality :: Knowledge -> Expr -> Expr -> IO ()
+_addSMTEquality γ e1 e2 = do
   ctx <- knContext γ
-  SMT.smtAssert ctx (PAtom Eq (makeLam γ e1) (makeLam γ e2))
+  SMT.smtAssert ctx (tracepp "addSMTEQ" (PAtom Eq (makeLam γ e1) (makeLam γ e2)))
 
 --------------------------------------------------------------------------------
 -- | Symbolic Evaluation with SMT
 --------------------------------------------------------------------------------
 data EvalEnv = EvalEnv { evId        :: Int
                        , evSequence  :: [(Expr,Expr)]
-                       , evAEnv     :: AxiomEnv
+                       , _evAEnv     :: AxiomEnv
                        , evEnv      :: !SymEnv
                        }
 
@@ -399,14 +403,14 @@ evalApp γ e (EVar f, [ex])
   | (EVar dc, es) <- splitEApp ex
   , Just simp <- L.find (\simp -> (smName simp == f) && (smDC simp == dc)) (knSims γ)
   , length (smArgs simp) == length es
-  = do e'    <- eval γ $ η $ substPopIf (zip (smArgs simp) es) (smBody simp)
+  = do e'    <- eval γ $ wtf $ substPopIf (zip (smArgs simp) es) (smBody simp)
        (e, "Rewrite -" ++ showpp f) ~> e'
 evalApp γ _ (EVar f, es)
   | Just eq <- L.find ((==f) . eqName) (knAms γ)
   , Just bd <- getEqBody eq
   , length (eqArgs eq) == length es
   , f `notElem` syms bd               -- non-recursive equations
-  = eval γ . η =<< substEq PopIf eq es bd
+  = eval γ . wtf =<< assertSelectors γ <<= substEq PopIf eq es bd
 
 evalApp γ _e (EVar f, es)
   | Just eq <- L.find ((==f) . eqName) (knAms γ)
@@ -496,7 +500,7 @@ eqArgNames :: Equation -> [Symbol]
 eqArgNames = map fst . eqArgs
 
 substPopIf :: [(Symbol, Expr)] -> Expr -> Expr
-substPopIf xes e = η $ L.foldl' go e xes
+substPopIf xes e = wtf $ L.foldl' go e xes
   where
     go e (x, EIte b e1 e2) = EIte b (subst1 e (x, e1)) (subst1 e (x, e2))
     go e (x, ex)           = subst1 e (x, ex)
@@ -506,22 +510,22 @@ evalRecApplication γ e (EIte b e1 e2)
   = do b' <- eval γ b
        b'' <- liftIO (isValid γ b')
        if b''
-          then addApplicationEq γ e e1 >>
+          then addEquality γ e e1 >>
                ({-# SCC "assertSelectors-1" #-} assertSelectors γ e1) >>
                eval γ e1 >>=
                ((e, "App") ~>)
           else do b''' <- liftIO (isValid γ (PNot b'))
                   if b'''
-                     then addApplicationEq γ e e2 >>
-                          ({-# SCC "assertSelectors-1" #-} assertSelectors γ e2) >>
+                     then addEquality γ e e2 >>
+                          ({-# SCC "assertSelectors-2" #-} assertSelectors γ e2) >>
                           eval γ e2 >>=
                           ((e, "App") ~>)
                      else return e
 evalRecApplication _ _ e
   = return e
 
-addApplicationEq :: Knowledge -> Expr -> Expr -> EvalST ()
-addApplicationEq γ e1 e2 =
+addEquality :: Knowledge -> Expr -> Expr -> EvalST ()
+addEquality γ e1 e2 =
   modify (\st -> st{evSequence = (makeLam γ e1, makeLam γ e2):evSequence st})
 
 evalIte :: Knowledge -> Expr -> Expr -> Expr -> Expr -> EvalST Expr
@@ -545,10 +549,14 @@ evalIte' γ _ b e1 e2 _ _
        e2' <- eval γ e2
        return $ EIte b e1' e2'
 
+--------------------------------------------------------------------------------
 -- normalization required by ApplicativeMaybe.composition
----------------------------------------------------------
-η :: Expr -> Expr
-η = snd . go
+--------------------------------------------------------------------------------
+-- RJ: What on earth is this function doing?
+wtf :: Expr -> Expr
+wtf = id
+{-
+wtf = snd . go
   where
     go (EIte b t f)
       | isTautoPred t && isFalse f
@@ -572,5 +580,6 @@ evalIte' γ _ b e1 e2 _ _
               else (False, EApp e1' e2')
     go e = (False, e)
 
+-}
 instance Expression (Symbol, SortedReft) where
   expr (x, RR _ (Reft (v, r))) = subst1 (expr r) (v, EVar x)

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -56,41 +56,40 @@ defaultMaxPartSize :: Int
 defaultMaxPartSize = 700
 
 
-data Config
-  = Config {
-      srcFile     :: FilePath            -- ^ src file (*.hs, *.ts, *.c, or even *.fq or *.bfq)
-    , cores       :: Maybe Int           -- ^ number of cores used to solve constraints
-    , minPartSize :: Int                 -- ^ Minimum size of a partition
-    , maxPartSize :: Int                 -- ^ Maximum size of a partition. Overrides minPartSize
-    , solver      :: SMTSolver           -- ^ which SMT solver to use
-    , linear      :: Bool                -- ^ not interpret div and mul in SMT
-    , stringTheory :: Bool               -- ^ interpretation of string theory by SMT
-    , defunction  :: Bool                -- ^ defunctionalize (use 'apply' for all uninterpreted applications)
-    , allowHO     :: Bool                -- ^ allow higher order binders in the logic environment
-    , allowHOqs   :: Bool                -- ^ allow higher order qualifiers
-    , eliminate   :: Eliminate           -- ^ eliminate non-cut KVars
-    , elimBound   :: Maybe Int           -- ^ maximum length of KVar chain to eliminate
-    , elimStats   :: Bool                -- ^ print eliminate stats
-    , solverStats :: Bool                -- ^ print solver stats
-    , metadata    :: Bool                -- ^ print meta-data associated with constraints
-    , stats       :: Bool                -- ^ compute constraint statistics
-    , parts       :: Bool                -- ^ partition FInfo into separate fq files
-    , save        :: Bool                -- ^ save FInfo as .bfq and .fq file
-    , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
-    , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
-    , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
-    , minimalSol  :: Bool                -- ^ shrink final solution by pruning redundant qualfiers from fixpoint
-    , gradual     :: Bool                -- ^ solve "gradual" constraints
-    , ginteractive :: Bool                -- ^ interactive gradual solving
-    , extensionality   :: Bool           -- ^ allow function extensionality
-    , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
-    , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
-    , normalForm       :: Bool           -- ^ allow lambda normal-form equivalence axioms
-    , autoKuts         :: Bool           -- ^ ignore given kut variables
-    , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
-    , noslice          :: Bool           -- ^ Disable non-concrete KVar slicing
-    , rewriteAxioms    :: Bool           -- ^ allow axiom instantiation via rewriting
-    } deriving (Eq,Data,Typeable,Show,Generic)
+data Config = Config
+  { srcFile     :: FilePath            -- ^ src file (*.hs, *.ts, *.c, or even *.fq or *.bfq)
+  , cores       :: Maybe Int           -- ^ number of cores used to solve constraints
+  , minPartSize :: Int                 -- ^ Minimum size of a partition
+  , maxPartSize :: Int                 -- ^ Maximum size of a partition. Overrides minPartSize
+  , solver      :: SMTSolver           -- ^ which SMT solver to use
+  , linear      :: Bool                -- ^ not interpret div and mul in SMT
+  , stringTheory :: Bool               -- ^ interpretation of string theory by SMT
+  , defunction  :: Bool                -- ^ defunctionalize (use 'apply' for all uninterpreted applications)
+  , allowHO     :: Bool                -- ^ allow higher order binders in the logic environment
+  , allowHOqs   :: Bool                -- ^ allow higher order qualifiers
+  , eliminate   :: Eliminate           -- ^ eliminate non-cut KVars
+  , elimBound   :: Maybe Int           -- ^ maximum length of KVar chain to eliminate
+  , elimStats   :: Bool                -- ^ print eliminate stats
+  , solverStats :: Bool                -- ^ print solver stats
+  , metadata    :: Bool                -- ^ print meta-data associated with constraints
+  , stats       :: Bool                -- ^ compute constraint statistics
+  , parts       :: Bool                -- ^ partition FInfo into separate fq files
+  , save        :: Bool                -- ^ save FInfo as .bfq and .fq file
+  , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
+  , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
+  , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
+  , minimalSol  :: Bool                -- ^ shrink final solution by pruning redundant qualfiers from fixpoint
+  , gradual     :: Bool                -- ^ solve "gradual" constraints
+  , ginteractive :: Bool                -- ^ interactive gradual solving
+  , extensionality   :: Bool           -- ^ allow function extensionality
+  , alphaEquivalence :: Bool           -- ^ allow lambda alpha equivalence axioms
+  , betaEquivalence  :: Bool           -- ^ allow lambda beta equivalence axioms
+  , normalForm       :: Bool           -- ^ allow lambda normal-form equivalence axioms
+  , autoKuts         :: Bool           -- ^ ignore given kut variables
+  , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
+  , noslice          :: Bool           -- ^ Disable non-concrete KVar slicing
+  , rewriteAxioms    :: Bool           -- ^ allow axiom instantiation via rewriting
+  } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
   def = defConfig

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -831,4 +831,4 @@ instance Fixpoint Rewrite where
    <+> toFix f
    <+> parens (toFix d <+> hsep (toFix <$> xs))
    <+> text " = "
-   <+> lparen <> toFix e <> rparen
+   <+> parens (toFix e)

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -806,11 +806,12 @@ ppArgs = parens . intersperse ", " . fmap pprint
 
 -- eg  SMeasure (f D [x1..xn] e)
 -- for f (D x1 .. xn) = e
-data Rewrite  = SMeasure  { smName  :: Symbol         -- eg. f
-                          , smDC    :: Symbol         -- eg. D
-                          , smArgs  :: [Symbol]       -- eg. xs
-                          , smBody  :: Expr           -- eg. e[xs]
-                          }
+data Rewrite  = SMeasure
+  { smName  :: Symbol         -- eg. f
+  , smDC    :: Symbol         -- eg. D
+  , smArgs  :: [Symbol]       -- eg. xs
+  , smBody  :: Expr           -- eg. e[xs]
+  }
   deriving (Eq, Show, Generic)
 
 instance Fixpoint AxiomEnv where
@@ -832,3 +833,6 @@ instance Fixpoint Rewrite where
    <+> parens (toFix d <+> hsep (toFix <$> xs))
    <+> text " = "
    <+> parens (toFix e)
+
+instance PPrint Rewrite where
+  pprintTidy _ = toFix

--- a/tests/proof/ple2.fq
+++ b/tests/proof/ple2.fq
@@ -1,0 +1,20 @@
+fixpoint "--rewrite"
+
+constant mkQQ  : (func(0, [int; QQ]))
+constant QQ    : (func(0, [int; QQ]))
+constant selQQ : (func(0, [QQ; int]))
+
+match selQQ QQ x = (x)
+
+define mkQQ(n : int) : QQ = (((mkQQ n) = (QQ n)))
+define QQ(z : int) : QQ   = ((selQQ (QQ z)) = z)
+
+expand [1 : True]
+
+bind 0 z : {v: QQ | v = mkQQ 10 }
+
+constraint:
+  env []
+  lhs {v : QQ | v = mkQQ 10  }
+  rhs {v : QQ | selQQ v = 10 }
+  id 1 tag []


### PR DESCRIPTION
In theory `assertSelectors` is subsumed by SMTLIB ADT, but in practice, we need it for those cases where ADTs cannot be used, e.g. when encoding GADTs or family instances and such like.

For an example, see:

- `tests/proof/ple2.fq`

Matching PR for https://github.com/ucsd-progsys/liquidhaskell/pull/1178


