### PR TITLE
Make CoSub visible externally

### DIFF
--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -418,14 +418,13 @@ substEqCoerce eq es bd = do
   let ts    = snd    <$> eqArgs eq
   let sp    = panicSpan "mkCoSub"
   let eTs   = sortExpr sp env <$> es
-  let coSub = tracepp ("substEqCoerce" ++ showpp (eqName eq, es, eTs, ts)) $ mkCoSub env eTs ts
+  let coSub = tracepp ("substEqCoerce" ++ showpp (eqName eq, es, eTs, ts)) $ mkCoSub eTs ts
   return    $ Vis.applyCoSub coSub bd
 
-mkCoSub :: SEnv Sort -> [Sort] -> [Sort] -> Vis.CoSub
-mkCoSub env eTs xTs = Misc.safeFromList "mkCoSub" xys
+mkCoSub :: [Sort] -> [Sort] -> Vis.CoSub
+mkCoSub eTs xTs = Misc.safeFromList "mkCoSub" xys
   where
-    sp              = panicSpan "mkCoSub"
-    xys             = concat (zipWith matchSorts xTs eTs)
+    xys         = concat (zipWith matchSorts xTs eTs)
 
 matchSorts :: Sort -> Sort -> [(Symbol, Sort)]
 matchSorts s1 s2 = tracepp ("matchSorts :" ++ show (s1, s2)) $ go s1 s2

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -417,15 +417,9 @@ substEqCoerce eq es bd = do
   env      <- seSort <$> gets evEnv
   let ts    = snd    <$> eqArgs eq
   let coSub = mkCoSub env es ts
-  return    $ applyCoSub coSub bd
+  return    $ Vis.applyCoSub coSub bd
 
--- | @CoSub@ is a map from (coercion) ty-vars represented as 'FObj s'
---   to the ty-vars that they should be substituted with. Note the
---   domain and range are both Symbol and not the Int used for real ty-vars.
-
-type CoSub = M.HashMap Symbol Symbol
-
-mkCoSub :: SEnv Sort -> [Expr] -> [Sort] -> CoSub
+mkCoSub :: SEnv Sort -> [Expr] -> [Sort] -> Vis.CoSub
 mkCoSub env es xTs = Misc.safeFromList "mkCoSub" xys
   where
     eTs            = sortExpr sp env <$> es
@@ -440,16 +434,6 @@ matchSorts = go
     go (FFunc s1 t1) (FFunc s2 t2) = go s1 s2 ++ go t1 t2
     go (FApp s1 t1)  (FApp s2 t2)  = go s1 s2 ++ go t1 t2
     go _             _             = []
-
-applyCoSub :: CoSub -> Expr -> Expr
-applyCoSub coSub      = Vis.mapExpr fE
-  where
-    fE (ECoerc s t e) = ECoerc (txS s) (txS t) e
-    fE e              = e
-    txS               = Vis.mapSort fS
-    fS (FObj a)       = FObj   (txV a)
-    fS t              = t
-    txV a             = M.lookupDefault a a coSub
 
 --------------------------------------------------------------------------------
 getEqBody :: Equation -> Maybe Expr

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -54,7 +54,7 @@ instantiate' :: Config -> GInfo SimpC a -> IO (SInfo a)
 instantiate' cfg fi = sInfo cfg fi env <$> withCtx cfg file env act
   where
     act ctx         = forM cstrs $ \(i, c) ->
-                        (i,) . tracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
+                        (i,) . notracepp ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs fi) aenv i c
     cstrs           = M.toList (cm fi)
     file            = srcFile cfg ++ ".evals"
     env             = symbolEnv cfg fi

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -240,7 +240,7 @@ type LocSymbol = Located Symbol
 type LocText   = Located T.Text
 
 isDummy :: (Symbolic a) => a -> Bool
-isDummy a = symbol a == symbol dummyName
+isDummy a = isPrefixOfSym (symbol dummyName) (symbol a)
 
 instance Symbolic a => Symbolic (Located a) where
   symbol = symbol . val

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -334,7 +334,8 @@ type CoSub = M.HashMap Symbol Symbol
 applyCoSub :: CoSub -> Expr -> Expr
 applyCoSub coSub      = mapExpr fE
   where
-    fE (ECoerc s t e) = ECoerc (txS s) (txS t) e
+    fE (ECoerc s t e) = ECoerc  (txS s) (txS t) e
+    fE (ELam (x,t) e) = ELam (x, txS t)         e
     fE e              = e
     txS               = mapSort fS
     fS (FObj a)       = FObj   (txV a)

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -34,7 +34,7 @@ module Language.Fixpoint.Types.Visitor (
   , mapExpr, mapMExpr
 
   -- * Coercion Substitutions
-  , CoSub (..)
+  , CoSub
   , applyCoSub
 
   -- * Predicates on Constraints

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -33,6 +33,10 @@ module Language.Fixpoint.Types.Visitor (
   , mapKVars, mapKVars', mapGVars', mapKVarSubsts
   , mapExpr, mapMExpr
 
+  -- * Coercion Substitutions
+  , CoSub (..)
+  , applyCoSub
+
   -- * Predicates on Constraints
   , isConcC , isKvarC
 
@@ -318,6 +322,24 @@ stripCasts = trans (defaultVisitor { txExpr = const go }) () ()
 --  where
 --    go (ECst e _) = e
 --    go e          = e
+
+--------------------------------------------------------------------------------
+-- | @CoSub@ is a map from (coercion) ty-vars represented as 'FObj s'
+--   to the ty-vars that they should be substituted with. Note the
+--   domain and range are both Symbol and not the Int used for real ty-vars.
+--------------------------------------------------------------------------------
+
+type CoSub = M.HashMap Symbol Symbol
+
+applyCoSub :: CoSub -> Expr -> Expr
+applyCoSub coSub      = mapExpr fE
+  where
+    fE (ECoerc s t e) = ECoerc (txS s) (txS t) e
+    fE e              = e
+    txS               = mapSort fS
+    fS (FObj a)       = FObj   (txV a)
+    fS t              = t
+    txV a             = M.lookupDefault a a coSub
 
 ---------------------------------------------------------------------------------
 -- | Visitors over @Sort@

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -329,7 +329,7 @@ stripCasts = trans (defaultVisitor { txExpr = const go }) () ()
 --   domain and range are both Symbol and not the Int used for real ty-vars.
 --------------------------------------------------------------------------------
 
-type CoSub = M.HashMap Symbol Symbol
+type CoSub = M.HashMap Symbol Sort -- Symbol
 
 applyCoSub :: CoSub -> Expr -> Expr
 applyCoSub coSub      = mapExpr fE
@@ -338,9 +338,9 @@ applyCoSub coSub      = mapExpr fE
     fE (ELam (x,t) e) = ELam (x, txS t)         e
     fE e              = e
     txS               = mapSort fS
-    fS (FObj a)       = FObj   (txV a)
+    fS (FObj a)       = {- FObj -} (txV a)
     fS t              = t
-    txV a             = M.lookupDefault a a coSub
+    txV a             = M.lookupDefault (FObj a) a coSub
 
 ---------------------------------------------------------------------------------
 -- | Visitors over @Sort@


### PR DESCRIPTION
We need it if we have ty-vars floating around inside refinements, e.g. in `ELam` and `ECoerc` because as TyVars are substituted, we need to also update the refinements. Matching PR for:

https://github.com/ucsd-progsys/liquidhaskell/pull/1226