### PR TITLE
Upgrade to GHC 8.4.4.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,25 +1,25 @@
 { fetchgitLocal }:
 { mkDerivation, ansi-terminal, array, ascii-progress, async
 , attoparsec, base, bifunctors, binary, boxes, bytestring, cereal
-, cmdargs, containers, deepseq, directory, filemanip, filepath
-, ghc-prim, hashable, intern, located-base, mtl, parallel, parsec, pretty
-, process, stdenv, syb, tasty, tasty-hunit, tasty-rerun, text
-, text-format, transformers, unordered-containers, z3
-, dotgen, fgl, fgl-visualize
+, cmdargs, containers, deepseq, directory, dotgen, fgl
+, fgl-visualize, filemanip, filepath, ghc-prim, hashable
+, intern, located-base, mtl, parallel
+, parsec, pretty, process, stdenv, syb, tasty
+, tasty-hunit, tasty-rerun, text, text-format, transformers
+, unordered-containers, z3
 }:
 mkDerivation {
   pname = "liquid-fixpoint";
-  version = "9.9.9.9";
+  version = "0.8.0.1";
   src = fetchgitLocal ./.;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     ansi-terminal array ascii-progress async attoparsec base bifunctors
     binary boxes bytestring cereal cmdargs containers deepseq directory
-    filemanip filepath ghc-prim hashable intern located-base mtl parallel parsec
-    pretty process syb text text-format transformers
-    unordered-containers
-    dotgen fgl fgl-visualize
+    dotgen fgl fgl-visualize filemanip filepath ghc-prim hashable
+    intern located-base mtl parallel parsec pretty process
+    syb text text-format transformers unordered-containers
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [

--- a/default.nix
+++ b/default.nix
@@ -1,31 +1,34 @@
-{ fetchgitLocal }:
 { mkDerivation, ansi-terminal, array, ascii-progress, async
 , attoparsec, base, bifunctors, binary, boxes, bytestring, cereal
 , cmdargs, containers, deepseq, directory, dotgen, fgl
-, fgl-visualize, filemanip, filepath, ghc-prim, hashable
-, intern, located-base, mtl, parallel
-, parsec, pretty, process, stdenv, syb, tasty
-, tasty-hunit, tasty-rerun, text, text-format, transformers
+, fgl-visualize, filemanip, filepath, ghc-prim, git, hashable
+, intern, located-base, mtl, nettools, ocaml, parallel, parallel-io
+, parsec, pretty, process, stdenv, stm, syb, tasty, tasty-ant-xml
+, tasty-hunit, tasty-rerun, text, text-format, time, transformers
 , unordered-containers, z3
 }:
 mkDerivation {
   pname = "liquid-fixpoint";
   version = "0.8.0.1";
-  src = fetchgitLocal ./.;
+  src = ./.;
+  configureFlags = [ "-fbuild-external" ];
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     ansi-terminal array ascii-progress async attoparsec base bifunctors
     binary boxes bytestring cereal cmdargs containers deepseq directory
     dotgen fgl fgl-visualize filemanip filepath ghc-prim hashable
-    intern located-base mtl parallel parsec pretty process
-    syb text text-format transformers unordered-containers
+    intern located-base mtl parallel parallel-io parsec pretty process
+    syb text text-format time transformers unordered-containers
   ];
   executableHaskellDepends = [ base ];
+  executableSystemDepends = [ ocaml ];
   testHaskellDepends = [
-    base directory filepath process tasty tasty-hunit tasty-rerun text
+    base containers directory filepath mtl process stm tasty
+    tasty-ant-xml tasty-hunit tasty-rerun text transformers
   ];
-  testSystemDepends = [ z3 ];
+  testSystemDepends = [ git nettools z3 ];
+  doCheck = false;
   homepage = "https://github.com/ucsd-progsys/liquid-fixpoint";
   description = "Predicate Abstraction-based Horn-Clause/Implication Constraint Solver";
   license = stdenv.lib.licenses.bsd3;

--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,52 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
 
 let
 
   inherit (nixpkgs) pkgs;
 
-  f = import ./default.nix { inherit (pkgs) fetchgitLocal; };
+  f = { mkDerivation, ansi-terminal, array, ascii-progress, async
+      , attoparsec, base, bifunctors, binary, boxes, bytestring, cereal
+      , cmdargs, containers, deepseq, directory, dotgen, fgl
+      , fgl-visualize, filemanip, filepath, ghc-prim, git, hashable
+      , intern, located-base, mtl, nettools, ocaml, parallel, parallel-io
+      , parsec, pretty, process, stdenv, stm, syb, tasty, tasty-ant-xml
+      , tasty-hunit, tasty-rerun, text, text-format, time, transformers
+      , unordered-containers, z3
+      }:
+      mkDerivation {
+        pname = "liquid-fixpoint";
+        version = "0.8.0.1";
+        src = ./.;
+        configureFlags = [ "-fbuild-external" ];
+        isLibrary = true;
+        isExecutable = true;
+        libraryHaskellDepends = [
+          ansi-terminal array ascii-progress async attoparsec base bifunctors
+          binary boxes bytestring cereal cmdargs containers deepseq directory
+          dotgen fgl fgl-visualize filemanip filepath ghc-prim hashable
+          intern located-base mtl parallel parallel-io parsec pretty process
+          syb text text-format time transformers unordered-containers
+        ];
+        executableHaskellDepends = [ base ];
+        executableSystemDepends = [ ocaml ];
+        testHaskellDepends = [
+          base containers directory filepath mtl process stm tasty
+          tasty-ant-xml tasty-hunit tasty-rerun text transformers
+        ];
+        testSystemDepends = [ git nettools z3 ];
+        doCheck = false;
+        homepage = "https://github.com/ucsd-progsys/liquid-fixpoint";
+        description = "Predicate Abstraction-based Horn-Clause/Implication Constraint Solver";
+        license = stdenv.lib.licenses.bsd3;
+      };
 
   haskellPackages = if compiler == "default"
                        then pkgs.haskellPackages
                        else pkgs.haskell.packages.${compiler};
 
-  drv = haskellPackages.callPackage f { inherit (pkgs) z3; };
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
 
 in
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.2
+resolver: lts-12.26
 
 flags:
   liquid-fixpoint:


### PR DESCRIPTION
These changes will allow liquid-fixpoint to build with GHC 8.4.4. I have tested building it with both Stack and Nix/NixOS. You may not be ready for that yet, so feel free to disregard this pull request.

There are a lot of changes to default.nix and shell.nix. That's because I'm using the versions that are automatically generated by `cabal2nix`. I think this will be simpler for others who might work on the package.

For future reference, here's how I generated those files.

```
cabal2nix . > default.nix
cabal2nix . --shell > shell.nix
```

I am creating a similar pull request for liquidhaskell.