### PR TITLE
Support for Mutually Recursive Datatypes 

### DIFF
--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -346,7 +346,20 @@ topoSortWith vF xs = fst3 . f <$> G.topSort g
     (g, f, _)      = G.graphFromEdges es
     es             = [ (x, ux, vxs) | x <- xs, let (ux, vxs) = vF x ]
 
--- >>> λ> exTopo
+-- |
+-- >>> let em = M.fromList [ (1, [2, 3]), (2, [1, 3]), (3, []   ) ]
+-- >>> let ef = \v -> (v, M.lookupDefault [] v em)
+-- >>> sccsWith f [1,2,3]  
+-- [[3], [1, 2]] 
+
+sccsWith :: (Ord v) => (a -> (v, [v])) -> [a] -> [[a]]
+sccsWith vF xs     = map (fst3 . f) <$> (T.flatten <$> G.scc g)
+  where
+    (g, f, _)      = G.graphFromEdges es
+    es             = [ (x, ux, vxs) | x <- xs, let (ux, vxs) = vF x ]
+
+
+-- >>> exTopo
 -- >>> [1,2,4,6,5,3]
 exTopo  :: [Int]
 exTopo  = topoSortWith f [1,2,3,4,5,6]

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -46,8 +46,7 @@ import           System.Process
 data Command      = Push
                   | Pop
                   | CheckSat
-                  | DeclData !DataDecl
--- /                  | Declare  !Symbol [Sort] !Sort
+                  | DeclData ![DataDecl]
                   | Declare  !Symbol [SmtSort] !SmtSort
                   | Define   !Sort
                   | Assert   !(Maybe Int) !Expr

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -33,7 +33,7 @@ import           Prelude                              hiding (init, lookup)
 import           Language.Fixpoint.Solver.Sanitize
 
 -- DEBUG
--- import Text.Printf (printf)
+import Text.Printf (printf)
 -- import           Debug.Trace (trace)
 
 
@@ -65,11 +65,11 @@ instConstants = F.fromListSEnv . filter notLit . F.toListSEnv . F.gLits
 
 
 refineK :: Bool -> F.SEnv F.Sort -> [F.Qualifier] -> (F.Symbol, F.Sort, F.KVar) -> (F.KVar, Sol.QBind)
-refineK ho env qs (v, t, k) = {- F.tracepp _msg -} (k, eqs')
+refineK ho env qs (v, t, k) = F.notracepp _msg (k, eqs')
    where
     eqs                     = instK ho env v t qs
     eqs'                    = Sol.qbFilter (okInst env v t) eqs
-    -- _msg                    = printf "\n\nrefineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
+    _msg                    = printf "\n\nrefineK: k = %s, eqs = %s" (F.showpp k) (F.showpp eqs)
 
 --------------------------------------------------------------------------------
 instK :: Bool

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -115,12 +115,6 @@ import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ
 
 -- import           Text.Printf               (printf)
--- import           Language.Fixpoint.Types.Config
--- import           Language.Fixpoint.Types.Errors
--- import           Text.Parsec.Pos
--- import           Data.Array                hiding (indices)
--- import qualified Data.HashSet              as S
-
 
 
 instance NFData KVar

--- a/tests/neg/adt_mutrec.fq
+++ b/tests/neg/adt_mutrec.fq
@@ -1,0 +1,24 @@
+
+data Val 0 = [
+  | VClos { vc1 : int, vc2 : int, vc3 : int, vc4 : VEnv}
+  | VInt  { vi1 : int } 
+  ]
+
+data VEnv 0 = [
+  | VEmp  { }
+  | VBind { vb1 : int, vb2 : Val, vb3 : VEnv}
+  ]
+
+bind 1 env  : {v : VEnv | true }
+bind 2 val  : {v : Val  | true }
+bind 3 x    : {v : int  | true } 
+bind 4 y    : {v : int  | true } 
+bind 5 envx : {v : VEnv | v = VBind x val env }
+bind 6 envy : {v : VEnv | v = VBind y val env }
+
+constraint: 
+  env [1;2;3;4;5;6]
+  lhs {v: int | true }   
+  rhs {v: int | envx = envy} 
+  id 1 tag []
+

--- a/tests/pos/adt_mutrec.fq
+++ b/tests/pos/adt_mutrec.fq
@@ -1,0 +1,24 @@
+
+data Val 0 = [
+  | VClos { vc1 : int, vc2 : int, vc3 : int, vc4 : VEnv}
+  | VInt  { vi1 : int } 
+  ]
+
+data VEnv 0 = [
+  | VEmp  { }
+  | VBind { vb1 : int, vb2 : Val, vb3 : VEnv}
+  ]
+
+bind 1 env  : {v : VEnv | true }
+bind 2 val  : {v : Val  | true }
+bind 3 x    : {v : int  | true } 
+bind 4 y    : {v : int  | true } 
+bind 5 envx : {v : VEnv | v = VBind x val env }
+bind 6 envy : {v : VEnv | v = VBind y val env }
+
+constraint: 
+  env [1;2;3;4;5;6]
+  lhs {v: int | x = y}   
+  rhs {v: int | envx = envy} 
+  id 1 tag []
+


### PR DESCRIPTION
Fixes #365 

Note that SMTLIB requires mutually recursive data to have *same* number of type params (AFAICT),
which may lead to wierd panics...