### PR TITLE
SMT-LIB datatypes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
       - run: 
           name: Install z3 
           command: |
-            wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-osx-10.14.6.zip
-            unzip z3-4.8.7-x64-osx-10.14.6.zip
-            rm -f z3-4.8.7-x64-osx-10.14.6.zip
-            cp z3-4.8.7-x64-osx-10.14.6/bin/libz3.a /usr/local/lib
-            cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin
-            cp z3-4.8.7-x64-osx-10.14.6/include/* /usr/local/include
-            rm -rf z3-4.8.7-x64-osx-10.14.6
+            wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip
+            unzip z3-4.8.7-x64-ubuntu-16.04.zip
+            rm -f z3-4.8.7-x64-ubuntu-16.04.zip
+            cp z3-4.8.7-x64-ubuntu-16.04/bin/libz3.a /usr/local/lib
+            cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
+            cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
+            rm -rf z3-4.8.7-x64-ubuntu-16.04
       
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,6 @@ jobs:
       - run:
           name: Compile
           command : |
-            stack exec -- which z3
-            stack exec -- z3 --version
             stack build liquid-fixpoint --flag liquid-fixpoint:devel
             stack build liquid-fixpoint --flag liquid-fixpoint:devel --test --no-run-tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ version: 2.0
 
 jobs:
   build:
+    machine:
+      image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
     docker:
       - image: fpco/stack-build:lts-15.4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,17 @@ jobs:
       - image: fpco/stack-build:lts-15.4
     steps:
       - add_ssh_keys
-      - run: apt-get install z3
+      - run: 
+          name: Install z3 
+          command: |
+            wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-osx-10.14.6.zip
+            unzip z3-4.8.7-x64-osx-10.14.6.zip
+            rm -f z3-4.8.7-x64-osx-10.14.6.zip
+            cp z3-4.8.7-x64-osx-10.14.6/bin/libz3.a /usr/local/lib
+            cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin
+            cp z3-4.8.7-x64-osx-10.14.6/include/* /usr/local/include
+            rm -rf z3-4.8.7-x64-osx-10.14.6
+      
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ version: 2.0
 
 jobs:
   build:
-    machine:
-      image: ubuntu-1604:201903-01 # recommended linux image - includes Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
     docker:
       - image: fpco/stack-build:lts-15.4
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
             cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
             cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
             rm -rf z3-4.8.7-x64-ubuntu-16.04
-            echo $PATH
             z3 --version
 
       - checkout
@@ -43,8 +42,6 @@ jobs:
           name: Test
           command: |
             stack clean
-            echo $PATH
-            z3 --version
             mkdir -p /tmp/junit
             stack test liquid-fixpoint:test --flag liquid-fixpoint:devel --test-arguments="--xml=/tmp/junit/main-test-results.xml":
             stack haddock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin
             cp z3-4.8.7-x64-osx-10.14.6/include/* /usr/local/include
             rm -rf z3-4.8.7-x64-osx-10.14.6
+            z3 --version
       
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-14.0
+      - image: fpco/stack-build:lts-15.4
     steps:
       - add_ssh_keys
       - run: apt-get install z3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
             cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
             cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
             rm -rf z3-4.8.7-x64-ubuntu-16.04
-      
+            echo $PATH
+            z3 --version
+
       - checkout
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - run:
           name: Compile
           command : |
-            stack exec -- z3 -- version
+            stack exec -- z3 --version
             stack build liquid-fixpoint --flag liquid-fixpoint:devel
             stack build liquid-fixpoint --flag liquid-fixpoint:devel --test --no-run-tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
           name: Test
           command: |
             stack clean
+            echo $PATH
+            z3 --version
             mkdir -p /tmp/junit
             stack test liquid-fixpoint:test --flag liquid-fixpoint:devel --test-arguments="--xml=/tmp/junit/main-test-results.xml":
             stack haddock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - run:
           name: Compile
           command : |
+            stack exec -- which z3
             stack exec -- z3 --version
             stack build liquid-fixpoint --flag liquid-fixpoint:devel
             stack build liquid-fixpoint --flag liquid-fixpoint:devel --test --no-run-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
             cp z3-4.8.7-x64-osx-10.14.6/bin/z3 /usr/local/bin
             cp z3-4.8.7-x64-osx-10.14.6/include/* /usr/local/include
             rm -rf z3-4.8.7-x64-osx-10.14.6
-            z3 --version
       
       - checkout
       - restore_cache:
@@ -36,6 +35,7 @@ jobs:
       - run:
           name: Compile
           command : |
+            stack exec -- z3 -- version
             stack build liquid-fixpoint --flag liquid-fixpoint:devel
             stack build liquid-fixpoint --flag liquid-fixpoint:devel --test --no-run-tests
       - run:

--- a/tests/neg/adt0.fq
+++ b/tests/neg/adt0.fq
@@ -1,7 +1,7 @@
 
 data Vec 1 = [
   | mkNil  { }
-  | mkCons { head : @(0), tail : Vec }
+  | mkCons { head : @(0), tail : Vec @(0)}
 ]
 
 bind 1 x  : {v : int | true}

--- a/tests/neg/adt1.fq
+++ b/tests/neg/adt1.fq
@@ -1,7 +1,7 @@
 
 data Vec 1 = [
   | mkNil  { }
-  | mkCons { head : @(0), tail : Vec }
+  | mkCons { head : @(0), tail : Vec @(0) }
 ]
 
 bind 1 x  : {v : int | true}

--- a/tests/neg/adt2.fq
+++ b/tests/neg/adt2.fq
@@ -1,6 +1,6 @@
 data Vec 1 = [
   | mkNil  { }
-  | mkCons { head : @(0), tail : Vec }
+  | mkCons { head : @(0), tail : Vec @(0) }
 ]
 
 bind 1 x  : {v : int | true}

--- a/tests/neg/adt3.fq
+++ b/tests/neg/adt3.fq
@@ -1,6 +1,6 @@
 data Vec 1 = [
   | mkNil  { }
-  | mkCons { head : @(0), tail : Vec }
+  | mkCons { head : @(0), tail : Vec @(0)}
 ]
 
 bind 1 x  : {v : int | true}

--- a/tests/pos/adt.fq
+++ b/tests/pos/adt.fq
@@ -1,7 +1,7 @@
 
 data Vec 1 = [
   | mkNil  { }
-  | mkCons { head : @(0), tail : Vec }
+  | mkCons { head : @(0), tail : Vec @(0)}
 ]
 
 bind 1 x  : {v : int | true}

--- a/tests/pos/adt_list_1.fq
+++ b/tests/pos/adt_list_1.fq
@@ -1,7 +1,7 @@
 
 data LL 1 = [
   | emp { }
-  | con { lHead : @(0), lTail : LL }
+  | con { lHead : @(0), lTail : LL @(0) }
 ]
 
 bind 1 n1 : {n:int | true}

--- a/tests/pos/adt_list_2.fq
+++ b/tests/pos/adt_list_2.fq
@@ -1,7 +1,7 @@
 
 data LL 1 = [
   | emp { }
-  | con { lHead : @(0), lTail : LL }
+  | con { lHead : @(0), lTail : LL @(0) }
 ]
 
 bind 0 junk : {v:LL bool | true}

--- a/tests/pos/adt_list_nested.fq
+++ b/tests/pos/adt_list_nested.fq
@@ -2,7 +2,7 @@
 
 data LL 1 = [
   | emp { }
-  | con { lHead : @(0), lTail : LL }
+  | con { lHead : @(0), lTail : LL @(0)}
 ]
 
 bind 0 junk : {v:LL int | true}

--- a/tests/pos/adt_poly_dead.fq
+++ b/tests/pos/adt_poly_dead.fq
@@ -8,7 +8,7 @@ data Boo 1 = [
 
 data LL 1 = [
   | emp { }
-  | con { lHead : @(0), lTail : LL }
+  | con { lHead : @(0), lTail : LL @(0)}
 ]
 
 bind 1 x  : {v: Boo int  | true}

--- a/tests/proof/list01.fq
+++ b/tests/proof/list01.fq
@@ -2,7 +2,7 @@ fixpoint "--rewrite"
 
 data Vec 1 = [
   | VNil  { }
-  | VCons { head : @(0), tail : Vec }
+  | VCons { head : @(0), tail : Vec @(0)}
 ]
 
 constant len: (func(1, [(Vec @(0)); int]))

--- a/tests/proof/pleBoolA.fq
+++ b/tests/proof/pleBoolA.fq
@@ -2,7 +2,7 @@ fixpoint "--rewrite"
 
 data Vec 1 = [
   | VNil  { }
-  | VCons { head : @(0), tail : Vec }
+  | VCons { head : @(0), tail : Vec @(0)}
 ]
 
 match isNil VNil       = true 

--- a/tests/proof/pleBoolB.fq
+++ b/tests/proof/pleBoolB.fq
@@ -2,7 +2,7 @@ fixpoint "--rewrite"
 
 data Vec 1 = [
   | VNil  { }
-  | VCons { mhead : @(0), mtail : Vec }
+  | VCons { mhead : @(0), mtail : Vec @(0)}
 ]
 
 match isNil VNil       = true 

--- a/tests/proof/pleBoolC.fq
+++ b/tests/proof/pleBoolC.fq
@@ -3,7 +3,7 @@ fixpoint "--rewrite"
 
 data Vec 1 = [
   | VNil  { }
-  | VCons { mhead : @(0), mtail : Vec }
+  | VCons { mhead : @(0), mtail : Vec @(0) }
 ]
 
 match isNil VNil       = true 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -34,9 +34,6 @@ import Paths_liquid_fixpoint
 
 main :: IO ()
 main    = do 
-  system "which z3"
-  system "z3 --version"
-  system "echo $PATH"
   run =<< group "Tests" [unitTests]
   where
     run = defaultMainWithIngredients [

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -33,7 +33,11 @@ import Test.Tasty.Runners.AntXML
 import Paths_liquid_fixpoint
 
 main :: IO ()
-main    = run =<< group "Tests" [unitTests]
+main    = do 
+  system "which z3"
+  system "z3 --version"
+  system "echo $PATH"
+  run =<< group "Tests" [unitTests]
   where
     run = defaultMainWithIngredients [
                 testRunner


### PR DESCRIPTION
Update to SMT-LIB datatype declaration syntax (which requires type constructors to be applied to type arguments in definitions). 

Also update circle z3 to z3-4.8 to support this syntax. 