### PR TITLE
fix test.hs to use fixpoint executable built from current source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Session.vim
 /external/ocamlgraph/config.log
 /TAGS
 /tags
+*.swp

--- a/default.nix
+++ b/default.nix
@@ -1,32 +1,52 @@
-{ fetchgitLocal }:
-{ mkDerivation, ansi-terminal, array, ascii-progress, async
-, attoparsec, base, bifunctors, binary, boxes, bytestring, cereal
-, cmdargs, containers, deepseq, directory, filemanip, filepath
-, ghc-prim, hashable, intern, located-base, mtl, parallel, parsec, pretty
-, process, stdenv, syb, tasty, tasty-hunit, tasty-rerun, text
-, text-format, transformers, unordered-containers, z3
-, dotgen, fgl, fgl-visualize
-}:
-mkDerivation {
-  pname = "liquid-fixpoint";
-  version = "9.9.9.9";
-  src = fetchgitLocal ./.;
-  isLibrary = true;
-  isExecutable = true;
-  libraryHaskellDepends = [
-    ansi-terminal array ascii-progress async attoparsec base bifunctors
-    binary boxes bytestring cereal cmdargs containers deepseq directory
-    filemanip filepath ghc-prim hashable intern located-base mtl parallel parsec
-    pretty process syb text text-format transformers
-    unordered-containers
-    dotgen fgl fgl-visualize
-  ];
-  executableHaskellDepends = [ base ];
-  testHaskellDepends = [
-    base directory filepath process tasty tasty-hunit tasty-rerun text
-  ];
-  testSystemDepends = [ z3 ];
-  homepage = "https://github.com/ucsd-progsys/liquid-fixpoint";
-  description = "Predicate Abstraction-based Horn-Clause/Implication Constraint Solver";
-  license = stdenv.lib.licenses.bsd3;
-}
+{ makeEnv ? false, config ? { allowBroken = true; }, ... }:
+let
+  # fetch pinned version of nixpkgs
+  nixpkgs = import (
+    builtins.fetchTarball {
+      # fetch latest nixpkgs https://github.com/NixOS/nixpkgs-channels/tree/nixos-20.03 as of Tue 18 Aug 2020 02:51:27 PM UTC
+      url = "https://github.com/NixOS/nixpkgs-channels/archive/cb1996818edf506c0d1665ab147c253c558a7426.tar.gz";
+      sha256 = "0lb6idvg2aj61nblr41x0ixwbphih2iz8xxc05m69hgsn261hk3j";
+    }
+  ) { inherit config; };
+  # override haskell compiler version, add and override dependencies in nixpkgs
+  haskellPackages = nixpkgs.haskell.packages."ghc8101".override (
+    old: {
+      all-cabal-hashes = nixpkgs.fetchurl {
+        # fetch latest cabal hashes https://github.com/commercialhaskell/all-cabal-hashes/tree/hackage as of Tue 18 Aug 2020 02:51:27 PM UTC
+        url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/112fef7b4bf392d4d4c36fbbe00ed061685ba26c.tar.gz";
+        sha256 = "0x0mkpwnndw7n62l089gimd76n9gy749giban9pacf5kxbsfxrdc";
+      };
+      overrides = self: super: with nixpkgs.haskell.lib; rec {
+        mkDerivation = args: super.mkDerivation (
+          args // {
+            doCheck = false;
+            doHaddock = false;
+            jailbreak = true;
+          }
+        );
+        # test dependencies
+        git = overrideCabal (self.callHackage "git" "0.3.0" {}) (
+          old: {
+            patches = [ ./git-0.3.0_fix-monad-fail-for-ghc-8.10.1.patch ]; # git-0.3.0 defines a Monad a fail function, which is incompatible with ghc-8.10.1 https://hackage.haskell.org/package/git-0.3.0/docs/src/Data.Git.Monad.html#line-240
+          }
+        );
+        # build dependencies; using latest hackage releases as of Tue 18 Aug 2020 02:51:27 PM UTC
+        memory = self.callHackage "memory" "0.15.0" {};
+      };
+    }
+  );
+  # function to bring devtools in to a package environment
+  devtools = old: { nativeBuildInputs = old.nativeBuildInputs ++ [ nixpkgs.cabal-install nixpkgs.ghcid ]; }; # ghc and hpack are automatically included
+  # ignore files specified by gitignore in nix-build
+  source = nixpkgs.nix-gitignore.gitignoreSource [] ./.;
+  # use overridden-haskellPackages to call gitignored-source
+  drv = nixpkgs.haskell.lib.overrideCabal (haskellPackages.callCabal2nix "liquid-fixpoint" source {}) (
+    old: {
+      buildTools = [ nixpkgs.z3 ];
+      doCheck = true;
+      doHaddock = true;
+      preCheck = ''export PATH="$PWD/dist/build/fixpoint:$PATH"''; # bring the `fixpoint` binary into scope for tests run by nix-build
+    }
+  );
+in
+if makeEnv then drv.env.overrideAttrs devtools else drv

