### PR TITLE
Add cradle information for haskell-language-server

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,8 @@
+cradle:
+  stack:
+    - path: "./src"
+      component: "liquid-fixpoint:lib"
+    - path: "./bin"
+      component: "liquid-fixpoint:exe:fixpoint"
+    - path: "./tests"
+      component: "liquid-fixpoint:test:test"


### PR DESCRIPTION
This allows [haskell-language-server](https://github.com/haskell/haskell-language-server) to be to develop and navigate the project, following the corresponding [documentation](https://github.com/haskell/haskell-language-server#project-configuration). In essence, it maps each folder to the corresponding stanza in Cabal.