### PR TITLE
Add support for automatic rewriting

### DIFF
--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -354,6 +354,65 @@ notGuardedApps = go
     go (PExist _ _)    = []
     go (PGrad{})       = []
 
+unifyAll :: [Symbol] -> [Expr] -> [Expr] -> Maybe Subst
+unifyAll _ []     []               = Just (Su M.empty)
+unifyAll freeVars (template:xs) (seen:ys) =
+  do
+    rs@(Su s1) <- unify freeVars template seen
+    let xs' = map (subst rs) xs
+    let ys' = map (subst rs) ys
+    (Su s2) <- unifyAll (freeVars L.\\ M.keys s1) xs' ys'
+    return $ Su (M.union s1 s2)
+unifyAll _ _ _ = undefined
+
+unify :: [Symbol] -> Expr -> Expr -> Maybe Subst
+unify _ template seenExpr | template == seenExpr = Just (Su M.empty)
+unify freeVars template seenExpr = case (template, seenExpr) of
+  (EVar rwVar, _) | rwVar `elem` freeVars ->
+    return $ Su (M.singleton rwVar seenExpr)
+  (EApp templateF templateBody, EApp seenF seenBody) ->
+    unifyAll freeVars [templateF, templateBody] [seenF, seenBody]
+  (ENeg rw, ENeg seen) ->
+    unify freeVars rw seen
+  (EBin op rwLeft rwRight, EBin op' seenLeft seenRight) | op == op' ->
+    unifyAll freeVars [rwLeft, rwRight] [seenLeft, seenRight]
+  (EIte cond rwLeft rwRight, EIte seenCond seenLeft seenRight) ->
+    unifyAll freeVars [cond, rwLeft, rwRight] [seenCond, seenLeft, seenRight]
+  (ECst rw _, ECst seen _) ->
+    unify freeVars rw seen
+  (ETApp rw _, ETApp seen _) ->
+    unify freeVars rw seen
+  (ETAbs rw _, ETAbs seen _) ->
+    unify freeVars rw seen
+  (PAnd rw, PAnd seen ) ->
+    unifyAll freeVars rw seen
+  (POr rw, POr seen ) ->
+    unifyAll freeVars rw seen
+  (PNot rw, PNot seen) ->
+    unify freeVars rw seen
+  (PImp templateF templateBody, PImp seenF seenBody) ->
+    unifyAll freeVars [templateF, templateBody] [seenF, seenBody]
+  (PIff templateF templateBody, PIff seenF seenBody) ->
+    unifyAll freeVars [templateF, templateBody] [seenF, seenBody]
+  (PAtom rel templateF templateBody, PAtom rel' seenF seenBody) | rel == rel' ->
+    unifyAll freeVars [templateF, templateBody] [seenF, seenBody]
+  (PAll _ rw, PAll _ seen) ->
+    unify freeVars rw seen
+  (PExist _ rw, PExist _ seen) ->
+    unify freeVars rw seen
+  (PGrad _ _ _ rw, PGrad _ _ _ seen) ->
+    unify freeVars rw seen
+  (ECoerc _ _ rw, ECoerc _ _ seen) ->
+    unify freeVars rw seen
+  _ -> Nothing
+
+
+getRewrite :: Expr -> AutoRewrite -> Maybe Expr
+getRewrite expr (AutoRewrite freeVars lhs rhs) =
+  do
+    expr' <- fmap ((flip subst) rhs) (unify freeVars lhs expr)
+    if expr /= expr' then Just expr' else Nothing
+
 eval :: Knowledge -> ICtx -> Expr -> EvalST Expr
 eval _ ctx e 
   | Just v <- M.lookup e (icSimpl ctx)
@@ -361,14 +420,18 @@ eval _ ctx e
 eval γ ctx e = 
   do acc <- S.toList . evAccum <$> get  
      case L.lookup e acc of 
-        Just e' -> eval γ ctx e' 
-        Nothing -> do 
+        Just e' | not (e' `elem` getRWs e) -> eval γ ctx e'
+        _ -> do
           e' <- simplify γ ctx <$> go e
-          if e /= e' 
-            then do modify (\st -> st{evAccum = S.insert (traceE (e, e')) (evAccum st)})
+          let evAccum' st = S.union (S.fromList (map (e,) (getRWs e))) (evAccum st)
+          if e /= e'
+            then do modify (\st -> st{evAccum = S.insert (traceE (e, e')) (evAccum' st)})
                     eval γ (addConst (e,e') ctx) e' 
-            else return e 
-  where 
+            else do modify (\st -> st{evAccum = evAccum' st })
+                    return e
+  where
+    autorws  = knAutoRWs γ
+    getRWs e = autorws >>= (Mb.maybeToList . (getRewrite e))
     addConst (e,e') ctx = if isConstant (knDCs γ) e' 
                            then ctx { icSimpl = M.insert e e' $ icSimpl ctx} else ctx 
     go (ELam (x,s) e)   = ELam (x, s) <$> eval γ' ctx e where γ' = γ { knLams = (x, s) : knLams γ }
@@ -494,6 +557,7 @@ data Knowledge = KN
   , knDCs     :: !(S.HashSet Symbol)     -- data constructors drawn from Rewrite 
   , knSels    :: !(SelectorMap) 
   , knConsts  :: !(ConstDCMap)
+  , knAutoRWs :: ![AutoRewrite]
   }
 
 isValid :: Knowledge -> Expr -> IO Bool
@@ -515,6 +579,7 @@ knowledge cfg ctx si = KN
   , knDCs     = S.fromList (smDC <$> sims) 
   , knSels    = Mb.catMaybes $ map makeSel  sims 
   , knConsts  = Mb.catMaybes $ map makeCons sims 
+  , knAutoRWs = aenvAutoRW aenv
   } 
   where 
     sims = aenvSimpl aenv ++ concatMap reWriteDDecl (ddecls si) 

--- a/tests/proof/rewrite.fq
+++ b/tests/proof/rewrite.fq
@@ -1,0 +1,55 @@
+fixpoint "--rewrite"
+
+data List 0 = [
+  | VNil  { }
+  | VCons { head: Int, tail : List} 
+]
+
+define concat (left : List, right : List) : List = {
+  if (is$VNil left) then 
+    right else 
+  (VCons (head left) (concat (tail left) right))
+}
+
+define concat3Left (as : List, bs : List, cs : List) : List = {
+  concat (concat as bs) cs
+}
+
+define concat3Right (as : List, bs : List, cs : List) : List = {
+  concat as (concat bs cs)
+}
+
+autorewrite as bs cs { concat (concat as bs) cs = concat as (concat bs cs) }
+
+autorewrite as bs cs { concat as (concat bs cs) = concat (concat as bs) cs }
+
+constant concat       : (func(0, [List;List;List]))
+constant concat3Left  : (func(0, [List; List; List; List]))
+constant concat3Right : (func(0, [List; List; List; List]))
+
+expand [1 : True]
+expand [2 : True]
+expand [3 : True]
+
+bind 0 xs    : {v: List | true }
+bind 1 ys    : {v: List | true }
+bind 2 zs    : {v: List | true }
+bind 3 ws    : {v: List | true }
+
+constraint:
+  env [0; 1; 2; 3]
+  lhs {v1 : List | true  }
+  rhs {v2 : List | concat3Left (concat xs ws) ys zs = concat3Right (concat xs ws) ys zs }
+  id 1 tag []
+
+constraint:
+  env [0; 1; 2; 3]
+  lhs {v1 : List | true  }
+  rhs {v2 : List | concat3Right (concat xs ws) ys zs = concat3Left (concat xs ws) ys zs }
+  id 2 tag []
+
+constraint:
+  env [0; 1; 2; 3]
+  lhs {v1 : List | true  }
+  rhs {v2 : List | concat3Left (concat xs ws) ys zs = concat3Right xs ws (concat ys zs) }
+  id 3 tag []


### PR DESCRIPTION
Allows for automatic rewriting of expressions during PLE.

The goal is to enable LH proofs annotated with `{-@ rewrite @-}` to be applied automatically during PLE, thereby improving proof automation. For example:
https://github.com/zgrannan/liquid-fixpoint/blob/rewrite-old/rewriting/Assoc.hs