### PR TITLE
Required extensions to support source plugins

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -71,6 +71,7 @@ library
                     Language.Fixpoint.Solver.Sanitize
                     Language.Fixpoint.Solver.Solution
                     Language.Fixpoint.Solver.Solve
+                    Language.Fixpoint.Solver.Stats
                     Language.Fixpoint.Solver.TrivialSort
                     Language.Fixpoint.Solver.UniqifyBinds
                     Language.Fixpoint.Solver.UniqifyKVars

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -117,7 +117,6 @@ library
                   , directory
                   , fgl
                   , filepath
-                  , ghc-prim
                   , hashable
                   , intern
                   , mtl

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -99,7 +99,7 @@ editDistance xs ys = table ! (m, n)
 ------------ Support for Colored Logging ------------------------------------------
 -----------------------------------------------------------------------------------
 
-data Moods = Ok | Loud | Sad | Happy | Angry
+data Moods = Ok | Loud | Sad | Happy | Angry | Wary
 
 moodColor :: Moods -> Color
 moodColor Ok    = Black
@@ -107,6 +107,7 @@ moodColor Loud  = Blue
 moodColor Sad   = Magenta
 moodColor Happy = Green
 moodColor Angry = Red
+moodColor Wary  = Yellow
 
 wrapStars :: String -> String
 wrapStars msg = "\n**** " ++ msg ++ " " ++ replicate (74 - length msg) '*'

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -964,7 +964,7 @@ defsFInfo defs = {-# SCC "defsFI" #-} FI cm ws bs ebs lts dts kts qs binfo adts 
 
 fixResultP :: Parser a -> Parser (FixResult a)
 fixResultP pp
-  =  (reserved "SAT"   >> return Safe)
+  =  (reserved "SAT"   >> return (Safe mempty))
  <|> (reserved "UNSAT" >> Unsafe <$> brackets (sepBy pp comma))
  <|> (reserved "CRASH" >> crashP pp)
 

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -28,8 +28,6 @@ module Language.Fixpoint.Solver.Monad
        )
        where
 
-import           Control.DeepSeq
-import           GHC.Generics
 import           Language.Fixpoint.Utils.Progress
 import qualified Language.Fixpoint.Types.Config  as C
 import           Language.Fixpoint.Types.Config  (Config)
@@ -37,19 +35,18 @@ import qualified Language.Fixpoint.Types   as F
 -- import qualified Language.Fixpoint.Misc    as Misc
 -- import           Language.Fixpoint.SortCheck
 import qualified Language.Fixpoint.Types.Solutions as F
-import           Language.Fixpoint.Types   (pprint)
 -- import qualified Language.Fixpoint.Types.Errors  as E
 import           Language.Fixpoint.Smt.Serialize ()
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Smt.Interface
 -- import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Solver.Sanitize
+import           Language.Fixpoint.Solver.Stats
 import           Language.Fixpoint.Graph.Types (SolverInfo (..))
 -- import           Language.Fixpoint.Solver.Solution
 -- import           Data.Maybe           (catMaybes)
 import           Data.List            (partition)
 -- import           Data.Char            (isUpper)
-import           Text.PrettyPrint.HughesPJ (text)
 import           Control.Monad.State.Strict
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes)
@@ -67,29 +64,10 @@ data SolverState = SS
   , ssStats   :: !Stats            -- ^ Solver Statistics
   }
 
-data Stats = Stats 
-  { numCstr :: !Int -- ^ # Horn Constraints
-  , numIter :: !Int -- ^ # Refine Iterations
-  , numBrkt :: !Int -- ^ # smtBracket    calls (push/pop)
-  , numChck :: !Int -- ^ # smtCheckUnsat calls
-  , numVald :: !Int -- ^ # times SMT said RHS Valid
-  } deriving (Show, Generic)
-
-instance NFData Stats
-
 stats0    :: F.GInfo c b -> Stats
 stats0 fi = Stats nCs 0 0 0 0
   where
     nCs   = M.size $ F.cm fi
-
-
-instance F.PTable Stats where
-  ptable s = F.DocTable [ (text "# Constraints"         , pprint (numCstr s))
-                        , (text "# Refine Iterations"   , pprint (numIter s))
-                        , (text "# SMT Brackets"        , pprint (numBrkt s))
-                        , (text "# SMT Queries (Valid)" , pprint (numVald s))
-                        , (text "# SMT Queries (Total)" , pprint (numChck s))
-                        ]
 
 --------------------------------------------------------------------------------
 runSolverM :: Config -> SolverInfo b c -> SolveM a -> IO a

