### PR TITLE
T1409

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,50 +2,20 @@
 
 ## PLE-DEBUG
 
-GOOD [OLD]
+* 91 --> 100 --> 113 --> 115 --> 118 -> 236 -> [7]
 
-stack exec -- fixpoint tests/todo/IndPalindrome.hs.bfq --allowho --eliminate=some --rewrite > log.old 2>&1
+why do ple1-cands make no mention of "parity" ?
 
+n : Peano 
 
-Trace: [INSTANTIATE i = 26] : ((isJust GHC.Base.Nothing <=> false))
-&& ((((((is$GHC.Types.: GHC.Types.[] <=> false)
-        && (is$GHC.Types.[] GHC.Types.[] <=> true))
-       && (is$GHC.Types.: GHC.Types.[] <=> false))
-      && (is$GHC.Types.[] GHC.Types.[] <=> true))
-     && len GHC.Types.[] == 0))
-&& (((((is$IndPalindrome.Pals IndPalindrome.Pal0 <=> false)
-       && (is$IndPalindrome.Pal1 IndPalindrome.Pal0 <=> false))
-      && (is$IndPalindrome.Pal0 IndPalindrome.Pal0 <=> true))
-     && prop IndPalindrome.Pal0 == IndPalindrome.Pal GHC.Types.[]))
-     
-&& IndPalindrome.Pal (IndPalindrome.single d2DX) == IndPalindrome.Pal (GHC.Types.: d2DX GHC.Types.[])
-&& len (GHC.Types.: d2DX GHC.Types.[]) == 1 + len GHC.Types.[]
-&& is$GHC.Types.[] (GHC.Types.: d2DX GHC.Types.[]) == false
-&& is$GHC.Types.: (GHC.Types.: d2DX GHC.Types.[]) == true
-&& lqdc##$select##GHC.Types.:##1 (GHC.Types.: d2DX GHC.Types.[]) == d2DX
-&& lqdc##$select##GHC.Types.:##2 (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[]
-&& is$GHC.Types.[] (GHC.Types.: d2DX GHC.Types.[]) == false
-&& is$GHC.Types.: (GHC.Types.: d2DX GHC.Types.[]) == true
-&& lqdc##$select##GHC.Types.:##1 (GHC.Types.: d2DX GHC.Types.[]) == d2DX
-&& lqdc##$select##GHC.Types.:##2 (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[]
-&& head (GHC.Types.: d2DX GHC.Types.[]) == d2DX
-&& tail (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[]
+a : Peano 
 
+t1 : { even n }
+	|- 1 + 2 = 3 
 
-BAD [NEW]
+t2 : { S a = n }
+	|- 1 + 2 = 3 
 
-stack exec -- fixpoint tests/todo/IndPalindrome.hs.bfq --allowho --eliminate=some --rewrite --incr > log.new 2>&1
+t3 : { a = Z } 
+	|- false 
 
-INCR-INSTANTIATE i = 26: 
-(IndPalindrome.Pal (IndPalindrome.single d2DX) == IndPalindrome.Pal (GHC.Types.: d2DX GHC.Types.[])
- && len (GHC.Types.: d2DX GHC.Types.[]) == 1 + len GHC.Types.[]
- && is$GHC.Types.[] (GHC.Types.: d2DX GHC.Types.[]) == false
- && is$GHC.Types.: (GHC.Types.: d2DX GHC.Types.[]) == true
- && lqdc##$select##GHC.Types.:##1 (GHC.Types.: d2DX GHC.Types.[]) == d2DX
- && lqdc##$select##GHC.Types.:##2 (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[]
- && is$GHC.Types.[] (GHC.Types.: d2DX GHC.Types.[]) == false
- && is$GHC.Types.: (GHC.Types.: d2DX GHC.Types.[]) == true
- && lqdc##$select##GHC.Types.:##1 (GHC.Types.: d2DX GHC.Types.[]) == d2DX
- && lqdc##$select##GHC.Types.:##2 (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[]
- && head (GHC.Types.: d2DX GHC.Types.[]) == d2DX
- && tail (GHC.Types.: d2DX GHC.Types.[]) == GHC.Types.[])

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -185,18 +185,19 @@ equalitiesPred eqs = [ EEq e1 e2 | (e1, e2) <- eqs, e1 /= e2 ]
 updCtxRes :: InstEnv a -> ICtx -> InstRes -> Maybe BindId -> Maybe SubcId -> [Unfold] -> (ICtx, InstRes) 
 updCtxRes env ctx res iMb cidMb us 
                        = -- trace _msg 
-                         ( ctx { icCands  = _cands',   icEquals = mempty}
+                         ( ctx { {- icCands  = _cands', -}  icEquals = mempty}
                          , res'
                          ) 
   where 
     _msg               = Mb.maybe "nuttin\n" (debugResult env res') cidMb
     res'               = updRes res iMb (pAnd solvedEqs) 
-    _cands'             = ((icCands ctx) `S.union` newCands) `S.difference`  (S.fromList solvedCands)
+    -- _cands'             = ((icCands ctx) `S.union` newCands) `S.difference`  (S.fromList solvedCands)
+    -- newCands           = S.fromList (concatMap topApps newEqs) 
+    -- solvedCands        = [ e          | (Just e, _) <- okUnfolds ]
     solvedEqs          = icEquals ctx ++ newEqs 
     newEqs             = concatMap snd okUnfolds
-    solvedCands        = [ e          | (Just e, _) <- okUnfolds ]
     okUnfolds          = tracepp _str [ (eMb, ps)  | (eMb, eqs) <- us, let ps = equalitiesPred eqs, not (null ps) ] 
-    newCands           = _fixme "FIXME: get-topApps newEqs"
+
     _str               = "okUnfolds " ++ showpp (iMb, cidMb)
 
 debugResult :: InstEnv a -> InstRes -> SubcId -> String 

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -90,7 +90,7 @@ data Config = Config
   , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
   , noslice          :: Bool           -- ^ Disable non-concrete KVar slicing
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
-  , incrPle          :: Bool           -- ^ Use incremental PLE
+  , noIncrPle        :: Bool           -- ^ Use incremental PLE
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints 
   } deriving (Eq,Data,Typeable,Show,Generic)
 
@@ -173,7 +173,7 @@ defConfig = Config {
   , nonLinCuts       = False &= help "Treat non-linear kvars as cuts"
   , noslice          = False &= help "Disable non-concrete KVar slicing"
   , rewriteAxioms    = False &= help "allow axiom instantiation via rewriting"
-  , incrPle          = True  &= help "Use incremental PLE"
+  , noIncrPle        = False &= help "Don't use incremental PLE"
   , checkCstr        = []    &= help "Only check these specific constraint-ids" 
   }
   &= verbosity

--- a/tests/proof/ple3.fq
+++ b/tests/proof/ple3.fq
@@ -1,0 +1,30 @@
+// minimal reproduction of LH #1409. UNSAFE with --rewrite; SAFE with --rewrite --noincrple 
+fixpoint "--rewrite"
+
+data Peano 0 = [
+  | S { prev : Peano}
+  | Z { }
+  ]
+
+expand [ 1 : True ]
+expand [ 2 : True ]
+
+constant isEven : (func(0 , [Peano; int]))
+
+define isEven (n : Peano) : int = (((isEven n) = (if (is$Z n) then 1 else (1 - ((isEven (prev n)))))))
+
+bind 0 n :  {n: Peano | (isEven n) = 1 }
+bind 1 a :  {a: Peano | n = S a }
+bind 2 t2 : {v: int   |   a = Z  }
+
+constraint:
+  env [0; 1]
+  lhs {v : int | true }
+  rhs {v : int | 1 + 2 = 3 }
+  id 1 tag []
+
+constraint:
+  env [0; 1; 2]
+  lhs {v : int | true }
+  rhs {v : int | false }
+  id 2 tag []

--- a/unix/Language/Fixpoint/Utils/Progress.hs
+++ b/unix/Language/Fixpoint/Utils/Progress.hs
@@ -24,6 +24,8 @@ withProgress n act = displayConsoleRegions $ do
   progressClose
   return r
 
+
+  
 progressInit :: Int -> IO ()
 progressInit n = do
   normal <- isNormal 
@@ -45,6 +47,18 @@ progressTick    = go =<< readIORef pbRef
   where
    go (Just pr) = tick pr
    go _         = return ()
+
+{- 
+incTick :: ProgressBar -> IO () 
+incTick pb = do
+  st <- getProgressStats pb 
+  if (incomplete st) 
+    then putStrLn (show (stPercent st, stTotal st, stCompleted st)) >> (tick pb)
+    else return () 
+
+incomplete :: Stats -> Bool 
+incomplete st = stPercent st < 100 -- stCompleted st < stTotal st
+-}
 
 progressClose :: IO ()
 progressClose = go =<< readIORef pbRef


### PR DESCRIPTION
Fix for liquidhaskell/#1409 

In incremental-PLE we cannot remove "partially unfolded" 
candidates as _later_ equalities may trigger a "full" unfolding. 

See the test case `tests/proof/ple3.fq` 

Solution is to add new candidates from partially unfolded terms.

Real solution is to rewrite PLE to the version in the POPL18 paper...