### PR TITLE
Add Semigroups -  GHC-8.4 support

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -53,7 +53,7 @@ Executable fixpoint
   if flag(devel)
     ghc-options: -Werror
   hs-source-dirs: bin
-  Build-Depends: base >=4.8.1.0 && <5
+  Build-Depends: base >=4.9.1.0 && <5
                , liquid-fixpoint
 
 Library
@@ -110,9 +110,13 @@ Library
                    Language.Fixpoint.Solver.Instantiate,
                    Language.Fixpoint.Solver.Sanitize,
                    Language.Fixpoint.Utils.Statistics,
-                   Language.Fixpoint.Solver.Solve
+                   Language.Fixpoint.Solver.Solve,
 
-  Build-Depends: base >=4.8.1.0 && <5
+                   Text.PrettyPrint.HughesPJ.Compat
+
+  Other-Modules: Paths_liquid_fixpoint
+
+  Build-Depends: base >=4.9.1.0 && <5
                , array
                , async
                , attoparsec
@@ -131,7 +135,7 @@ Library
                , intern
                , mtl
                , parsec
-               , pretty
+               , pretty >=1.1.3.1
                , boxes
                , parallel
                , process
@@ -148,8 +152,9 @@ Library
                , time
                , parallel-io
 
-  if impl(ghc >= 7.10.2)
-    Build-Depends: located-base
+  -- unconditionally depend on located-base
+  Build-Depends: located-base
+
   if !os(windows)
     Build-Depends: ascii-progress >= 0.3
     hs-source-dirs: unix
@@ -164,14 +169,15 @@ test-suite test
   if flag(devel)
     ghc-options:    -Werror
   main-is:          test.hs
-  build-depends:    base >= 4.8 && < 5,
+  Other-Modules:    Paths_liquid_fixpoint
+  build-depends:    base >= 4.9.1.0 && < 5,
                     directory,
                     filepath,
                     process,
                     stm >= 2.4,
                     containers >= 0.5,
-                    mtl >= 2.1,
-                    transformers >= 0.3,
+                    mtl >= 2.2.2,
+                    transformers >= 0.5,
                     tasty >= 0.10,
                     tasty-hunit,
                     tasty-rerun >= 1.1,
@@ -187,7 +193,7 @@ test-suite testparser
   if flag(devel)
     ghc-options:    -Werror
   main-is:          testParser.hs
-  build-depends:    base >= 4.8 && < 5,
+  build-depends:    base >= 4.9.1.0 && < 5,
                     directory,
                     filepath,
                     tasty >= 0.10,
@@ -198,6 +204,28 @@ test-suite testparser
                     text
   if flag(devel)
     hs-source-dirs:   tests src
+    other-modules:
+                 Language.Fixpoint.Misc
+                 Language.Fixpoint.Parse
+                 Language.Fixpoint.Smt.Bitvector
+                 Language.Fixpoint.Smt.Types
+                 Language.Fixpoint.Types
+                 Language.Fixpoint.Types.Config
+                 Language.Fixpoint.Types.Constraints
+                 Language.Fixpoint.Types.Environments
+                 Language.Fixpoint.Types.Errors
+                 Language.Fixpoint.Types.Names
+                 Language.Fixpoint.Types.PrettyPrint
+                 Language.Fixpoint.Types.Refinements
+                 Language.Fixpoint.Types.Sorts
+                 Language.Fixpoint.Types.Spans
+                 Language.Fixpoint.Types.Substitutions
+                 Language.Fixpoint.Types.Theories
+                 Language.Fixpoint.Types.Triggers
+                 Language.Fixpoint.Types.Utils
+                 Language.Fixpoint.Utils.Files
+                 Text.PrettyPrint.HughesPJ.Compat
+
     build-depends:
                  array
                , async

