### PR TITLE
Rename LH Set to work around Z3 having its own Set

### DIFF
--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -61,6 +61,8 @@ import           Data.String                 (IsString(..))
 -- | Theory Symbols ------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+-- "set" is currently \"LSet\" instead of just \"Set\" because Z3 has its own
+-- \"Set\" since 4.8.5
 elt, set, map :: Raw
 elt  = "Elt"
 set  = "LSet"

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -63,7 +63,7 @@ import           Data.String                 (IsString(..))
 
 elt, set, map :: Raw
 elt  = "Elt"
-set  = "Set"
+set  = "LSet"
 map  = "Map"
 
 emp, add, cup, cap, mem, dif, sub, com, sel, sto, mcup, mdef :: Raw


### PR DESCRIPTION
This fixes [#1503](https://github.com/ucsd-progsys/liquidhaskell/issues/1503) for me.
Is this all I have to do? @nikivazou