--- a/src/Language/Fixpoint/Solver/Stats.hs
+++ b/src/Language/Fixpoint/Solver/Stats.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE OverloadedStrings  #-}
+module Language.Fixpoint.Solver.Stats where
+
+import           Control.DeepSeq
+import           Data.Data
+import           Data.Serialize                (Serialize (..))
+import           GHC.Generics
+import           Text.PrettyPrint.HughesPJ (text)
+import qualified Data.Binary              as B
+import qualified Language.Fixpoint.Types.PrettyPrint as F
+
+#if !MIN_VERSION_base(4,14,0)
+import           Data.Semigroup            (Semigroup (..))
+#endif
+
+data Stats = Stats 
+  { numCstr      :: !Int -- ^ # Horn Constraints
+  , numIter      :: !Int -- ^ # Refine Iterations
+  , numBrkt      :: !Int -- ^ # smtBracket    calls (push/pop)
+  , numChck      :: !Int -- ^ # smtCheckUnsat calls
+  , numVald      :: !Int -- ^ # times SMT said RHS Valid
+  } deriving (Data, Show, Generic, Eq)
+
+instance NFData Stats
+instance B.Binary Stats
+instance Serialize Stats
+
+instance F.PTable Stats where
+  ptable s = F.DocTable [ (text "# Constraints"                       , F.pprint (numCstr      s))
+                        , (text "# Refine Iterations"                 , F.pprint (numIter      s))
+                        , (text "# SMT Brackets"                      , F.pprint (numBrkt      s))
+                        , (text "# SMT Queries (Valid)"               , F.pprint (numVald      s))
+                        , (text "# SMT Queries (Total)"               , F.pprint (numChck      s))
+                        ]
+
+instance Semigroup Stats where
+  s1 <> s2 = 
+    Stats { numCstr      = numCstr s1      + numCstr s2
+          , numIter      = numIter s1      + numIter s2
+          , numBrkt      = numBrkt s1      + numBrkt s2
+          , numChck      = numChck s1      + numChck s2
+          , numVald      = numVald s1      + numVald s2
+          }
+
+instance Monoid Stats where
+  mempty  = Stats 0 0 0 0 0
+  mappend = (<>)
+
+-- | Returns the Horn clauses checked.
+checked :: Stats -> Int
+checked = numCstr
+
+-- | Returns a number which can be used in the 'Safe' constructor of a 'FixResult' to show
+-- \"the work done\".
+totalWork :: Stats -> Int
+totalWork Stats{..} = numCstr + numIter + numBrkt + numChck + numVald

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -109,6 +109,7 @@ import           Language.Fixpoint.Types.Refinements
 import           Language.Fixpoint.Types.Substitutions
 import           Language.Fixpoint.Types.Environments
 import qualified Language.Fixpoint.Utils.Files as Files
+import qualified Language.Fixpoint.Solver.Stats as Solver
 
 import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ.Compat
@@ -285,11 +286,11 @@ instance Monoid (Result a) where
 
 unsafe, safe :: Result a
 unsafe = mempty {resStatus = Unsafe []}
-safe   = mempty {resStatus = Safe}
+safe   = mempty {resStatus = Safe mempty}
 
 isSafe :: Result a -> Bool
-isSafe (Result Safe _ _) = True
-isSafe _                 = False
+isSafe (Result (Safe _) _ _) = True
+isSafe _                     = False
 
 isUnsafe :: Result a -> Bool
 isUnsafe r | Unsafe _ <- resStatus r
@@ -297,7 +298,7 @@ isUnsafe r | Unsafe _ <- resStatus r
 isUnsafe _ = False
 
 instance (Ord a, Fixpoint a) => Fixpoint (FixResult (SubC a)) where
-  toFix Safe             = text "Safe"
+  toFix (Safe stats)     = text "Safe (" <+> text (show $ Solver.checked stats) <+> " constraints checked)" 
   -- toFix (UnknownError d) = text $ "Unknown Error: " ++ d
   toFix (Crash xs msg)   = vcat $ [ text "Crash!" ] ++  pprSinfos "CRASH: " xs ++ [parens (text msg)]
   toFix (Unsafe xs)      = vcat $ text "Unsafe:" : pprSinfos "WARNING: " xs

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -403,6 +403,7 @@ instance Hashable QualPattern
 instance Hashable QualParam
 instance Hashable Equation
 
+
 ---------------------------------------------------------------------------
 -- | "Smart Constructors" for Constraints ---------------------------------
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -209,8 +209,7 @@ colorResult (_)         = Sad
 
 resultExit :: FixResult a -> ExitCode
 resultExit Safe        = ExitSuccess