--- a/git-0.3.0_fix-monad-fail-for-ghc-8.10.1.patch
+++ b/git-0.3.0_fix-monad-fail-for-ghc-8.10.1.patch
@@ -1,0 +1,13 @@
+diff --git a/Data/Git/Monad.hs b/Data/Git/Monad.hs
+index 480af9f..27c3b3e 100644
+--- a/Data/Git/Monad.hs
++++ b/Data/Git/Monad.hs
+@@ -130 +130 @@ instance Resolvable Git.RefName where
+-class (Functor m, Applicative m, Monad m) => GitMonad m where
++class (Functor m, Applicative m, Monad m, MonadFail m) => GitMonad m where
+@@ -242,0 +243 @@ instance Monad GitM where
++instance MonadFail GitM where
+@@ -315,0 +317 @@ instance Monad CommitAccessM where
++instance MonadFail CommitAccessM where
+@@ -476,0 +479 @@ instance Monad CommitM where
++instance MonadFail CommitM where

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -160,6 +160,7 @@ test-suite test
   main-is:          test.hs
   other-modules:    Paths_liquid_fixpoint
   hs-source-dirs:   tests
+  build-tool-depends: liquid-fixpoint:fixpoint
   build-depends:    base          >= 4.9.1.0 && < 5
                   , containers    >= 0.5
                   , directory

--- a/shell.nix
+++ b/shell.nix
@@ -1,17 +1,1 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default" }:
-
-let
-
-  inherit (nixpkgs) pkgs;
-
-  f = import ./default.nix { inherit (pkgs) fetchgitLocal; };
-
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  drv = haskellPackages.callPackage f { inherit (pkgs) z3; };
-
-in
-
-  if pkgs.lib.inNixShell then drv.env else drv
+import ./. { makeEnv = true; }

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -112,18 +112,14 @@ mkTest testCmd code dir file
         assertEqual "" True True
       else do
         createDirectoryIfMissing True $ takeDirectory log
-        bin <- binPath "fixpoint"
         withFile log WriteMode $ \h -> do
-          let cmd     = testCmd bin dir file
+          let cmd     = testCmd "fixpoint" dir file
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           c          <- waitForProcess ph
           assertEqual "Wrong exit code" code c
   where
     test = dir </> file
     log  = let (d,f) = splitFileName file in dir </> d </> ".liquid" </> f <.> "log"
-
-binPath :: FilePath -> IO FilePath
-binPath pkgName = (</> pkgName) <$> getBinDir
 
 knownToFail = []
 ---------------------------------------------------------------------------


### PR DESCRIPTION
Before

* test issues
    * `test.hs` uses `getBinDir` to locate `fixpoint` which is something like `/home/username/.cabal/bin` on my system. You need to do  `cabal v2-install` to put `fixpoint` in the directory before the tests will pass.
* nix issues
    * `default.nix` is statically generated, 5 years outdated, and doesn't pin the versions of the compiler or dependencies.

After

* test fixes
    * `test.hs` assumes that `fixpoint` can be found in `$PATH`
    * `liquid-fixpoint.cabal` uses `build-tool-depends:` to specify that `test.hs` needs `fixpoint` when `cabal v2-test` is run.
    * `default.nix` uses `$PATH` to ensure `fixpoint` is available when `nix-build` runs tests.
* nix fixes
    * `default.nix` dynamically generates its configuration from the cabalfile
    * `default.nix` pins versions of nixpkgs, all-cabal-hashes, ghc, and all dependencies for reproducibility.
    * `default.nix` patches an outdated package, `git-0.3.0` which isn't compatible with the removal of `fail` from `Monad` in ghc 8.10.1

Unknown

* I don't know how this will affect users of `stack`