### PR TITLE
We have to use LTS-13.10 on Windows currently

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.11
+resolver: lts-13.10
 
 flags:
   liquid-fixpoint:


### PR DESCRIPTION
Because of this bug https://github.com/commercialhaskell/stack/issues/4662