-resultExit (Unsafe _)  = ExitFailure 1
-resultExit _           = ExitFailure 2
+resultExit _           = ExitFailure 1
 
 ---------------------------------------------------------------------
 -- | Catalogue of Errors --------------------------------------------

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -277,6 +277,10 @@ data DataDecl = DDecl
   , ddCtors :: [DataCtor]         -- ^ Datatype Ctors. Invariant: type variables bound in ctors are greater than ddVars
   } deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
+
+instance Loc DataDecl where
+    srcSpan (DDecl ty _ _) = srcSpan ty
+
 instance Symbolic DataDecl where
   symbol = symbol . ddTyCon
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -69,11 +69,11 @@ unitTests
   = group "Unit" [
       testGroup "native-pos" <$> dirTests nativeCmd "tests/pos"    skipNativePos  ExitSuccess
     , testGroup "native-neg" <$> dirTests nativeCmd "tests/neg"    ["float.fq"]   (ExitFailure 1)
-    , testGroup "elim-crash" <$> dirTests nativeCmd "tests/crash"  []             (ExitFailure 2)
+    , testGroup "elim-crash" <$> dirTests nativeCmd "tests/crash"  []             (ExitFailure 1)
     , testGroup "elim-pos1"  <$> dirTests elimCmd   "tests/pos"    []             ExitSuccess
     , testGroup "elim-pos2"  <$> dirTests elimCmd   "tests/elim"   []             ExitSuccess
     , testGroup "elim-neg"   <$> dirTests elimCmd   "tests/neg"    ["float.fq"]   (ExitFailure 1)
-    , testGroup "elim-crash" <$> dirTests elimCmd   "tests/crash"  []             (ExitFailure 2)
+    , testGroup "elim-crash" <$> dirTests elimCmd   "tests/crash"  []             (ExitFailure 1)
     , testGroup "proof"      <$> dirTests elimCmd   "tests/proof"     []          ExitSuccess
     , testGroup "rankN"      <$> dirTests elimCmd   "tests/rankNTypes" []         ExitSuccess
 

--- a/unix/Language/Fixpoint/Utils/Progress.hs
+++ b/unix/Language/Fixpoint/Utils/Progress.hs
@@ -8,7 +8,7 @@ module Language.Fixpoint.Utils.Progress (
 
 import           Control.Monad                    (when)
 import           System.IO.Unsafe                 (unsafePerformIO)
-import           System.Console.CmdArgs.Verbosity (isNormal)
+import           System.Console.CmdArgs.Verbosity (isNormal, isLoud)
 import           Data.IORef
 import           System.Console.AsciiProgress
 -- import           Language.Fixpoint.Misc (traceShow)
@@ -18,12 +18,16 @@ pbRef :: IORef (Maybe ProgressBar)
 pbRef = unsafePerformIO (newIORef Nothing)
 
 withProgress :: Int -> IO a -> IO a
-withProgress n act = displayConsoleRegions $ do
-  -- putStrLn $ "withProgress: " ++ show n
-  progressInit n
-  r <- act
-  progressClose
-  return r
+withProgress n act = do
+  loud <- isLoud
+  case loud of
+    False -> act
+    True  -> displayConsoleRegions $ do
+      -- putStrLn $ "withProgress: " ++ show n
+      progressInit n
+      r <- act
+      progressClose
+      return r
   
 progressInit :: Int -> IO ()
 progressInit n = do

--- a/unix/Language/Fixpoint/Utils/Progress.hs
+++ b/unix/Language/Fixpoint/Utils/Progress.hs
@@ -8,7 +8,7 @@ module Language.Fixpoint.Utils.Progress (
 
 import           Control.Monad                    (when)
 import           System.IO.Unsafe                 (unsafePerformIO)
-import           System.Console.CmdArgs.Verbosity (isNormal, isLoud)
+import           System.Console.CmdArgs.Verbosity (isNormal, getVerbosity, Verbosity(..))
 import           Data.IORef
 import           System.Console.AsciiProgress
 -- import           Language.Fixpoint.Misc (traceShow)
@@ -19,8 +19,8 @@ pbRef = unsafePerformIO (newIORef Nothing)
 
 withProgress :: Int -> IO a -> IO a
 withProgress n act = do
-  loud <- isLoud
-  case loud of
+  showBar <- ((/=) Quiet) <$> getVerbosity
+  case showBar of
     False -> act
     True  -> displayConsoleRegions $ do
       -- putStrLn $ "withProgress: " ++ show n


### PR DESCRIPTION
This commit extends `liquid-fixpoint` to fully support the new LiquidHaskell source plugin.

Most of the changes are innocuous, as we mostly add new instances (like `Hashable`) for some types. The only potential "breaking" change is the use of `ExitFailure 1` for `FixResult` even in case of validation errors, but as long as users didn't rely on a particular exit code in their programs, this should be fine.

I will annotate the PR with in-line comments for ease of review.