### PR TITLE
Rewrite and simplify the paser; add proper layout.

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquid-fixpoint
-version:            0.8.10.2
+version:            0.8.10.2.1
 synopsis:           Predicate Abstraction-based Horn-Clause/Implication Constraint Solver
 description:
   This package implements an SMTLIB based Horn-Clause\/Logical Implication constraint
@@ -123,7 +123,8 @@ library
                   , intern
                   , mtl
                   , parallel
-                  , parsec
+                  , parser-combinators
+                  , megaparsec           >= 7.0.0 && < 9
                   , pretty               >= 1.1.3.1
                   , process
                   , syb

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -12,7 +12,7 @@ import           Data.Maybe  (fromMaybe)
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Solver.Sanitize (symbolEnv)
-import           Language.Fixpoint.Types hiding (mapSort)
+import           Language.Fixpoint.Types hiding (mapSort, Pos)
 import           Language.Fixpoint.Types.Visitor ( (<$$>), mapSort )
 
 mytracepp :: (PPrint a) => String -> a -> a

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -23,7 +23,7 @@ module Language.Fixpoint.Types.Errors (
   , FixResult (..)
   , colorResult
   , resultDoc
-  , resultExit 
+  , resultExit
 
   -- * Error Type
   , Error, Error1

--- a/tests/testParser.hs
+++ b/tests/testParser.hs
@@ -69,11 +69,11 @@ testSortP =
 
     , testCase "bv32" $
         show (doParse' sortP "test" "BitVec Size32") @?=
-              "FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 8) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined from: \"test\" (line 1, column 8) to: \"test\" (line 1, column 14) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
+              "FApp (FTC (TC \"BitVec\" defined at: test:1:1-1:7 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined at: test:1:8-1:14 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
 
     , testCase "bv64" $
         show (doParse' sortP "test" "BitVec Size64") @?=
-              "FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 8) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size64\" defined from: \"test\" (line 1, column 8) to: \"test\" (line 1, column 14) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
+              "FApp (FTC (TC \"BitVec\" defined at: test:1:1-1:7 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size64\" defined at: test:1:8-1:14 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))"
 
     , testCase "FInt int" $
         show (doParse' sortP "test" "int") @?= "FInt"
@@ -96,7 +96,7 @@ testSortP =
 
     , testCase "SYMBOL" $
         show (doParse' sortP "test" "F#y") @?=
-             "FTC (TC \"F#y\" defined from: \"test\" (line 1, column 1) to: \"test\" (line 1, column 4) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))"
+             "FTC (TC \"F#y\" defined at: test:1:1-1:4 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))"
 
     , testCase "FVar 3" $
         show (doParse' sortP "test" "@(3)") @?= "FVar 3"
@@ -136,7 +136,7 @@ testFunAppP =
   testGroup "FunAppP"
     [ testCase "ECon (litP)" $
         show (doParse' funAppP "test" "lit \"#x00000008\" (BitVec  Size32)") @?=
-          "ECon (L \"#x00000008\" (FApp (FTC (TC \"BitVec\" defined from: \"test\" (line 1, column 19) to: \"test\" (line 1, column 27) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined from: \"test\" (line 1, column 27) to: \"test\" (line 1, column 33) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))))"
+          "ECon (L \"#x00000008\" (FApp (FTC (TC \"BitVec\" defined at: test:1:19-1:25 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) (FTC (TC \"Size32\" defined at: test:1:27-1:33 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False})))))"
 
     , testCase "ECon (exprFunSpacesP)" $
         show (doParse' funAppP "test" "fooBar baz qux") @?= "EApp (EApp (EVar \"fooBar\") (EVar \"baz\")) (EVar \"qux\")"


### PR DESCRIPTION
[matches PR https://github.com/ucsd-progsys/liquidhaskell/pull/1704]

This is a major restructuring, even though more work remains to do.

The most important changes are:

- Use megaparsec instead of parsec.
- Change the handling of internal parser state.
- Improve error reporting somewhat.
- Improve location tracking somewhat.
- Add layout information to the parser state.
- Export layout block parser combinators.
- Add more coments and TODOs.