--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -28,6 +28,7 @@ module Language.Fixpoint.Graph.Deps (
 
 import           Prelude hiding (init)
 import           Data.Maybe                       (mapMaybe, fromMaybe)
+import           Data.Semigroup                   (Semigroup (..))
 import           Data.Tree (flatten)
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Utils.Files
@@ -46,7 +47,7 @@ import qualified Data.HashMap.Strict                  as M
 import qualified Data.Graph                           as G
 import           Data.Function (on)
 import           Data.Hashable
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import           Debug.Trace (trace)
 
 --------------------------------------------------------------------------------
@@ -289,9 +290,12 @@ instance PPrint (Elims a) where
     where
       ppSize     = pprint . S.size
 
+instance (Eq a, Hashable a) => Semigroup (Elims a) where
+  Deps d1 n1 <> Deps d2 n2 = Deps (S.union d1 d2) (S.union n1 n2)
+
 instance (Eq a, Hashable a) => Monoid (Elims a) where
-  mempty                            = Deps S.empty S.empty
-  mappend (Deps d1 n1) (Deps d2 n2) = Deps (S.union d1 d2) (S.union n1 n2)
+  mempty  = Deps S.empty S.empty
+  mappend = (<>)
 
 dCut, dNonCut :: (Hashable a) => a -> Elims a
 dNonCut v = Deps S.empty (S.singleton v)

--- a/src/Language/Fixpoint/Graph/Partition.hs
+++ b/src/Language/Fixpoint/Graph/Partition.hs
@@ -38,7 +38,8 @@ import qualified Data.HashMap.Strict                  as M
 -- import           Data.Function (on)
 import           Data.Maybe                     (fromMaybe)
 import           Data.Hashable
-import           Text.PrettyPrint.HughesPJ
+import           Data.Semigroup                 (Semigroup (..))
+import           Text.PrettyPrint.HughesPJ.Compat
 import           Data.List (sortBy)
 -- import qualified Data.HashSet              as S
 
@@ -55,11 +56,14 @@ data CPart c a = CPart { pws :: !(M.HashMap F.KVar (F.WfC a))
                        , pcm :: !(M.HashMap Integer (c a))
                        }
   
+instance Semigroup (CPart c a) where
+   l <> r = CPart { pws = pws l `mappend` pws r
+                  , pcm = pcm l `mappend` pcm r
+                  }
+
 instance Monoid (CPart c a) where
-   mempty      = CPart mempty mempty
-   mappend l r = CPart { pws = pws l `mappend` pws r
-                       , pcm = pcm l `mappend` pcm r
-                       }
+   mempty  = CPart mempty mempty
+   mappend = (<>)
 
 --------------------------------------------------------------------------------
 -- | Multicore info ------------------------------------------------------------

--- a/src/Language/Fixpoint/Graph/Types.hs
+++ b/src/Language/Fixpoint/Graph/Types.hs
@@ -50,7 +50,7 @@ module Language.Fixpoint.Graph.Types (
 
 import           GHC.Generics              (Generic)
 import           Data.Hashable
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 
 import           Language.Fixpoint.Misc         -- hiding (group)
 import           Language.Fixpoint.Types.PrettyPrint
@@ -73,8 +73,8 @@ data CVertex = KVar  !KVar    -- ^ real kvar vertex
 instance PPrint CVertex where
   pprintTidy _ (KVar k)  = doubleQuotes $ pprint $ kv k
   pprintTidy _ (EBind s)  = doubleQuotes $ pprint $ s
-  pprintTidy _ (Cstr i)  = text "id_" <> pprint i
-  pprintTidy _ (DKVar k) = pprint k   <> text "*"
+  pprintTidy _ (Cstr i)  = text "id_" <-> pprint i
+  pprintTidy _ (DKVar k) = pprint k   <-> text "*"
 
 
 instance Hashable CVertex

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -78,8 +78,8 @@ import           Control.Monad
 import           Control.Exception
 import           Data.Char
 import qualified Data.HashMap.Strict      as M
-import           Data.Monoid
-import           Data.Maybe                  (fromMaybe)
+import           Data.Maybe              (fromMaybe)
+import           Data.Semigroup          (Semigroup (..))
 import qualified Data.Text                as T
 import           Data.Text.Format
 import qualified Data.Text.IO             as TIO

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -17,7 +17,7 @@ import           Language.Fixpoint.Types
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import           Language.Fixpoint.Smt.Types
 import qualified Language.Fixpoint.Smt.Theories as Thy
-import           Data.Monoid
+import           Data.Semigroup                 (Semigroup (..))
 import qualified Data.Text.Lazy.Builder         as Builder
 import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -37,13 +37,13 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
+import           Data.Semigroup            (Semigroup (..))
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Smt.Types
 -- import qualified Data.HashMap.Strict      as M
 import           Data.Maybe (catMaybes)
-import           Data.Monoid
 import qualified Data.Text.Lazy           as T
 import qualified Data.Text.Lazy.Builder   as Builder
 import           Data.Text.Format

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -19,7 +19,7 @@ import qualified Data.HashSet                   as S
 import qualified Data.HashMap.Strict            as M
 import qualified Data.List                      as L
 import           Data.Maybe                     (fromMaybe, maybeToList, isNothing)
-import           Data.Monoid                    ((<>))
+import           Data.Semigroup                 (Semigroup (..))
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Types.Visitor      as V
 import qualified Language.Fixpoint.SortCheck          as So
@@ -414,13 +414,16 @@ data KInfo = KI { kiTags  :: [Tag]
                 , kiCubes :: !Integer
                 } deriving (Eq, Ord, Show)
 
-instance Monoid KInfo where
-  mempty         = KI [] 0 1
-  mappend ki ki' = KI ts d s
+instance Semigroup KInfo where
+  ki <> ki' = KI ts d s
     where
       ts         = appendTags (kiTags  ki) (kiTags  ki')
       d          = max        (kiDepth ki) (kiDepth ki')
       s          = (*)        (kiCubes ki) (kiCubes ki')
+
+instance Monoid KInfo where
+  mempty  = KI [] 0 1
+  mappend = (<>)
 
 mplus :: KInfo -> KInfo -> KInfo
 mplus ki ki' = (mappend ki ki') { kiCubes = kiCubes ki + kiCubes ki'}

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -60,13 +60,14 @@ import           Control.Monad.State.Strict
 import qualified Data.HashMap.Strict       as M
 import qualified Data.List                 as L
 import           Data.Maybe                (mapMaybe, fromMaybe, catMaybes)
+import           Data.Semigroup            (Semigroup (..))
 
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Types hiding   (subst)
 import qualified Language.Fixpoint.Types.Visitor  as Vis
 import qualified Language.Fixpoint.Smt.Theories   as Thy
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import           Text.Printf
 
 -- import Debug.Trace
@@ -1035,9 +1036,12 @@ checkFunSort t             = throwErrorAt (errNonFunction 1 t)
 
 newtype TVSubst = Th (M.HashMap Int Sort) deriving (Show)
 
+instance Semigroup TVSubst where
+  Th s1 <> Th s2 = Th (mappend s1 s2)
+
 instance Monoid TVSubst where
-  mempty                  = Th mempty
-  mappend (Th s1) (Th s2) = Th (mappend s1 s2)
+  mempty  = Th mempty
+  mappend = (<>)
 
 lookupVar :: Int -> TVSubst -> Maybe Sort
 lookupVar i (Th m)   = M.lookup i m

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -83,6 +83,7 @@ module Language.Fixpoint.Types.Constraints (
 
 import qualified Data.Binary as B
 import           Data.Generics             (Data)
+import           Data.Semigroup            (Semigroup (..))
 import           Data.Typeable             (Typeable)
 import           GHC.Generics              (Generic)
 import qualified Data.List                 as L -- (sort, nub, delete)
@@ -102,7 +103,7 @@ import           Language.Fixpoint.Types.Environments
 import qualified Language.Fixpoint.Utils.Files as Files
 
 import           Language.Fixpoint.Misc
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
 
@@ -251,7 +252,7 @@ type GFixSolution = GFixSol Expr
 
 type FixSolution  = M.HashMap KVar Expr
 newtype GFixSol e = GSol (M.HashMap KVar (e, [e]))
-  deriving (Generic, Monoid, Functor)
+  deriving (Generic, Semigroup, Monoid, Functor)
 
 toGFixSol :: M.HashMap KVar (e, [e]) -> GFixSol e
 toGFixSol = GSol
@@ -263,8 +264,11 @@ data Result a = Result { resStatus    :: !(FixResult a)
                 deriving (Generic, Show)
 
 instance Monoid (Result a) where
-  mempty        = Result mempty mempty mempty
-  mappend r1 r2 = Result stat soln gsoln
+  mempty  = Result mempty mempty mempty
+  mappend = (<>)
+
+instance  Semigroup (Result a) where
+  r1 <> r2 = Result stat soln gsoln
     where
       stat      = mappend (resStatus r1)    (resStatus r2)
       soln      = mappend (resSolution r1)  (resSolution r2)
@@ -290,7 +294,7 @@ instance (Ord a, Fixpoint a) => Fixpoint (FixResult (SubC a)) where
   toFix (Unsafe xs)      = vcat $ text "Unsafe:" : pprSinfos "WARNING: " xs
 
 pprSinfos :: (Ord a, Fixpoint a) => String -> [SubC a] -> [Doc]
-pprSinfos msg = map ((text msg <>) . toFix) . L.sort . fmap sinfo
+pprSinfos msg = map ((text msg <->) . toFix) . L.sort . fmap sinfo
 
 instance Fixpoint a => Show (WfC a) where
   show = showFix
@@ -345,7 +349,7 @@ instance PPrint GFixSolution where
   pprintTidy k (GSol xs) = vcat $ punctuate "\n\n" (pprintTidyGradual k <$> M.toList xs)
 
 pprintTidyGradual :: Tidy -> (KVar, (Expr, [Expr])) -> Doc
-pprintTidyGradual _ (x, (e, es)) = ppLocOfKVar x <+> text ":=" <+> (ppNonTauto " && " e <> pprint es)
+pprintTidyGradual _ (x, (e, es)) = ppLocOfKVar x <+> text ":=" <+> (ppNonTauto " && " e <-> pprint es)
 
 ppLocOfKVar :: KVar -> Doc
 ppLocOfKVar = text. dropWhile (/='(') . symbolString .kv
@@ -353,7 +357,7 @@ ppLocOfKVar = text. dropWhile (/='(') . symbolString .kv
 ppNonTauto :: Doc -> Expr -> Doc
 ppNonTauto d e
   | isTautoPred e = mempty
-  | otherwise     = pprint e <> d
+  | otherwise     = pprint e <-> d
 
 instance Show   GFixSolution where
   show = showpp
@@ -480,8 +484,8 @@ instance PPrint QualParam where
 
 instance PPrint QualPattern where 
   pprintTidy _ PatNone         = "" 
-  pprintTidy k (PatPrefix s i) = "as" <+> pprintTidy k s <+> ("$" <> pprint i)
-  pprintTidy k (PatSuffix s i) = "as" <+> ("$" <> pprint i) <+> pprintTidy k s 
+  pprintTidy k (PatPrefix s i) = "as" <+> pprintTidy k s <+> ("$" <-> pprint i)
+  pprintTidy k (PatSuffix s i) = "as" <+> ("$" <-> pprint i) <+> pprintTidy k s 
   pprintTidy k (PatExact  s  ) = "~"  <+> pprintTidy k s 
 
 instance Fixpoint Qualifier where
@@ -491,7 +495,7 @@ instance PPrint Qualifier where
   pprintTidy k q = "qualif" <+> pprintTidy k (qName q) <+> "defined at" <+> pprintTidy k (qPos q)
 
 pprQual :: Qualifier -> Doc
-pprQual (Q n xts p l) = text "qualif" <+> text (symbolString n) <> parens args <> colon <+> parens (toFix p) <+> text "//" <+> toFix l
+pprQual (Q n xts p l) = text "qualif" <+> text (symbolString n) <-> parens args <-> colon <+> parens (toFix p) <+> text "//" <+> toFix l
   where
     args              = intersperse comma (toFix <$> xts)
 
@@ -576,14 +580,17 @@ newtype Kuts = KS { ksVars :: S.HashSet KVar }
                deriving (Eq, Show, Generic)
 
 instance Fixpoint Kuts where
-  toFix (KS s) = vcat $ ((text "cut " <>) . toFix) <$> S.toList s
+  toFix (KS s) = vcat $ ((text "cut " <->) . toFix) <$> S.toList s
 
 ksMember :: KVar -> Kuts -> Bool
 ksMember k (KS s) = S.member k s
 
 instance Monoid Kuts where
-  mempty        = KS S.empty
-  mappend k1 k2 = KS $ S.union (ksVars k1) (ksVars k2)
+  mempty  = KS S.empty
+  mappend = (<>)
+
+instance Semigroup Kuts where
+  k1 <> k2 = KS $ S.union (ksVars k1) (ksVars k2)
 
 ------------------------------------------------------------------------
 -- | Constructing Queries
@@ -661,11 +668,14 @@ data GInfo c a =
 instance HasGradual (GInfo c a) where
   isGradual info = any isGradual (M.elems $ ws info)
 
+instance Semigroup HOInfo where
+  i1 <> i2 = HOI { hoBinds = hoBinds i1 || hoBinds i2
+                 , hoQuals = hoQuals i1 || hoQuals i2
+                 }
+
 instance Monoid HOInfo where
-  mempty        = HOI False False
-  mappend i1 i2 = HOI { hoBinds = hoBinds i1 || hoBinds i2
-                      , hoQuals = hoQuals i1 || hoQuals i2
-                      }
+  mempty  = HOI False False
+  mappend = (<>)
 
 instance Monoid (GInfo c a) where
   mempty        = FI { cm       = M.empty
@@ -682,21 +692,23 @@ instance Monoid (GInfo c a) where
                      , asserts  = mempty 
                      , ae       = mempty
                      } 
+  mappend =  (<>)
 
-  mappend i1 i2 = FI { cm       = mappend (cm i1)       (cm i2)
-                     , ws       = mappend (ws i1)       (ws i2)
-                     , bs       = mappend (bs i1)       (bs i2)
-                     , ebinds   = mappend (ebinds i1)   (ebinds i2)
-                     , gLits    = mappend (gLits i1)    (gLits i2)
-                     , dLits    = mappend (dLits i1)    (dLits i2)
-                     , kuts     = mappend (kuts i1)     (kuts i2)
-                     , quals    = mappend (quals i1)    (quals i2)
-                     , bindInfo = mappend (bindInfo i1) (bindInfo i2)
-                     , ddecls   = mappend (ddecls i1)   (ddecls i2)
-                     , hoInfo   = mappend (hoInfo i1)   (hoInfo i2)
-                     , asserts  = mappend (asserts i1)  (asserts i2)
-                     , ae       = mappend (ae i1)       (ae i2)
-                     }
+instance Semigroup (GInfo c a) where
+  i1 <> i2 = FI { cm       = mappend (cm i1)       (cm i2)
+                , ws       = mappend (ws i1)       (ws i2)
+                , bs       = mappend (bs i1)       (bs i2)
+                , ebinds   = mappend (ebinds i1)   (ebinds i2)
+                , gLits    = mappend (gLits i1)    (gLits i2)
+                , dLits    = mappend (dLits i1)    (dLits i2)
+                , kuts     = mappend (kuts i1)     (kuts i2)
+                , quals    = mappend (quals i1)    (quals i2)
+                , bindInfo = mappend (bindInfo i1) (bindInfo i2)
+                , ddecls   = mappend (ddecls i1)   (ddecls i2)
+                , hoInfo   = mappend (hoInfo i1)   (hoInfo i2)
+                , asserts  = mappend (asserts i1)  (asserts i2)
+                , ae       = mappend (ae i1)       (ae i2)
+                }
 
 instance PTable (SInfo a) where
   ptable z = DocTable [ (text "# Sub Constraints", pprint $ length $ cm z)
@@ -832,13 +844,16 @@ instance NFData Equation
 instance NFData SMTSolver
 instance NFData Eliminate
 
-instance Monoid AxiomEnv where
-  mempty           = AEnv [] [] (M.fromList [])
-  mappend a1 a2    = AEnv aenvEqs' aenvSimpl' aenvExpand'
+instance Semigroup AxiomEnv where
+  a1 <> a2    = AEnv aenvEqs' aenvSimpl' aenvExpand'
     where
       aenvEqs'     = mappend (aenvEqs a1) (aenvEqs a2)
       aenvSimpl'   = mappend (aenvSimpl a1) (aenvSimpl a2)
       aenvExpand'  = mappend (aenvExpand a1) (aenvExpand a2)
+
+instance Monoid AxiomEnv where
+  mempty  = AEnv [] [] (M.fromList [])
+  mappend = (<>)
 
 instance PPrint AxiomEnv where
   pprintTidy _ = text . show

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -60,6 +60,7 @@ module Language.Fixpoint.Types.Environments (
 import qualified Data.Binary as B
 import qualified Data.List   as L
 import           Data.Generics             (Data)
+import           Data.Semigroup            (Semigroup (..))
 import           Data.Typeable             (Typeable)
 import           GHC.Generics              (Generic)
 import           Data.Hashable
@@ -67,7 +68,7 @@ import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
 import           Data.Maybe
 import           Data.Function             (on)
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import           Control.DeepSeq
 
 import           Language.Fixpoint.Types.PrettyPrint
@@ -174,10 +175,12 @@ data SESearch a = Found a | Alts [Symbol]
 
 -- | Functions for Indexed Bind Environment
 
+instance Semigroup IBindEnv where
+  FB e1 <> FB e2 = FB (e1 `mappend` e2)
 
 instance Monoid IBindEnv where
-  mempty                  = emptyIBindEnv
-  mappend (FB e1) (FB e2) = FB (e1 `mappend` e2)
+  mempty  = emptyIBindEnv
+  mappend = (<>)
 
 emptyIBindEnv :: IBindEnv
 emptyIBindEnv = FB S.empty
@@ -271,15 +274,21 @@ instance (Fixpoint a) => Fixpoint (SEnv a) where
 instance Fixpoint (SEnv a) => Show (SEnv a) where
   show = render . toFix
 
+instance Semigroup (SEnv a) where
+  s1 <> s2 = SE $ M.union (seBinds s1) (seBinds s2)
+
 instance Monoid (SEnv a) where
-  mempty        = SE M.empty
-  mappend s1 s2 = SE $ M.union (seBinds s1) (seBinds s2)
+  mempty  = SE M.empty
+  mappend = (<>)
+
+instance Semigroup BindEnv where
+  BE 0 _ <> b = b
+  b <> BE 0 _ = b
+  _ <> _      = errorstar "mappend on non-trivial BindEnvs"
 
 instance Monoid BindEnv where
   mempty = BE 0 M.empty
-  mappend (BE 0 _) b = b
-  mappend b (BE 0 _) = b
-  mappend _ _        = errorstar "mappend on non-trivial BindEnvs"
+  mappend = (<>)
 
 envCs :: BindEnv -> IBindEnv -> [(Symbol, SortedReft)]
 envCs be env = [lookupBindEnv i be | i <- elemsIBindEnv env]
@@ -317,9 +326,12 @@ instance Fixpoint Packs where
 instance PPrint Packs where
   pprintTidy _ = toFix
 
+instance Semigroup Packs where
+  m1 <> m2 = Packs $ M.union (packm m1) (packm m2)
+
 instance Monoid Packs where
-  mempty        = Packs mempty
-  mappend m1 m2 = Packs $ M.union (packm m1) (packm m2)
+  mempty  = Packs mempty
+  mappend = (<>)
 
 getPack :: KVar -> Packs -> Maybe Int
 getPack k (Packs m) = M.lookup k m

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -53,6 +53,7 @@ import           Control.Exception
 import           Data.Serialize                (Serialize (..))
 import           Data.Generics                 (Data)
 import           Data.Typeable
+import           Data.Semigroup                (Semigroup (..))
 import           Control.DeepSeq
 -- import           Data.Hashable
 import qualified Data.Binary                   as B
@@ -60,19 +61,17 @@ import           GHC.Generics                  (Generic)
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Misc
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 -- import           Text.Printf
 import           Data.Function (on)
 
 -- import           Debug.Trace
 
-#if MIN_VERSION_pretty(1,1,3)
 import qualified Text.PrettyPrint.Annotated.HughesPJ as Ann
 
 deriving instance Generic (Ann.AnnotDetails a)
 instance Serialize a => Serialize (Ann.AnnotDetails a)
 instance Serialize a => Serialize (Ann.Doc a)
-#endif
 
 instance Serialize Error1
 -- FIXME: orphans are bad...
@@ -172,13 +171,16 @@ instance Eq a => Eq (FixResult a) where
   Safe      == Safe               = True
   _         == _                  = False
 
+instance Semigroup (FixResult a) where
+  Safe <> x              = x
+  x <> Safe              = x
+  _ <> c@(Crash _ _)     = c
+  c@(Crash _ _) <> _     = c
+  Unsafe xs <> Unsafe ys = Unsafe (xs ++ ys)
+
 instance Monoid (FixResult a) where
-  mempty                          = Safe
-  mappend Safe x                  = x
-  mappend x Safe                  = x
-  mappend _ c@(Crash _ _)         = c
-  mappend c@(Crash _ _) _         = c
-  mappend (Unsafe xs) (Unsafe ys) = Unsafe (xs ++ ys)
+  mempty  = Safe
+  mappend = (<>)
 
 instance Functor FixResult where
   fmap f (Crash xs msg)   = Crash (f <$> xs) msg

--- a/src/Language/Fixpoint/Types/Graduals.hs
+++ b/src/Language/Fixpoint/Types/Graduals.hs
@@ -43,11 +43,15 @@ import qualified Data.List                 as L
 
 import Control.Monad.State.Lazy
 import Data.Maybe (fromMaybe)
+import Data.Semigroup (Semigroup (..))
 import qualified Language.Fixpoint.SortCheck       as So
 import Language.Fixpoint.Solver.Sanitize (symbolEnv)
 
 
 data GSol = GSol !SymEnv !(M.HashMap KVar (Expr, GradInfo))
+
+instance Semigroup GSol where
+  GSol e1 m1 <> GSol e2 m2 = GSol (mappend e1 e2) (mappend m1 m2)
 
 instance Monoid GSol where
   mempty = GSol mempty mempty

--- a/src/Language/Fixpoint/Types/PrettyPrint.hs
+++ b/src/Language/Fixpoint/Types/PrettyPrint.hs
@@ -6,15 +6,15 @@
 module Language.Fixpoint.Types.PrettyPrint where
 
 import           Debug.Trace               (trace)
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Text.PrettyPrint.Boxes as B
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet        as S
 import qualified Data.List           as L
 import           Language.Fixpoint.Misc
 import           Data.Hashable
+import           Data.Semigroup (Semigroup (..))
 import qualified Data.Text as T
-
 
 traceFix     ::  (Fixpoint a) => String -> a -> a
 traceFix s x = trace ("\nTrace: [" ++ s ++ "] : " ++ showFix x) x
@@ -115,23 +115,23 @@ pprintKVs t = vcat . punctuate "\n" . map pp1
     pp1 (x,y) = pprintTidy t x <+> ":=" <+> pprintTidy t y
 
 instance (PPrint a, PPrint b, PPrint c) => PPrint (a, b, c) where
-  pprintTidy k (x, y, z)  = parens $ pprintTidy k x <> "," <+>
-                                     pprintTidy k y <> "," <+>
+  pprintTidy k (x, y, z)  = parens $ pprintTidy k x <-> "," <+>
+                                     pprintTidy k y <-> "," <+>
                                      pprintTidy k z
 
 
 
 instance (PPrint a, PPrint b, PPrint c, PPrint d) => PPrint (a, b, c, d) where
-  pprintTidy k (w, x, y, z)  = parens $ pprintTidy k w <> "," <+>
-                                        pprintTidy k x <> "," <+>
-                                        pprintTidy k y <> "," <+>
+  pprintTidy k (w, x, y, z)  = parens $ pprintTidy k w <-> "," <+>
+                                        pprintTidy k x <-> "," <+>
+                                        pprintTidy k y <-> "," <+>
                                         pprintTidy k z
 
 instance (PPrint a, PPrint b, PPrint c, PPrint d, PPrint e) => PPrint (a, b, c, d, e) where
-  pprintTidy k (v, w, x, y, z)  = parens $ pprintTidy k v <> "," <+>
-                                           pprintTidy k w <> "," <+>
-                                           pprintTidy k x <> "," <+>
-                                           pprintTidy k y <> "," <+>
+  pprintTidy k (v, w, x, y, z)  = parens $ pprintTidy k v <-> "," <+>
+                                           pprintTidy k w <-> "," <+>
+                                           pprintTidy k x <-> "," <+>
+                                           pprintTidy k y <-> "," <+>
                                            pprintTidy k z
 
 
@@ -164,9 +164,12 @@ instance PPrint T.Text where
 
 newtype DocTable = DocTable [(Doc, Doc)]
 
+instance Semigroup DocTable where
+  DocTable t1 <> DocTable t2 = DocTable (t1 ++ t2)
+
 instance Monoid DocTable where
-  mempty                              = DocTable []
-  mappend (DocTable t1) (DocTable t2) = DocTable (t1 ++ t2)
+  mempty  = DocTable []
+  mappend = (<>)
 
 class PTable a where
   ptable :: a -> DocTable

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -112,7 +112,7 @@ import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Misc
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 
 -- import           Text.Printf               (printf)
 
@@ -224,7 +224,7 @@ instance Show Subst where
 instance Fixpoint Subst where
   toFix (Su m) = case hashMapToAscList m of
                    []  -> empty
-                   xys -> hcat $ map (\(x,y) -> brackets $ toFix x <> text ":=" <> toFix y) xys
+                   xys -> hcat $ map (\(x,y) -> brackets $ toFix x <-> text ":=" <-> toFix y) xys
 
 instance PPrint Subst where
   pprintTidy _ = toFix
@@ -359,7 +359,7 @@ elit l s = ECon $ L (symbolText $ val l) s
 instance Fixpoint Constant where
   toFix (I i)   = toFix i
   toFix (R i)   = toFix i
-  toFix (L s t) = parens $ text "lit" <+> text "\"" <> toFix s <> text "\"" <+> toFix t
+  toFix (L s t) = parens $ text "lit" <+> text "\"" <-> toFix s <-> text "\"" <+> toFix t
 
 --------------------------------------------------------------------------------
 -- | String Constants ----------------------------------------------------------
@@ -381,7 +381,7 @@ instance Fixpoint SymConst where
   toFix  = toFix . encodeSymConst
 
 instance Fixpoint KVar where
-  toFix (KV k) = text "$" <> toFix k
+  toFix (KV k) = text "$" <-> toFix k
 
 instance Fixpoint Brel where
   toFix Eq  = text "="
@@ -422,7 +422,7 @@ instance Fixpoint Expr where
   toFix (PAnd ps)      = text "&&" <+> toFix ps
   toFix (POr  ps)      = text "||" <+> toFix ps
   toFix (PAtom r e1 e2)  = parens $ toFix e1 <+> toFix r <+> toFix e2
-  toFix (PKVar k su)     = toFix k <> toFix su
+  toFix (PKVar k su)     = toFix k <-> toFix su
   toFix (PAll xts p)     = "forall" <+> (toFix xts
                                         $+$ ("." <+> toFix p))
   toFix (PExist xts p)   = "exists" <+> (toFix xts
@@ -507,7 +507,7 @@ instance PPrint Sort where
   pprintTidy _ = toFix
 
 instance PPrint KVar where
-  pprintTidy _ (KV x) = text "$" <> pprint x
+  pprintTidy _ (KV x) = text "$" <-> pprint x
 
 instance PPrint SymConst where
   pprintTidy _ (SL x) = doubleQuotes $ text $ T.unpack x
@@ -551,7 +551,7 @@ instance PPrint Expr where
   pprintPrec _ k (EVar s)        = pprintTidy k s
   -- pprintPrec _ (EBot)          = text "_|_"
   pprintPrec z k (ENeg e)        = parensIf (z > zn) $
-                                   "-" <> pprintPrec (zn + 1) k e
+                                   "-" <-> pprintPrec (zn + 1) k e
     where zn = 2
   pprintPrec z k (EApp f es)     = parensIf (z > za) $
                                    pprintPrec za k f <+> pprintPrec (za+1) k es

--- a/src/Language/Fixpoint/Types/Solutions.hs
+++ b/src/Language/Fixpoint/Types/Solutions.hs
@@ -77,6 +77,7 @@ import qualified Data.Maybe                 as Mb
 import qualified Data.HashMap.Strict        as M
 import qualified Data.List                  as L
 import           Data.Generics             (Data)
+import           Data.Semigroup            (Semigroup (..))
 import           Data.Typeable             (Typeable)
 import           Control.Monad (filterM)
 import           Language.Fixpoint.Misc
@@ -90,7 +91,7 @@ import           Language.Fixpoint.Types.Environments
 import           Language.Fixpoint.Types.Constraints
 import           Language.Fixpoint.Types.Substitutions
 import           Language.Fixpoint.SortCheck (elaborate)
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 
 --------------------------------------------------------------------------------
 -- | Update Solution -----------------------------------------------------------
@@ -221,6 +222,15 @@ updateGMap sol gmap = sol {gMap = gmap}
 mapGMap :: Sol b a -> (b -> b) -> Sol b a
 mapGMap sol f = sol {gMap = M.map f (gMap sol)}
 
+instance Semigroup (Sol a b) where
+  s1 <> s2 = Sol { sEnv = mappend (sEnv s1) (sEnv s2)
+                 , sMap = mappend (sMap s1) (sMap s2)
+                 , gMap = mappend (gMap s1) (gMap s2)
+                 , sHyp = mappend (sHyp s1) (sHyp s2)
+                 , sScp = mappend (sScp s1) (sScp s2)
+                 , sEbd = mappend (sEbd s1) (sEbd s2) 
+                 , sxEnv = mappend (sxEnv s1) (sxEnv s2) 
+                 }
 
 instance Monoid (Sol a b) where
   mempty        = Sol { sEnv = mempty 
@@ -231,14 +241,8 @@ instance Monoid (Sol a b) where
                       , sEbd = mempty
                       , sxEnv = mempty
                       }
-  mappend s1 s2 = Sol { sEnv = mappend (sEnv s1) (sEnv s2)
-                      , sMap = mappend (sMap s1) (sMap s2)
-                      , gMap = mappend (gMap s1) (gMap s2)
-                      , sHyp = mappend (sHyp s1) (sHyp s2)
-                      , sScp = mappend (sScp s1) (sScp s2)
-                      , sEbd = mappend (sEbd s1) (sEbd s2) 
-                      , sxEnv = mappend (sxEnv s1) (sxEnv s2) 
-                      }
+  mappend = (<>)
+
 
 instance Functor (Sol a) where
   fmap f (Sol e s m1 m2 m3 m4 m5) = Sol e (f <$> s) m1 m2 m3 m4 m5

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -32,6 +32,7 @@ module Language.Fixpoint.Types.Theories (
 
 
 import           Data.Generics             (Data)
+import           Data.Semigroup            (Semigroup (..))
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
@@ -42,7 +43,7 @@ import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Types.Environments
 
-import           Text.PrettyPrint.HughesPJ
+import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.Text.Lazy           as LT
 import qualified Data.Binary              as B
 import qualified Data.HashMap.Strict      as M
@@ -72,14 +73,17 @@ type FuncSort = (SmtSort, SmtSort)
 instance NFData   SymEnv
 instance B.Binary SymEnv
 
+instance Semigroup SymEnv where
+  e1 <> e2 = SymEnv { seSort   = seSort   e1 `mappend` seSort   e2
+                    , seTheory = seTheory e1 `mappend` seTheory e2
+                    , seData   = seData   e1 `mappend` seData   e2
+                    , seLits   = seLits   e1 `mappend` seLits   e2
+                    , seAppls  = seAppls  e1 `mappend` seAppls  e2
+                    }
+
 instance Monoid SymEnv where
-  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty
-  mappend e1 e2 = SymEnv { seSort   = seSort   e1 `mappend` seSort   e2
-                         , seTheory = seTheory e1 `mappend` seTheory e2
-                         , seData   = seData   e1 `mappend` seData   e2
-                         , seLits   = seLits   e1 `mappend` seLits   e2
-                         , seAppls  = seAppls  e1 `mappend` seAppls  e2
-                         }
+  mempty  = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty
+  mappend = (<>)
 
 symEnv :: SEnv Sort -> SEnv TheorySymbol -> [DataDecl] -> SEnv Sort -> [Sort] -> SymEnv
 symEnv xEnv fEnv ds ls ts = SymEnv xEnv' fEnv dEnv ls sortMap
@@ -272,7 +276,7 @@ instance PPrint SmtSort where
   pprintTidy _ SSet         = text "Set"
   pprintTidy _ SMap         = text "Map"
   pprintTidy _ (SBitVec n)  = text "BitVec" <+> int n
-  pprintTidy _ (SVar i)     = text "@" <> int i
+  pprintTidy _ (SVar i)     = text "@" <-> int i
 --  HKT pprintTidy k (SApp ts)    = ppParens k (pprintTidy k tyAppName) ts
   pprintTidy k (SData c ts) = ppParens k (pprintTidy k c)         ts
 

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -50,6 +50,7 @@ module Language.Fixpoint.Types.Visitor (
 
 -- import           Control.Monad.Trans.State.Strict (State, modify, runState)
 -- import           Control.DeepSeq
+import           Data.Semigroup      (Semigroup (..))
 import           Control.Monad.State.Strict
 import qualified Data.HashSet        as S
 import qualified Data.HashMap.Strict as M
@@ -248,9 +249,12 @@ mapKVarSubsts f          = trans kvVis () ()
 
 newtype MInt = MInt Integer -- deriving (Eq, NFData)
 
+instance Semigroup MInt where
+  MInt m <> MInt n = MInt (m + n)
+
 instance Monoid MInt where
-  mempty                    = MInt 0
-  mappend (MInt m) (MInt n) = MInt (m + n)
+  mempty  = MInt 0
+  mappend = (<>)
 
 size :: Visitable t => t -> Integer
 size t    = n

--- a/src/Text/PrettyPrint/HughesPJ/Compat.hs
+++ b/src/Text/PrettyPrint/HughesPJ/Compat.hs
@@ -1,0 +1,13 @@
+module Text.PrettyPrint.HughesPJ.Compat (
+    module Text.PrettyPrint.HughesPJ,
+    (<->),
+    ) where
+
+import Text.PrettyPrint.HughesPJ hiding ((<>), first)
+import qualified Text.PrettyPrint.HughesPJ as PP
+
+-- | Also known as '<>' in @pretty@, but that clashes with Semigroup's <>
+(<->) :: Doc -> Doc -> Doc
+(<->) = (PP.<>)
+
+infixl 6 <->

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-
-resolver: lts-8.9
+resolver: lts-12.2
 
 flags:
   liquid-fixpoint:
@@ -10,7 +9,7 @@ packages:
 extra-deps:
 - dotgen-0.4.2
 - fgl-visualize-0.1.0.1
-- intern-0.9.1.4
-- located-base-0.1.1.0
-
-# resolver: nightly-2016-05-21
+- intern-0.9.2
+- located-base-0.1.1.1
+- tasty-rerun-1.1.12
+- text-format-0.3.2


### PR DESCRIPTION
In short, I added a compat module for `pretty` renaming `<>` to `<->` so `pretty` and `Data.Semigroup` don't clash. We  cannot use only `Semigroup`'s `<>` as their fixities are different.

Other names for `<->` can. E.g. `><` or `<<>>`.