### PR TITLE
fix substitution bug in PLE

### DIFF
--- a/tests/pos/pleSubst.fq
+++ b/tests/pos/pleSubst.fq
@@ -1,0 +1,18 @@
+fixpoint "--rewrite"
+
+constant geq: (func(0, [int; int; bool]))
+constant lte: (func(0, [int; int; bool]))
+
+define geq(x:int, y:int) : bool = ( geq x y = if x >= y then true else false )
+define lte(x:int, y:int) : bool = ( lte x y = if x <= y then true else false )
+
+expand [1 : True]
+
+bind 0 x  : {v: int | true }
+bind 1 y  : {v: int | true }
+
+constraint:
+  env [0; 1]
+  lhs {v : int | true }
+  rhs {v : int | geq x y <=> lte y x  }
+  id 1 tag []


### PR DESCRIPTION
For an equation `geq x y = if x >= y then true else false` the call `geq y x` would return 
```
(if x >= y then true else false) [x |-> y, y |-> x]
(if y >= y then true else false) [y |-> x]
(if x >= x then true else false) 
true
```

Solution: uniquefy the arguments in Equations. 

PS: The fact that we have to write `geq x y = if x >= y then true else false` instead of `geq x y = x >= y`  was what I was really trying to address and it is coming next :) 