### PR TITLE
Make the horn solver "polymorphic" in the constraint label

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -128,7 +128,7 @@ library
                   , transformers
                   , unordered-containers
   default-language: Haskell98
-  ghc-options:      -W -fno-warn-missing-methods
+  ghc-options:      -W -fno-warn-missing-methods -fwarn-missing-signatures
 
   if flag(devel)
     ghc-options: -Werror

--- a/src/Language/Fixpoint/Horn/Solve.hs
+++ b/src/Language/Fixpoint/Horn/Solve.hs
@@ -20,7 +20,6 @@ import           Data.Either                    (partitionEithers)
 import           System.Exit
 import           GHC.Generics                   (Generic)
 import           Control.DeepSeq
-import           Control.Monad                  (void)
 import qualified Language.Fixpoint.Solver       as Solver 
 import qualified Language.Fixpoint.Misc         as Misc 
 import qualified Language.Fixpoint.Parse        as Parse 
@@ -47,6 +46,9 @@ solveHorn cfg = do
   r <- solve cfg q
   Solver.resultExitCode (fst <$> r)
 
+----------------------------------------------------------------------------------
+eliminate :: (Eq a, F.PPrint a) => F.Config -> H.Query a -> IO (H.Query a) 
+----------------------------------------------------------------------------------
 eliminate cfg q
   | F.eliminate cfg == F.Existentials = do
     q <- Tx.solveEbs q
@@ -61,14 +63,14 @@ eliminate cfg q
   | otherwise = pure q
 
 ----------------------------------------------------------------------------------
-solve :: (NFData a, F.Loc a, Show a, F.Fixpoint a) => F.Config -> H.Query a 
-       -> IO (F.Result (Integer, ()))
+solve :: (Eq a, F.PPrint a, NFData a, F.Loc a, Show a, F.Fixpoint a) => F.Config -> H.Query a 
+       -> IO (F.Result (Integer, a))
 ----------------------------------------------------------------------------------
 solve cfg q = do
   let c = Tx.uniq $ Tx.flatten $ H.qCstr q
   whenLoud $ putStrLn "Horn Uniq:"
   whenLoud $ putStrLn $ F.showpp c
-  q <- eliminate cfg (void $ q { H.qCstr = c })
+  q <- eliminate cfg ({- void $ -} q { H.qCstr = c })
   Solver.solve cfg (hornFInfo q)
 
 hornFInfo :: H.Query a -> F.FInfo a 

--- a/src/Language/Fixpoint/Horn/Transformations.hs
+++ b/src/Language/Fixpoint/Horn/Transformations.hs
@@ -105,8 +105,8 @@ solveEbs (Query qs vs c cons dist) = do
     else do
   let Just side = mside
   -- This whole business depends on Stringly-typed invariant that an ebind
-  -- n corresponds to a pivar πn . That's pretty shit but I can't think of
-  -- a better way to do this
+  -- n corresponds to a pivar πn. That's pretty bad but I can't think of
+  -- a better way to do this.
 
   -- find solutions to the pivars, put them on the Left of the map
   let ns = fst <$> ebs c
@@ -882,7 +882,7 @@ boundKvars (CAnd c)             = mconcat $ boundKvars <$> c
 boundKvars (All (Bind _ _ p) c) = pKVars p <> boundKvars c
 boundKvars (Any (Bind _ _ p) c) = pKVars p <> boundKvars c
 
--- pKVars :: Pred -> S.Set F.Symbol
+pKVars :: Pred -> S.Set F.Symbol
 pKVars (Var k _) = S.singleton k
 pKVars (PAnd ps) = mconcat $ pKVars <$> ps
 pKVars _         = S.empty

--- a/src/Language/Fixpoint/Horn/Transformations.hs
+++ b/src/Language/Fixpoint/Horn/Transformations.hs
@@ -122,7 +122,7 @@ solveEbs (Query qs vs c cons dist) = do
 
   let sol = evalState (mapM (lookupSol l0 M.empty . piVar) ns) (ksols <> pisols)
   whenLoud $ putStrLn "QE sols:"
-  let elimSol = M.fromList $ zip (piSym <$> ns) [Head (Reft p) l0 | p <- sol] -- <<< don't fing LOSE INFORMATION
+  let elimSol = M.fromList $ zip (piSym <$> ns) [Head (Reft p) l0 | p <- sol]
   whenLoud $ putStrLn $ F.showpp elimSol
   let kSol = M.mapMaybe (either (either Just (const Nothing)) (const Nothing)) ksols
 


### PR DESCRIPTION
Primarily, make the type of

```haskell
Horn.Solve.solve :: (...) => F.Config -> H.Query a -> IO (F.Result (Integer, a))
```

instead of erasing the labels with `F.Result (Integer, ())`.

Also, enforce top-level-signature requirement for building `liquid-fixpoint`.