### PR TITLE
Add extra Hashable instances to some types

### DIFF
--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -395,6 +395,7 @@ instance (NFData a) => NFData (Result a)
 instance Hashable Qualifier
 instance Hashable QualPattern
 instance Hashable QualParam
+instance Hashable Equation
 
 ---------------------------------------------------------------------------
 -- | "Smart Constructors" for Constraints ---------------------------------

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -86,6 +86,7 @@ import qualified Data.Binary as B
 import           Data.Generics             (Data)
 import           Data.Semigroup            (Semigroup (..))
 import           Data.Typeable             (Typeable)
+import           Data.Hashable
 import           GHC.Generics              (Generic)
 import qualified Data.List                 as L -- (sort, nub, delete)
 import           Data.Maybe                (catMaybes)
@@ -390,6 +391,10 @@ instance (NFData a) => NFData (WfC a)
 instance (NFData a) => NFData (SimpC a)
 instance (NFData (c a), NFData a) => NFData (GInfo c a)
 instance (NFData a) => NFData (Result a)
+
+instance Hashable Qualifier
+instance Hashable QualPattern
+instance Hashable QualParam
 
 ---------------------------------------------------------------------------
 -- | "Smart Constructors" for Constraints ---------------------------------

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -213,6 +213,7 @@ instance Hashable Constant
 instance Hashable GradInfo 
 instance Hashable Subst 
 instance Hashable Expr 
+instance Hashable Reft
 
 --------------------------------------------------------------------------------
 -- | Substitutions -------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -526,8 +526,12 @@ instance Monoid Sort where
 newtype TCEmb a = TCE (M.HashMap a (Sort, TCArgs)) 
   deriving (Eq, Show, Data, Typeable, Generic) 
 
+instance Hashable a => Hashable (TCEmb a)
+
 data TCArgs = WithArgs | NoArgs 
   deriving (Eq, Ord, Show, Data, Typeable, Generic) 
+
+instance Hashable TCArgs 
 
 tceInsertWith :: (Eq a, Hashable a) => (Sort -> Sort -> Sort) -> a -> Sort -> TCArgs -> TCEmb a -> TCEmb a
 tceInsertWith f k t a (TCE m) = TCE (M.insertWith ff k (t, a) m)


### PR DESCRIPTION
This PR adds a bunch of `Hashable` instances to the `liquid-fixpoint` types, which are required for making changes to the API types in `liquid-haskell`.

See: https://github.com/ucsd-progsys/liquidhaskell/pull/1636