### PR TITLE
Expose parts of the Horn parser

### DIFF
--- a/src/Language/Fixpoint/Horn/Parse.hs
+++ b/src/Language/Fixpoint/Horn/Parse.hs
@@ -1,7 +1,13 @@
 
 {-# LANGUAGE DeriveFunctor #-}
 
-module Language.Fixpoint.Horn.Parse (hornP) where
+module Language.Fixpoint.Horn.Parse (
+    hornP
+  , hCstrP
+  , hPredP
+  , hQualifierP
+  , hVarP
+) where
 
 import           Language.Fixpoint.Parse
 import qualified Language.Fixpoint.Types        as F


### PR DESCRIPTION
Hi! We are using `liquid-fixpoint` as part of a project, and it would be awesome if we could reuse parts of the parser for Horn clauses, and not only the top-level one.

Thanks in advance :)