### PR TITLE
Allow Tuple Syntax in Refinements

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -99,7 +99,6 @@ import           Language.Fixpoint.Smt.Bitvector
 import           Language.Fixpoint.Types.Errors
 import qualified Language.Fixpoint.Misc      as Misc      
 import           Language.Fixpoint.Smt.Types
--- import           Language.Fixpoint.Types.Names     (headSym)
 -- import           Language.Fixpoint.Types.Visitor   (foldSort, mapSort)
 import           Language.Fixpoint.Types hiding    (mapSort)
 import           Text.PrettyPrint.HughesPJ         (text, nest, vcat, (<+>))
@@ -362,6 +361,7 @@ expr0P
  <|> (ECon <$> constantP)
  <|> (reservedOp "_|_" >> return EBot)
  <|> lamP
+ <|> try tupleP
   -- TODO:AZ get rid of these try, after the rest
  <|> try (parens exprP)
  <|> (reserved "[]" >> emptyListP)
@@ -494,12 +494,19 @@ funAppP            =  litP <|> exprFunP <|> simpleAppP
     exprFunP = mkEApp <$> funSymbolP <*> funRhsP
     funRhsP  =  sepBy1 expr0P blanks
             <|> parens innerP
-    innerP =   brackets (sepBy exprP semi)
-           <|> sepBy exprP comma
+    innerP   = brackets (sepBy exprP semi)
 
     -- TODO:AZ the parens here should be superfluous, but it hits an infinite loop if removed
     simpleAppP     = EApp <$> parens exprP <*> parens exprP
     funSymbolP     = locParserP symbolP
+
+
+tupleP :: Parser Expr
+tupleP = do
+  let tp = parens (pairP exprP comma (sepBy1 exprP comma))
+  Loc l1 l2 (first, rest) <- locParserP tp
+  let cons = symbol $ "(" ++ replicate (length rest) ',' ++ ")"
+  return $ mkEApp (Loc l1 l2 cons) (first : rest)
 
 
 -- TODO:AZ: The comment says BitVector literal, but it accepts any @Sort@

--- a/tests/pos/test00.hs.fq
+++ b/tests/pos/test00.hs.fq
@@ -38,17 +38,17 @@ qualif True(v:bool)   : (? v)
 qualif False(v:bool)  : ~ (? v) 
 qualif True1(v:GHC.Types.Bool): (Prop(v))
 qualif False1(v:GHC.Types.Bool): (~ Prop(v))
-qualif Papp(v:a, p:Pred a) : (papp1(p, v))
+qualif Papp(v:a, p:Pred a) : (papp1 p v)
 
 constant papp1 : func(1, [Pred @(0); @(0); bool])
 
-qualif Papp2(v:a,x:b,p:Pred a b) : papp2(p, v, x)
+qualif Papp2(v:a,x:b,p:Pred a b) : (papp2 p v x)
 constant papp2 : func(4, [Pred @(0) @(1); @(2); @(3); bool])
 
-qualif Papp3(v:a,x:b, y:c, p:Pred a b c) : papp3(p, v, x, y)
+qualif Papp3(v:a,x:b, y:c, p:Pred a b c) : (papp3 p v x y)
 constant papp3 : func(6, [Pred @(0) @(1) @(2); @(3); @(4); @(5); bool])
 
-qualif Papp4(v:a,x:b, y:c, z:d, p:Pred a b c d) : papp4(p, v, x, y, z)
+qualif Papp4(v:a,x:b, y:c, z:d, p:Pred a b c d) : (papp4 p v x y z)
 constant papp4 : func(8, [Pred @(0) @(1) @(2) @(6); @(3); @(4); @(5); @(7); bool])
 
 

--- a/tests/proof/list00.fq
+++ b/tests/proof/list00.fq
@@ -10,7 +10,7 @@ match len Cons x xs = (1 + len xs)
 constraint:
   env []
   lhs {v : int | true }
-  rhs {v : int | len(Cons(1, Cons(2, Cons(3, Nil)))) = 3}
+  rhs {v : int | len (Cons 1 (Cons 2 (Cons 3 Nil))) = 3}
   id 1 tag []
 
 expand [1 : True]

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -142,7 +142,7 @@ testFunAppP =
         show (doParse' funAppP "test" "fooBar baz qux") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
 
     , testCase "ECon (exprFunCommasP)" $
-        show (doParse' funAppP "test" "fooBar (baz, qux)") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
+        show (doParse' funAppP "test" "fooBar (baz, qux)") @?= "EApp (EVar \"fooBar\") (EApp (EApp (EVar \"(,)\") (EVar \"baz\")) (EVar \"qux\"))"
 
     , testCase "ECon (exprFunSemisP)" $
         show (doParse' funAppP "test" "fooBar ([baz; qux])") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"
@@ -287,7 +287,7 @@ testPredP =
         show (doParse' predP "test" "f a b") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"
 
     , testCase "funApp 2" $
-        show (doParse' predP "test" "f (a, b)") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"
+        show (doParse' predP "test" "f (a, b)") @?= "EApp (EVar \"f\") (EApp (EApp (EVar \"(,)\") (EVar \"a\")) (EVar \"b\"))"
 
     , testCase "funApp 3" $
         show (doParse' predP "test" "f ([a; b])") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"


### PR DESCRIPTION
This pull request allows for tuple syntax to be used in refinements. It can handle the example in https://github.com/ucsd-progsys/liquidhaskell/issues/1162.

However, this will change is not entirely backwards compatible. Currently, `f (x, y)` in a refinement is parsed as `f x y`. This syntax will now mean the same as it does in Haskell (i.e applying the single argument `(x, y)` to `f`). It looks like there are some tests in the `liquidhaskell` repository that indeed do break with this change.