### PR TITLE
Expand Function Extensionality

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -74,6 +74,7 @@ library
                     Language.Fixpoint.Solver.UniqifyBinds
                     Language.Fixpoint.Solver.UniqifyKVars
                     Language.Fixpoint.Solver.Worklist
+                    Language.Fixpoint.Solver.Extensionality
                     Language.Fixpoint.SortCheck
                     Language.Fixpoint.Types
                     Language.Fixpoint.Types.Config

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -201,10 +201,9 @@ simplifyFInfo !cfg !fi0 = do
   let si4  = {-# SCC "defunction" #-} defunctionalize cfg $!! si3
   -- putStrLn $ "AXIOMS: " ++ showpp (asserts si4)
   loudDump 2 cfg si4
-  let senv = symbolEnv cfg si4
-  let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") senv si4
+  let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
   loudDump 3 cfg si5
-  let si6  = {-# SCC "expand"     #-} expand senv si5
+  let si6  = if extensionality cfg then {-# SCC "expand"     #-} expand cfg si5 else si5
   instantiate cfg $!! si6
 
 

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -34,6 +34,7 @@ import           Language.Fixpoint.Solver.Sanitize  (symbolEnv, sanitize)
 import           Language.Fixpoint.Solver.UniqifyBinds (renameAll)
 import           Language.Fixpoint.Defunctionalize (defunctionalize)
 import           Language.Fixpoint.SortCheck            (Elaborate (..))
+import           Language.Fixpoint.Solver.Extensionality (expand)
 import           Language.Fixpoint.Solver.UniqifyKVars (wfcUniqify)
 import qualified Language.Fixpoint.Solver.Solve     as Sol
 import           Language.Fixpoint.Types.Config
@@ -200,9 +201,11 @@ simplifyFInfo !cfg !fi0 = do
   let si4  = {-# SCC "defunction" #-} defunctionalize cfg $!! si3
   -- putStrLn $ "AXIOMS: " ++ showpp (asserts si4)
   loudDump 2 cfg si4
-  let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
+  let senv = symbolEnv cfg si4
+  let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") senv si4
   loudDump 3 cfg si5
-  instantiate cfg $!! si5
+  let si6  = {-# SCC "expand"     #-} expand senv si5
+  instantiate cfg $!! si6
 
 
 solveNative' !cfg !fi0 = do

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -8,82 +8,101 @@ module Language.Fixpoint.Solver.Extensionality (expand) where
 import           Control.Monad.State
 import qualified Data.HashMap.Strict       as M
 import           Data.Maybe  (fromMaybe)
-import qualified Data.List                 as L 
 
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Types hiding (mapSort)
 import           Language.Fixpoint.Types.Visitor ( (<$$>), mapSort )
 
+mytracepp :: (PPrint a) => String -> a -> a
+mytracepp = notracepp 
+
 expand :: SymEnv -> SInfo a -> SInfo a
-expand senv si = evalState (expend si) $ initST senv (ddecls si)
+expand senv si = evalState (extend si) $ initST senv (ddecls si)
 
 
-class Expend a where
-  expend :: a -> Ex a
+class Extend a where
+  extend :: a -> Ex a
 
 
-instance Expend (SInfo a) where
-  expend si = do 
+instance Extend (SInfo a) where
+  extend si = do 
     setBEnv (bs si)
-    cm'      <- expend (cm si) 
+    cm'      <- extend (cm si) 
     bs'      <- exbenv <$> get  
     return $ si{ cm = cm' , bs = bs' }
 
-instance (Expend a) => Expend (M.HashMap SubcId a) where 
-  expend h = M.fromList <$> mapM expend (M.toList h) 
+instance (Extend a) => Extend (M.HashMap SubcId a) where 
+  extend h = M.fromList <$> mapM extend (M.toList h) 
 
-instance (Expend a, Expend b) => Expend (a,b) where 
-  expend (a,b) = (,) <$> expend a <*> expend b 
+instance (Extend a, Extend b) => Extend (a,b) where 
+  extend (a,b) = (,) <$> extend a <*> extend b 
 
-instance Expend SubcId where
-  expend i = return i 
+instance Extend SubcId where
+  extend i = return i 
 
-instance Expend (SimpC a) where
-  expend c = do 
-    setExBinds 
-    rhs <- expend (_crhs c)
-    is <- exbinds <$> get 
-    return $ c{_crhs = rhs, _cenv = fromListIBindEnv is `unionIBindEnv` _cenv c}
+instance Extend (SimpC a) where
+  extend c = do 
+    setExBinds (_cenv c)
+    rhs <- extend (_crhs c)
+    is  <- exbinds <$> get 
+    return $ c{_crhs = rhs, _cenv = is }
 
-instance Expend Expr where 
-  expend e = mapMPosExpr Pos goP e >>= mapMPosExpr Pos goN 
+instance Extend Expr where 
+  extend e = mapMPosExpr Pos goP (normalize e) >>= mapMPosExpr Pos goN 
     where  
       goP Pos (PAtom b e1 e2)
-       | (b == Eq || b == Ne)
-       , Just s <- bkFFunc (exprSort "extensionality" e1)
-       = do let ss   = init $ snd s
-            xs      <- mapM freshArg ss 
-            env     <- exenv <$> get 
-            let e1'  = eApps (unElab e1) xs 
-            let e2'  = eApps (unElab e2) xs 
-            let elab = elaborate (dummyLoc "extensionality") env
-            return   $ PAtom b (elab e1') (elab e2')
+       | b == Eq || b == Ne  
+       , Just s <- getArg (exprSort "extensionality" e1)
+       = extendRHS b e1 e2 s >>= goP Pos  
       goP _ e = return e 
       goN Neg (PAtom b e1 e2)
-       | (b == Eq || b == Ne)
-       , Just s <- bkFFunc (exprSort "extensionality" e1)
-       = do dds <- exddecl <$> get 
-            let ss    = init $ snd s
-            es       <- instantiate dds ss 
-            env <- exenv <$> get 
-            let e1' x = eApps (unElab e1) x 
-            let e2' x = eApps (unElab e2) x 
-            let elab  = elaborate (dummyLoc "extensionality") env
-            let pAtom x = PAtom b (elab $ e1' x) (elab $ e2' x)
-            return $ PAnd (pAtom <$> L.transpose es)
+       | b == Eq || b == Ne
+       , Just s <- getArg (exprSort "extensionality" e1)
+       = extendLHS b e1 e2 s >>= goN Neg 
       goN _ e = return e 
 
-instantiate :: [DataDecl]  -> [Sort] -> Ex [[Expr]]
-instantiate ds ss = mapM instantiateOne (breakSort ds <$> ss)  
+getArg :: Sort -> Maybe Sort 
+getArg s = case bkFFunc s of 
+             Just (_,(a:_:_)) -> Just a 
+             _                -> Nothing 
 
-instantiateOne :: Either (LocSymbol, [Sort]) Sort  -> Ex [Expr]
+extendRHS, extendLHS :: Brel -> Expr -> Expr -> Sort -> Ex Expr
+extendRHS b e1 e2 s = 
+  do es <- generateArguments s 
+     (mytracepp "extendRHS = " . pAnd) <$> mapM (makeEq b e1 e2) es
+
+extendLHS b e1 e2 s = 
+  do es  <- generateArguments s 
+     dds <- exddecl <$> get 
+     is  <- instantiate dds s 
+     (mytracepp "extendLHS = " . pAnd) <$> mapM (makeEq b e1 e2) (es ++ is)
+
+
+generateArguments :: Sort -> Ex [Expr]
+generateArguments s = do 
+  st   <- get 
+  case breakSort (exddecl st) s of 
+    Left dds -> mapM freshArgDD dds  
+    Right s  -> (\x -> [EVar x]) <$> freshArgOne s 
+
+makeEq :: Brel-> Expr -> Expr -> Expr -> Ex Expr 
+makeEq b e1 e2 e = do 
+  env <- exenv <$> get 
+  let elab = elaborate (dummyLoc "extensionality") env
+  return $ PAtom b (elab $ EApp (unElab e1) e)  (elab $ EApp (unElab e2) e)
+
+instantiate :: [DataDecl]  -> Sort -> Ex [Expr]
+instantiate ds s = instantiateOne (breakSort ds s)  
+
+instantiateOne :: Either [(LocSymbol, [Sort])] Sort  -> Ex [Expr]
 instantiateOne (Right s@(FVar _)) = 
   (\x -> [EVar x]) <$> freshArgOne s
 instantiateOne (Right s) = do 
   xss <- excbs <$> get 
   return [EVar x | (x,xs) <- xss, xs == s ] 
-instantiateOne (Left (dc, ts)) = 
+instantiateOne (Left [(dc, ts)]) = 
   (map (mkEApp dc) . combine) <$>  mapM instantiateOne (Right <$> ts) 
+instantiateOne _ = undefined 
 
 combine :: [[a]] -> [[a]]
 combine []          = [[]]
@@ -103,34 +122,72 @@ mapMPosExpr p f = go p
     go p e@(ECon _)      = f p e
     go p e@(EVar _)      = f p e
     go p e@(PKVar _ _)   = f p e
-    go p (PGrad k s i e) = f p =<< (PGrad k s i <$>  go p e                     )
     go p (ENeg e)        = f p =<< (ENeg        <$>  go p e                     )
-    go p (PNot e)        = f p =<< (PNot        <$>  go p e                     )
     go p (ECst e t)      = f p =<< ((`ECst` t)  <$>  go p e                     )
+    go p (ECoerc a t e)  = f p =<< (ECoerc a t  <$>  go p e                     )
+    go p (EApp g e)      = f p =<< (EApp        <$>  go p g  <*> go p e             )
+    go p (EBin o e1 e2)  = f p =<< (EBin o      <$>  go p e1 <*> go p e2            )
+    go p (PAtom r e1 e2) = f p =<< (PAtom r     <$>  go p e1 <*> go p e2            )
+
+    go p (PImp p1 p2)    = f p =<< (PImp        <$>  go (negatePos p) p1 <*> go p p2)
+    go p (PAnd ps)       = f p =<< (PAnd        <$> (go p <$$> ps)                  )
+
+    -- The below cannot appear due to normalization
+    go p (PNot e)        = f p =<< (PNot        <$>  go p e                     )
+    go p (PIff p1 p2)    = f p =<< (PIff        <$>  go p p1 <*> go p p2            )
+    go p (EIte e e1 e2)  = f p =<< (EIte        <$>  go p e  <*> go p e1 <*> go p e2)
+    go p (POr  ps)       = f p =<< (POr         <$> (go p <$$> ps)                  )
+
+    -- The following canot appear in general 
     go p (PAll xts e)    = f p =<< (PAll   xts  <$>  go p e                     )
     go p (ELam (x,t) e)  = f p =<< (ELam (x,t)  <$>  go p e                     )
-    go p (ECoerc a t e)  = f p =<< (ECoerc a t  <$>  go p e                     )
     go p (PExist xts e)  = f p =<< (PExist xts  <$>  go p e                     )
     go p (ETApp e s)     = f p =<< ((`ETApp` s) <$>  go p e                     )
     go p (ETAbs e s)     = f p =<< ((`ETAbs` s) <$>  go p e                     )
-    go p (EApp g e)      = f p =<< (EApp        <$>  go p g  <*> go p e             )
-    go p (EBin o e1 e2)  = f p =<< (EBin o      <$>  go p e1 <*> go p e2            )
-    go p (PImp p1 p2)    = f p =<< (PImp        <$>  go (negatePos p) p1 <*> go p p2)
-    go p (PIff p1 p2)    = f p =<< (PIff        <$>  go p p1 <*> go p p2            )
-    go p (PAtom r e1 e2) = f p =<< (PAtom r     <$>  go p e1 <*> go p e2            )
-    go p (EIte e e1 e2)  = f p =<< (EIte        <$>  go p e  <*> go p e1 <*> go p e2)
-    go p (PAnd ps)       = f p =<< (PAnd        <$> (go p <$$> ps)                  )
-    go p (POr  ps)       = f p =<< (POr         <$> (go p <$$> ps)                  )
+    go p (PGrad k s i e) = f p =<< (PGrad k s i <$>  go p e                     )
+
+normalize :: Expr -> Expr 
+normalize e = mytracepp ("normalize: " ++ showpp e) $ go e  
+  where 
+    go e@(ESym _)        = e
+    go e@(ECon _)        = e
+    go e@(EVar _)        = e
+    go e@(PKVar _ _)     = e
+    go e@(ENeg _)        = e
+    go (PNot e)          = PImp e PFalse
+    go e@(ECst _ _)      = e
+    go e@(ECoerc _ _ _)  = e
+    go e@(EApp _ _)      = e 
+    go e@(EBin _ _ _)    = e 
+    go (PImp p1 p2)      = PImp (go p1) (go p2)
+    go (PIff p1 p2)      = PAnd [PImp p1' p2', PImp p2' p1'] where (p1', p2') = (go p1, go p2)
+    go e@(PAtom _ _ _)   = e 
+    go (EIte e e1 e2)    = go $ PAnd [PImp e e1, PImp (PNot e) e2]
+    go (PAnd ps)         = pAnd (go <$> ps)
+    go (POr  ps)         = go $ foldl (\p q -> PImp (PImp p PFalse) (go q)) PTrue ps 
+    go e@(PAll _ _)      = e -- Cannot appear
+    go e@(ELam _ _)      = e -- Cannot appear
+    go e@(PExist _ _)    = e -- Cannot appear
+    go e@(ETApp _ _)     = e -- Cannot appear
+    go e@(ETAbs _ _)     = e -- Cannot appear
+    go e@(PGrad _ _ _ _) = e -- Cannot appear
 
 
+    
 type Ex    = State ExSt
-data ExSt = ExSt { unique :: Int, exddecl :: [DataDecl] ,  exenv :: SymEnv, exbenv :: BindEnv, exbinds :: [BindId], excbs :: [(Symbol, Sort)] }
+data ExSt = ExSt { unique  :: Int
+                 , exddecl :: [DataDecl]
+                 , exenv   :: SymEnv        -- used for elaboration 
+                 , exbenv  :: BindEnv
+                 , exbinds :: IBindEnv
+                 , excbs   :: [(Symbol, Sort)] 
+                 }
 
 initST :: SymEnv -> [DataDecl]  -> ExSt
 initST env dd = ExSt 0 (d:dd) env mempty mempty mempty
   where 
     -- NV: hardcore Haskell pairs because they do not appear in DataDecl (why?)
-    d = tracepp "Tuple DataDecl" $ DDecl (symbolFTycon (dummyLoc tupConName)) 2 [ct]
+    d = mytracepp "Tuple DataDecl" $ DDecl (symbolFTycon (dummyLoc tupConName)) 2 [ct]
     ct = DCtor (dummyLoc (symbol "GHC.Tuple.(,)")) [
             DField (dummyLoc (symbol "lqdc$select$GHC.Tuple.(,)$1")) (FVar 0)
           , DField (dummyLoc (symbol "lqdc$select$GHC.Tuple.(,)$2")) (FVar 1)
@@ -140,17 +197,16 @@ initST env dd = ExSt 0 (d:dd) env mempty mempty mempty
 setBEnv :: BindEnv -> Ex () 
 setBEnv benv = modify (\st -> st{exbenv = benv})
 
-setExBinds :: Ex ()
-setExBinds = modify (\st -> st{exbinds = []})
+setExBinds :: IBindEnv-> Ex ()
+setExBinds bids = modify (\st -> st{ exbinds = bids
+                                   , excbs   = [ (x, sr_sort r) | (i, x, r) <- bindEnvToList (exbenv st)
+                                                                , memberIBindEnv i bids]})
 
-freshArg :: Sort -> Ex Expr 
-freshArg s = do 
-  st   <- get 
-  case breakSort (exddecl st) s of 
-    Left (dc, xs) -> do  
-      xs <- mapM freshArgOne xs
-      return $ mkEApp dc (EVar <$> xs)
-    Right s -> EVar <$> freshArgOne s 
+
+freshArgDD :: (LocSymbol, [Sort]) -> Ex Expr 
+freshArgDD (dc, xs) = do  
+  xs <- mapM freshArgOne xs
+  return $ mkEApp dc (EVar <$> xs)
 
 
 freshArgOne :: Sort -> Ex Symbol 
@@ -158,15 +214,20 @@ freshArgOne s = do
   st   <- get 
   let x = symbol ("ext$" ++ show (unique st))
   let (id, benv') = insertBindEnv x (trueSortedReft s) (exbenv st)
-  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st, unique = 1 + (unique st) , excbs = (x,s):(excbs st)})
+  modify (\st -> st{ exenv   = insertSymEnv x s (exenv st)
+                   , exbenv  = benv'
+                   , exbinds = insertsIBindEnv [id] (exbinds st)
+                   , unique   = 1 + (unique st) 
+                   , excbs = (x,s):(excbs st)
+                   })
   return x 
 
 
-breakSort :: [DataDecl] -> Sort -> Either (LocSymbol, [Sort]) Sort 
+breakSort :: [DataDecl] -> Sort -> Either [(LocSymbol, [Sort])] Sort 
 breakSort ddecls s
     | Just (tc, ts) <- splitTC s
-    , [([dd],i)] <- [ (ddCtors dd,ddVars dd) | dd <- ddecls, ddTyCon dd == tc ] 
-    = Left (dcName dd, (instSort  (Sub $ zip [0..(i-1)] ts)) <$> dfSort <$> dcFields dd)
+    , [(dds,i)] <- [ (ddCtors dd,ddVars dd) | dd <- ddecls, ddTyCon dd == tc ] 
+    = Left ((\dd -> (dcName dd, (instSort  (Sub $ zip [0..(i-1)] ts)) <$> dfSort <$> dcFields dd)) <$> dds)
     | otherwise 
     = Right s
 

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -9,15 +9,17 @@ import           Control.Monad.State
 import qualified Data.HashMap.Strict       as M
 import           Data.Maybe  (fromMaybe)
 
+import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.SortCheck
+import           Language.Fixpoint.Solver.Sanitize (symbolEnv)
 import           Language.Fixpoint.Types hiding (mapSort)
 import           Language.Fixpoint.Types.Visitor ( (<$$>), mapSort )
 
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp 
 
-expand :: SymEnv -> SInfo a -> SInfo a
-expand senv si = evalState (extend si) $ initST senv (ddecls si)
+expand :: Config -> SInfo a -> SInfo a
+expand cfg si = evalState (extend si) $ initST (symbolEnv cfg si) (ddecls si)
 
 
 class Extend a where

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -78,5 +78,5 @@ freshArg s = do
   st   <- get 
   let x = symbol ("ext$" ++ show (unique st))
   let (id, benv') = insertBindEnv x (trueSortedReft s) (exbenv st)
-  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st })
+  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st, unique = 1 + (unique st) })
   return x 

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE PatternGuards        #-}
+
+module Language.Fixpoint.Solver.Extensionality (expand) where
+
+import           Control.Monad.State
+import qualified Data.HashMap.Strict       as M
+
+import           Language.Fixpoint.SortCheck
+import           Language.Fixpoint.Types.Sorts
+import           Language.Fixpoint.Types
+import           Language.Fixpoint.Types.Visitor (mapMExpr)
+
+expand :: SymEnv -> SInfo a -> SInfo a
+expand senv si = evalState (expend si) $ initST senv 
+
+
+class Expend a where
+  expend :: a -> Ex a
+
+
+instance Expend (SInfo a) where
+  expend si = do 
+    setBEnv (bs si)
+    cm'      <- expend (cm si) 
+    bs'      <- exbenv <$> get  
+    return $ si{ cm = cm' , bs = bs' }
+
+instance (Expend a) => Expend (M.HashMap SubcId a) where 
+  expend h = M.fromList <$> mapM expend (M.toList h) 
+
+instance (Expend a, Expend b) => Expend (a,b) where 
+  expend (a,b) = (,) <$> expend a <*> expend b 
+
+instance Expend SubcId where
+  expend i = return i 
+
+instance Expend (SimpC a) where
+  expend c = do 
+    setExBinds 
+    rhs <- expend (_crhs c)
+    is <- exbinds <$> get 
+    return $ c{_crhs = rhs, _cenv = fromListIBindEnv is `unionIBindEnv` _cenv c}
+
+
+instance Expend Expr where 
+  expend = mapMExpr go 
+    where  
+      go (PAtom b e1 e2)
+       | (b == Eq || b == Ne)
+       , Just s <- bkFFunc (exprSort "extensionality" e1)
+       = do let ss   = init $ snd s
+            xs      <- mapM freshArg ss 
+            env     <- exenv <$> get 
+            let e1'  = eApps (unElab e1) (EVar <$> xs) 
+            let e2'  = eApps (unElab e2) (EVar <$> xs) 
+            let elab = elaborate (dummyLoc "extensionality") env
+            return   $ PAtom b (elab e1') (elab e2')
+      go e = return e 
+
+      
+type Ex    = State ExSt
+data ExSt = ExSt { unique :: Int, exenv :: SymEnv, exbenv :: BindEnv, exbinds :: [BindId] }
+
+initST :: SymEnv -> ExSt
+initST env = ExSt 0 env mempty mempty 
+
+
+setBEnv :: BindEnv -> Ex () 
+setBEnv benv = modify (\st -> st{exbenv = benv})
+
+setExBinds :: Ex ()
+setExBinds = modify (\st -> st{exbinds = []})
+
+freshArg :: Sort -> Ex Symbol
+freshArg s = do 
+  st   <- get 
+  let x = symbol ("ext$" ++ show (unique st))
+  let (id, benv') = insertBindEnv x (trueSortedReft s) (exbenv st)
+  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st })
+  return x 

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -59,12 +59,12 @@ extendExpr p e
       goP Pos (PAtom b e1 e2)
        | b == Eq || b == Ne  
        , Just s <- getArg (exprSort "extensionality" e1)
-       = extendRHS b e1 e2 s >>= goP Pos  
+       = mytracepp ("extending POS = " ++ showpp e) <$> (extendRHS b e1 e2 s >>= goP Pos) 
       goP _ e = return e 
       goN Neg (PAtom b e1 e2)
        | b == Eq || b == Ne
        , Just s <- getArg (exprSort "extensionality" e1)
-       = extendLHS b e1 e2 s >>= goN Neg 
+       = mytracepp ("extending NEG = " ++ showpp e) <$> (extendLHS b e1 e2 s >>= goN Neg) 
       goN _ e = return e 
 
 getArg :: Sort -> Maybe Sort 
@@ -170,14 +170,13 @@ normalize e = mytracepp ("normalize: " ++ showpp e) $ go e
     go e@(PAtom _ _ _)   = e 
     go (EIte e e1 e2)    = go $ PAnd [PImp e e1, PImp (PNot e) e2]
     go (PAnd ps)         = pAnd (go <$> ps)
-    go (POr  ps)         = go $ foldl (\p q -> PImp (PImp p PFalse) (go q)) PTrue ps 
+    go (POr  ps)         = foldl (\x y -> PImp (PImp (go x) PFalse) y) PFalse ps 
     go e@(PAll _ _)      = e -- Cannot appear
     go e@(ELam _ _)      = e -- Cannot appear
     go e@(PExist _ _)    = e -- Cannot appear
     go e@(ETApp _ _)     = e -- Cannot appear
     go e@(ETAbs _ _)     = e -- Cannot appear
     go e@(PGrad _ _ _ _) = e -- Cannot appear
-
 
     
 type Ex    = State ExSt

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -75,7 +75,7 @@ extendLHS b e1 e2 s =
   do es  <- generateArguments s 
      dds <- exddecl <$> get 
      is  <- instantiate dds s 
-     (mytracepp "extendLHS = " . pAnd) <$> mapM (makeEq b e1 e2) (es ++ is)
+     (mytracepp "extendLHS = " . pAnd . (PAtom b e1 e2:)) <$> mapM (makeEq b e1 e2) (es ++ is)
 
 
 generateArguments :: Sort -> Ex [Expr]

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -1,19 +1,21 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE PatternGuards        #-}
+{-# LANGUAGE FlexibleContexts     #-}
 
 module Language.Fixpoint.Solver.Extensionality (expand) where
 
 import           Control.Monad.State
 import qualified Data.HashMap.Strict       as M
+import           Data.Maybe  (fromMaybe)
+import qualified Data.List                 as L 
 
 import           Language.Fixpoint.SortCheck
-import           Language.Fixpoint.Types.Sorts
-import           Language.Fixpoint.Types
-import           Language.Fixpoint.Types.Visitor (mapMExpr)
+import           Language.Fixpoint.Types hiding (mapSort)
+import           Language.Fixpoint.Types.Visitor ( (<$$>), mapSort )
 
 expand :: SymEnv -> SInfo a -> SInfo a
-expand senv si = evalState (expend si) $ initST senv 
+expand senv si = evalState (expend si) $ initST senv (ddecls si)
 
 
 class Expend a where
@@ -43,28 +45,96 @@ instance Expend (SimpC a) where
     is <- exbinds <$> get 
     return $ c{_crhs = rhs, _cenv = fromListIBindEnv is `unionIBindEnv` _cenv c}
 
-
 instance Expend Expr where 
-  expend = mapMExpr go 
+  expend e = mapMPosExpr Pos goP e >>= mapMPosExpr Pos goN 
     where  
-      go (PAtom b e1 e2)
+      goP Pos (PAtom b e1 e2)
        | (b == Eq || b == Ne)
        , Just s <- bkFFunc (exprSort "extensionality" e1)
        = do let ss   = init $ snd s
             xs      <- mapM freshArg ss 
             env     <- exenv <$> get 
-            let e1'  = eApps (unElab e1) (EVar <$> xs) 
-            let e2'  = eApps (unElab e2) (EVar <$> xs) 
+            let e1'  = eApps (unElab e1) xs 
+            let e2'  = eApps (unElab e2) xs 
             let elab = elaborate (dummyLoc "extensionality") env
             return   $ PAtom b (elab e1') (elab e2')
-      go e = return e 
+      goP _ e = return e 
+      goN Neg (PAtom b e1 e2)
+       | (b == Eq || b == Ne)
+       , Just s <- bkFFunc (exprSort "extensionality" e1)
+       = do dds <- exddecl <$> get 
+            let ss    = init $ snd s
+            es       <- instantiate dds ss 
+            env <- exenv <$> get 
+            let e1' x = eApps (unElab e1) x 
+            let e2' x = eApps (unElab e2) x 
+            let elab  = elaborate (dummyLoc "extensionality") env
+            let pAtom x = PAtom b (elab $ e1' x) (elab $ e2' x)
+            return $ PAnd (pAtom <$> L.transpose es)
+      goN _ e = return e 
 
-      
+instantiate :: [DataDecl]  -> [Sort] -> Ex [[Expr]]
+instantiate ds ss = mapM instantiateOne (breakSort ds <$> ss)  
+
+instantiateOne :: Either (LocSymbol, [Sort]) Sort  -> Ex [Expr]
+instantiateOne (Right s@(FVar _)) = 
+  (\x -> [EVar x]) <$> freshArgOne s
+instantiateOne (Right s) = do 
+  xss <- excbs <$> get 
+  return [EVar x | (x,xs) <- xss, xs == s ] 
+instantiateOne (Left (dc, ts)) = 
+  (map (mkEApp dc) . combine) <$>  mapM instantiateOne (Right <$> ts) 
+
+combine :: [[a]] -> [[a]]
+combine []          = [[]]
+combine ([]:_)      = []
+combine ((x:xs):ys) = map (x:) (combine ys) ++ combine (xs:ys)
+
+
+data Pos = Pos | Neg 
+negatePos :: Pos -> Pos 
+negatePos Pos = Neg 
+negatePos Neg = Pos 
+
+mapMPosExpr :: (Monad m) => Pos -> (Pos -> Expr -> m Expr) -> Expr -> m Expr
+mapMPosExpr p f = go p 
+  where
+    go p e@(ESym _)      = f p e
+    go p e@(ECon _)      = f p e
+    go p e@(EVar _)      = f p e
+    go p e@(PKVar _ _)   = f p e
+    go p (PGrad k s i e) = f p =<< (PGrad k s i <$>  go p e                     )
+    go p (ENeg e)        = f p =<< (ENeg        <$>  go p e                     )
+    go p (PNot e)        = f p =<< (PNot        <$>  go p e                     )
+    go p (ECst e t)      = f p =<< ((`ECst` t)  <$>  go p e                     )
+    go p (PAll xts e)    = f p =<< (PAll   xts  <$>  go p e                     )
+    go p (ELam (x,t) e)  = f p =<< (ELam (x,t)  <$>  go p e                     )
+    go p (ECoerc a t e)  = f p =<< (ECoerc a t  <$>  go p e                     )
+    go p (PExist xts e)  = f p =<< (PExist xts  <$>  go p e                     )
+    go p (ETApp e s)     = f p =<< ((`ETApp` s) <$>  go p e                     )
+    go p (ETAbs e s)     = f p =<< ((`ETAbs` s) <$>  go p e                     )
+    go p (EApp g e)      = f p =<< (EApp        <$>  go p g  <*> go p e             )
+    go p (EBin o e1 e2)  = f p =<< (EBin o      <$>  go p e1 <*> go p e2            )
+    go p (PImp p1 p2)    = f p =<< (PImp        <$>  go (negatePos p) p1 <*> go p p2)
+    go p (PIff p1 p2)    = f p =<< (PIff        <$>  go p p1 <*> go p p2            )
+    go p (PAtom r e1 e2) = f p =<< (PAtom r     <$>  go p e1 <*> go p e2            )
+    go p (EIte e e1 e2)  = f p =<< (EIte        <$>  go p e  <*> go p e1 <*> go p e2)
+    go p (PAnd ps)       = f p =<< (PAnd        <$> (go p <$$> ps)                  )
+    go p (POr  ps)       = f p =<< (POr         <$> (go p <$$> ps)                  )
+
+
 type Ex    = State ExSt
-data ExSt = ExSt { unique :: Int, exenv :: SymEnv, exbenv :: BindEnv, exbinds :: [BindId] }
+data ExSt = ExSt { unique :: Int, exddecl :: [DataDecl] ,  exenv :: SymEnv, exbenv :: BindEnv, exbinds :: [BindId], excbs :: [(Symbol, Sort)] }
 
-initST :: SymEnv -> ExSt
-initST env = ExSt 0 env mempty mempty 
+initST :: SymEnv -> [DataDecl]  -> ExSt
+initST env dd = ExSt 0 (d:dd) env mempty mempty mempty
+  where 
+    -- NV: hardcore Haskell pairs because they do not appear in DataDecl (why?)
+    d = tracepp "Tuple DataDecl" $ DDecl (symbolFTycon (dummyLoc tupConName)) 2 [ct]
+    ct = DCtor (dummyLoc (symbol "GHC.Tuple.(,)")) [
+            DField (dummyLoc (symbol "lqdc$select$GHC.Tuple.(,)$1")) (FVar 0)
+          , DField (dummyLoc (symbol "lqdc$select$GHC.Tuple.(,)$2")) (FVar 1)
+          ]
 
 
 setBEnv :: BindEnv -> Ex () 
@@ -73,10 +143,48 @@ setBEnv benv = modify (\st -> st{exbenv = benv})
 setExBinds :: Ex ()
 setExBinds = modify (\st -> st{exbinds = []})
 
-freshArg :: Sort -> Ex Symbol
+freshArg :: Sort -> Ex Expr 
 freshArg s = do 
+  st   <- get 
+  case breakSort (exddecl st) s of 
+    Left (dc, xs) -> do  
+      xs <- mapM freshArgOne xs
+      return $ mkEApp dc (EVar <$> xs)
+    Right s -> EVar <$> freshArgOne s 
+
+
+freshArgOne :: Sort -> Ex Symbol 
+freshArgOne s = do 
   st   <- get 
   let x = symbol ("ext$" ++ show (unique st))
   let (id, benv') = insertBindEnv x (trueSortedReft s) (exbenv st)
-  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st, unique = 1 + (unique st) })
+  modify (\st -> st{exenv = insertSymEnv x s (exenv st), exbenv = benv', exbinds = id:exbinds st, unique = 1 + (unique st) , excbs = (x,s):(excbs st)})
   return x 
+
+
+breakSort :: [DataDecl] -> Sort -> Either (LocSymbol, [Sort]) Sort 
+breakSort ddecls s
+    | Just (tc, ts) <- splitTC s
+    , [([dd],i)] <- [ (ddCtors dd,ddVars dd) | dd <- ddecls, ddTyCon dd == tc ] 
+    = Left (dcName dd, (instSort  (Sub $ zip [0..(i-1)] ts)) <$> dfSort <$> dcFields dd)
+    | otherwise 
+    = Right s
+
+instSort :: Sub -> Sort -> Sort 
+instSort (Sub su) x = mapSort go x 
+  where 
+    go :: Sort -> Sort 
+    go (FVar i) = fromMaybe (FVar i) $ lookup i su  
+    go s        = s 
+  
+splitTC :: Sort -> Maybe (FTycon, [Sort])
+splitTC s 
+     | (FTC f, ts) <- splitFApp s 
+     = Just (f, ts)
+     | otherwise
+     = Nothing 
+
+splitFApp :: Sort -> (Sort, [Sort])
+splitFApp = go [] 
+    where go acc (FApp s1 s2) = go (s2:acc) s1 
+          go acc s            = (s, acc)

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -317,16 +317,6 @@ cstrExprs bds sub = (unElab <$> binds, unElab <$> es)
     es            = (crhs sub) : (expr <$> binds)
     binds         = envCs bds (senv sub)
 
-unElab :: (Vis.Visitable t) => t -> t
-unElab = Vis.stripCasts . unApply
-
-unApply :: (Vis.Visitable t) => t -> t
-unApply = Vis.trans (Vis.defaultVisitor { Vis.txExpr = const go }) () ()
-  where
-    go (ECst (EApp (EApp f e1) e2) _)
-      | Just _ <- unApplyAt f = EApp e1 e2
-    go e                      = e
-
 --------------------------------------------------------------------------------
 -- | Symbolic Evaluation with SMT
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -89,6 +89,7 @@ data Config = Config
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints 
+  , extensionality   :: Bool           -- ^ Enable extensional interpretation of function equality 
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -175,6 +176,7 @@ defConfig = Config {
   , rewriteAxioms    = False &= help "allow axiom instantiation via rewriting"
   , noIncrPle        = False &= help "Don't use incremental PLE"
   , checkCstr        = []    &= help "Only check these specific constraint-ids" 
+  , extensionality   = False &= help "Allow extensional interpretation of extensionality"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -45,6 +45,8 @@ module Language.Fixpoint.Types.Visitor (
   , mapSort
   , foldDataDecl
 
+  , (<$$>)
+
 
   ) where
 

--- a/tests/pos/T416.fq
+++ b/tests/pos/T416.fq
@@ -7,6 +7,11 @@ data Pair 2 = [
 
 define compose (lq1:func(0,[b;c]), lq2:func(0,[a;b]), lq3:a) : c = (((compose lq1 lq2 lq3) = (lq1 (lq2 lq3))))
 define first (lq1:func(0,[a;c]),  lq2:(Pair a b)) : Pair a c = (((first lq1 lq2) = (Pair (lq1 (pfst lq2)) (psnd lq2))))
+define plus1 (x:int) : int = (plus1 x = x + 1)
+define plus2 (x:int) : int = (plus2 x = x + 2 )
+
+constant plus1 : (func(0, [int;int]))
+constant plus2 : (func(0, [int;int]))
 
 constant compose : (func(3 , [func(0 , [@(0); @(1)]);
                                  func(0 , [@(2); @(0)]);
@@ -21,6 +26,8 @@ bind 1 f : {VV : func(0 , [a; b]) | []}
 
 bind 2 g : {VV : func(0 , [a; b]) | []}
 bind 3 f : {VV : func(0 , [a; b]) | []}
+
+bind 4 x : {VV:Int | [] }
 
 
 
@@ -40,3 +47,12 @@ constraint:
   id 2 tag []
 
 expand [ 2 : True ]
+
+
+constraint:
+  env []
+  lhs {v : Tuple | true }
+  rhs {v : Tuple | [ not (plus1 == plus2) ]}
+  id 3 tag []
+
+expand [ 3 : True ]

--- a/tests/pos/T416.fq
+++ b/tests/pos/T416.fq
@@ -1,4 +1,5 @@
 fixpoint "--rewrite"
+fixpoint "--extensionality"
 
 
 data Pair 2 = [

--- a/tests/pos/T416.fq
+++ b/tests/pos/T416.fq
@@ -19,6 +19,10 @@ constant first : (func(3 , [func(0 , [@(1); @(2)]);
 bind 0 g : {VV : func(0 , [b; c]) | []}
 bind 1 f : {VV : func(0 , [a; b]) | []}
 
+bind 2 g : {VV : func(0 , [a; b]) | []}
+bind 3 f : {VV : func(0 , [a; b]) | []}
+
+
 
 constraint:
   env [0; 1]
@@ -27,3 +31,12 @@ constraint:
   id 1 tag []
 
 expand [ 1 : True ]
+
+
+constraint:
+  env [2; 3]
+  lhs {v : Tuple | true }
+  rhs {v : Tuple | [ (first f == first g) => (f = g) ]}
+  id 2 tag []
+
+expand [ 2 : True ]

--- a/tests/pos/T416.fq
+++ b/tests/pos/T416.fq
@@ -1,0 +1,29 @@
+fixpoint "--rewrite"
+
+
+data Pair 2 = [
+  | Pair { pfst : @(0), psnd : @(1) }
+]
+
+define compose (lq1:func(0,[b;c]), lq2:func(0,[a;b]), lq3:a) : c = (((compose lq1 lq2 lq3) = (lq1 (lq2 lq3))))
+define first (lq1:func(0,[a;c]),  lq2:(Pair a b)) : Pair a c = (((first lq1 lq2) = (Pair (lq1 (pfst lq2)) (psnd lq2))))
+
+constant compose : (func(3 , [func(0 , [@(0); @(1)]);
+                                 func(0 , [@(2); @(0)]);
+                                 @(2);
+                                 @(1)]))
+constant first : (func(3 , [func(0 , [@(1); @(2)]);
+                                           (Pair @(1) @(0));
+                                           (Pair @(2) @(0))]))                                 
+
+bind 0 g : {VV : func(0 , [b; c]) | []}
+bind 1 f : {VV : func(0 , [a; b]) | []}
+
+
+constraint:
+  env [0; 1]
+  lhs {v : Tuple | true }
+  rhs {v : Tuple | [((compose (first g) (first f)) = (first (compose g f)))]}
+  id 1 tag []
+
+expand [ 1 : True ]


### PR DESCRIPTION
When two function expressions, say `e1` and `e2` are compared on the RHS of a constraint they are saturated with a fresh argument `x` (e1 == e2 turns into e1 x == e2 x). 

See https://github.com/ucsd-progsys/liquid-fixpoint/blob/698f5f7a00bd3e70080c76538bf8eca7af6cd20f/tests/pos/T416.fq that is now OK. 