### PR TITLE
Support for GHC 9

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquid-fixpoint
-version:            0.9.0.1
+version:            0.8.10.2.1
 synopsis:           Predicate Abstraction-based Horn-Clause/Implication Constraint Solver
 description:
   This package implements an SMTLIB based Horn-Clause\/Logical Implication constraint

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquid-fixpoint
-version:            0.8.10.2.1
+version:            0.9.0.0
 synopsis:           Predicate Abstraction-based Horn-Clause/Implication Constraint Solver
 description:
   This package implements an SMTLIB based Horn-Clause\/Logical Implication constraint

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               liquid-fixpoint
-version:            0.9.0.0
+version:            0.9.0.1
 synopsis:           Predicate Abstraction-based Horn-Clause/Implication Constraint Solver
 description:
   This package implements an SMTLIB based Horn-Clause\/Logical Implication constraint

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -210,6 +210,9 @@ hashNub = M.keys . M.fromList . fmap (, ())
 sortNub :: (Ord a) => [a] -> [a]
 sortNub = nubOrd . L.sort
 
+sortNubBy :: (Eq a) => (a -> a -> Ordering) -> [a] -> [a]
+sortNubBy f = nubOrd . L.sortBy f
+
 nubOrd :: (Eq a) => [a] -> [a]
 nubOrd (x:t@(y:_))
   | x == y    = nubOrd t

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -190,7 +190,7 @@ simplifyFInfo !cfg !fi0 = do
   let si0   = {-# SCC "convertFormat" #-} convertFormat fi1
   -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si0)
   -- rnf si0 `seq` donePhase Loud "Format Conversion"
-  let si1   = either die id $ {-# SCC "sanitize" #-} sanitize cfg $!! si0
+  let si1   = either die id $ ({-# SCC "sanitize" #-} sanitize cfg $!! si0)
   -- writeLoud $ "fq file after sanitize: \n" ++ render (toFixpoint cfg si1)
   -- rnf si1 `seq` donePhase Loud "Validated Constraints"
   graphStatistics cfg si1

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -45,12 +45,15 @@ mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
 
 traceE :: (Expr,Expr) -> (Expr,Expr)
-traceE (e,e') 
-  | False -- True 
-  , e /= e' 
-  = trace ("\n" ++ showpp e ++ " ~> " ++ showpp e') (e,e') 
-  | otherwise 
+traceE (e,e')
+  | isEnabled
+  , e /= e'
+  = trace ("\n" ++ showpp e ++ " ~> " ++ showpp e') (e,e')
+  | otherwise
   = (e,e')
+  where
+    isEnabled :: Bool
+    isEnabled = False
 
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE 

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -21,7 +21,7 @@ import           Language.Fixpoint.SortCheck     (elaborate, applySorts, isFirst
 -- import           Language.Fixpoint.Defunctionalize 
 import qualified Language.Fixpoint.Misc                            as Misc
 import qualified Language.Fixpoint.Types                           as F
-import           Language.Fixpoint.Types.Config (Config, allowHO)
+import           Language.Fixpoint.Types.Config (Config)
 import qualified Language.Fixpoint.Types.Config as Cfg 
 import qualified Language.Fixpoint.Types.Errors                    as E
 import qualified Language.Fixpoint.Smt.Theories                    as Thy
@@ -404,24 +404,22 @@ symbolSorts :: Config -> F.GInfo c a -> [(F.Symbol, F.Sort)]
 symbolSorts cfg fi = either E.die id $ symbolSorts' cfg fi
 
 symbolSorts' :: Config -> F.GInfo c a -> SanitizeM [(F.Symbol, F.Sort)]
-symbolSorts' cfg fi  = (normalize . compact . (defs ++)) =<< bindSorts fi
+symbolSorts' _cfg fi  = (normalize . compact . (defs ++)) =<< bindSorts fi
   where
     normalize       = fmap (map (unShadow txFun dm))
     dm              = M.fromList defs
     defs            = F.toListSEnv . F.gLits $ fi
-    txFun           
+    txFun
       | True        = id
-      | allowHO cfg = id
-      | otherwise   = defuncSort
 
 unShadow :: (F.Sort -> F.Sort) -> M.HashMap F.Symbol a -> (F.Symbol, F.Sort) -> (F.Symbol, F.Sort)
 unShadow tx dm (x, t)
   | M.member x dm  = (x, t)
   | otherwise      = (x, tx t)
 
-defuncSort :: F.Sort -> F.Sort
-defuncSort (F.FFunc {}) = F.funcSort
-defuncSort t            = t
+_defuncSort :: F.Sort -> F.Sort
+_defuncSort (F.FFunc {}) = F.funcSort
+_defuncSort t            = t
 
 compact :: [(F.Symbol, F.Sort)] -> Either E.Error [(F.Symbol, F.Sort)]
 compact xts


### PR DESCRIPTION
This PR adds support to build `liquid-fixpoint` with GHC 9 and adds a new combinator `sortNubBy` useful for the GHC 9 migration of `liquidhaskell`. See: https://github.com/ucsd-progsys/liquidhaskell/pull/1774