### PR TITLE
Remove dependency on `text-format`

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -98,6 +98,7 @@ library
                     Language.Fixpoint.Types.Triggers
                     Language.Fixpoint.Types.Utils
                     Language.Fixpoint.Types.Visitor
+                    Language.Fixpoint.Utils.Builder
                     Language.Fixpoint.Utils.Files
                     Language.Fixpoint.Utils.Progress
                     Language.Fixpoint.Utils.Statistics

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -131,7 +131,6 @@ library
                   , syb
                   , syb
                   , text
-                  -- , text-format
                   , transformers
                   , unordered-containers
                   , aeson

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -130,7 +130,7 @@ library
                   , syb
                   , syb
                   , text
-                  , text-format
+                  -- , text-format
                   , transformers
                   , unordered-containers
                   , aeson

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -178,8 +178,8 @@ smtRead me = {-# SCC "smtRead" #-} do
   case A.eitherResult res of
     Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
     Right r -> do
-      maybe (return ()) (\h -> hPutStrLnNow h $ blt ("; SMT Says: " <> (fromShow r))) (ctxLog me)
-      when (ctxVerbose me) $ LTIO.putStrLn $ blt ("SMT Says: " <> fromShow r)
+      maybe (return ()) (\h -> hPutStrLnNow h $ blt ("; SMT Says: " <> (bShow r))) (ctxLog me)
+      when (ctxVerbose me) $ LTIO.putStrLn $ blt ("SMT Says: " <> bShow r)
       return r
 
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -100,6 +100,7 @@ import qualified Data.Attoparsec.Text     as A
 import           Data.Attoparsec.Internal.Types (Parser)
 import           Text.PrettyPrint.HughesPJ (text)
 import           Language.Fixpoint.SortCheck
+import           Language.Fixpoint.Utils.Builder
 -- import qualified Language.Fixpoint.Types as F
 -- import           Language.Fixpoint.Types.PrettyPrint (tracepp)
 
@@ -177,8 +178,8 @@ smtRead me = {-# SCC "smtRead" #-} do
   case A.eitherResult res of
     Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
     Right r -> do
-      maybe (return ()) (\h -> hPutStrLnNow h $ Builder.toLazyText ("; SMT Says: " <> (Only $ show r)) (ctxLog me)
-      when (ctxVerbose me) $ LTIO.putStrLn $ format "SMT Says: {}" (Only $ show r)
+      maybe (return ()) (\h -> hPutStrLnNow h $ blt ("; SMT Says: " <> (fromShow r))) (ctxLog me)
+      when (ctxVerbose me) $ LTIO.putStrLn $ blt ("SMT Says: " <> fromShow r)
       return r
 
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -84,7 +84,7 @@ import           Data.Semigroup          (Semigroup (..))
 #endif
 
 import qualified Data.Text                as T
-import           Data.Text.Format
+-- import           Data.Text.Format
 import qualified Data.Text.IO             as TIO
 import qualified Data.Text.Lazy           as LT
 import qualified Data.Text.Lazy.Builder   as Builder

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -177,9 +177,11 @@ smtRead me = {-# SCC "smtRead" #-} do
   case A.eitherResult res of
     Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
     Right r -> do
-      maybe (return ()) (\h -> hPutStrLnNow h $ format "; SMT Says: {}" (Only $ show r)) (ctxLog me)
+      maybe (return ()) (\h -> hPutStrLnNow h $ Builder.toLazyText ("; SMT Says: " <> (Only $ show r)) (ctxLog me)
       when (ctxVerbose me) $ LTIO.putStrLn $ format "SMT Says: {}" (Only $ show r)
       return r
+
+
 
 type SmtParser a = Parser T.Text a
 

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -23,9 +23,12 @@ import           Data.Semigroup                 (Semigroup (..))
 #endif
 
 import qualified Data.Text.Lazy.Builder         as Builder
-import           Data.Text.Format
+-- import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)
 -- import Debug.Trace (trace)
+
+parens :: Builder.Builder -> Builder.Builder
+parens b = "(" <>  b <> ")"
 
 instance SMTLIB2 (Symbol, Sort) where
   smt2 env c@(sym, t) = build "({} {})" (smt2 env sym, smt2SortMono c env t)

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -112,10 +112,9 @@ instance SMTLIB2 SymConst where
   smt2 env = smt2 env . symbol
 
 instance SMTLIB2 Constant where
-  smt2 _ (I n)   = fromShow n
-  smt2 _ (R d)   = fromShow d
-  smt2 _ (L t _) = fromShow t
-
+  smt2 _ (I n)   = bShow n
+  smt2 _ (R d)   = bShow d
+  smt2 _ (L t _) = lbb t
 
 instance SMTLIB2 Bop where
   smt2 _ Plus   = "+"
@@ -236,7 +235,7 @@ instance SMTLIB2 Command where
   smt2 env (Declare x ts t)    = parenSeqs ["declare-fun", smt2 env x, parens (smt2many (smt2 env <$> ts)), smt2 env t]
   smt2 env c@(Define t)        = key "declare-sort" (smt2SortMono c env t)
   smt2 env (Assert Nothing p)  = key "assert" (smt2 env p)
-  smt2 env (Assert (Just i) p) = key "assert" (parens ("!"<+> smt2 env p <+> ":named p-" <> fromShow i))
+  smt2 env (Assert (Just i) p) = key "assert" (parens ("!"<+> smt2 env p <+> ":named p-" <> bShow i))
   smt2 env (Distinct az)
     | length az < 2            = ""
     | otherwise                = key "assert" (key "distinct" (smt2s env az))

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -113,7 +113,7 @@ instance SMTLIB2 SymConst where
 
 instance SMTLIB2 Constant where
   smt2 _ (I n)   = bShow n
-  smt2 _ (R d)   = bShow d
+  smt2 _ (R d)   = bFloat d
   smt2 _ (L t _) = lbb t
 
 instance SMTLIB2 Bop where

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -25,13 +25,12 @@ import           Data.Semigroup                 (Semigroup (..))
 import qualified Data.Text.Lazy.Builder         as Builder
 -- import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)
+import           Language.Fixpoint.Utils.Builder
 -- import Debug.Trace (trace)
 
-parens :: Builder.Builder -> Builder.Builder
-parens b = "(" <>  b <> ")"
-
 instance SMTLIB2 (Symbol, Sort) where
-  smt2 env c@(sym, t) = build "({} {})" (smt2 env sym, smt2SortMono c env t)
+  smt2 env c@(sym, t) = -- build "({} {})" (smt2 env sym, smt2SortMono c env t)
+                        parenSeq1s [smt2 env sym, smt2SortMono c env t]
 
 smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder.Builder
 smt2SortMono = smt2Sort False
@@ -44,45 +43,34 @@ smt2data :: SymEnv -> [DataDecl] -> Builder.Builder
 smt2data env = smt2data' env . map padDataDecl
 
 smt2data' :: SymEnv -> [DataDecl] -> Builder.Builder
-smt2data' env ds = build "({}) ({})" (smt2many (smt2dataname env <$> ds), smt2many (smt2datactors env <$> ds))
+smt2data' env ds = seq1s [ parens $ smt2many (smt2dataname env <$> ds)
+                         , parens $ smt2many (smt2datactors env <$> ds)
+                         ]
+
  
 smt2dataname :: SymEnv -> DataDecl -> Builder.Builder
-smt2dataname env (DDecl tc as _) = build "({} {})" (name, n)
+smt2dataname env (DDecl tc as _) = parenSeq1s [name, n]
   where
     name  = smt2 env (symbol tc)
     n     = smt2 env as 
 
 
 smt2datactors :: SymEnv -> DataDecl -> Builder.Builder
-smt2datactors env (DDecl _ as cs) = build "(par ({}) ({}))" (tvars,ds) 
+smt2datactors env (DDecl _ as cs) = parenSeq1s ["par", parens tvars, parens ds]
   where
     tvars        = smt2many (smt2TV <$> [0..(as-1)])
     smt2TV       = smt2 env . SVar
     ds           = smt2many (smt2ctor env as <$> cs) 
 
-{- 
-smt2data' :: SymEnv -> DataDecl -> Builder.Builder
-smt2data' env (DDecl tc n cs) = build "({}) (({} {}))" (tvars, name, ctors)
-  where
-    tvars                    = smt2many (smt2TV <$> [0..(n-1)])
-    name                     = smt2 env (symbol tc)
-    ctors                    = smt2many (smt2ctor env <$> cs)
-    smt2TV                   = smt2 env . SVar
--}
-
-{- 
-    (declare-datatypes (T) ((Tree leaf (node (value T) (children TreeList)))
-    (TreeList nil (cons (car Tree) (cdr TreeList)))))
--}
-
 smt2ctor :: SymEnv -> Int -> DataCtor -> Builder.Builder
 smt2ctor env _  (DCtor c [])  = smt2 env c
-smt2ctor env as (DCtor c fs)  = build "({} {})" (smt2 env c, fields)
+smt2ctor env as (DCtor c fs)  = parenSeq1s [smt2 env c, fields]
+                                
   where
     fields                 = smt2many (smt2field env as <$> fs)
 
 smt2field :: SymEnv -> Int -> DataField -> Builder.Builder
-smt2field env as d@(DField x t) = build "({} {})" (smt2 env x, smt2SortPoly d env $ mkPoly as t)
+smt2field env as d@(DField x t) = parenSeq1s [smt2 env x, smt2SortPoly d env $ mkPoly as t]
 
 -- | SMTLIB/Z3 don't like "unused" type variables; they get pruned away and
 --   cause wierd hassles. See tests/pos/adt_poly_dead.fq for an example.
@@ -124,9 +112,9 @@ instance SMTLIB2 SymConst where
   smt2 env = smt2 env . symbol
 
 instance SMTLIB2 Constant where
-  smt2 _ (I n)   = build "{}" (Only n)
-  smt2 _ (R d)   = build "{}" (Only d)
-  smt2 _ (L t _) = build "{}" (Only t)
+  smt2 _ (I n)   = fromShow n
+  smt2 _ (R d)   = fromShow d
+  smt2 _ (L t _) = fromShow t
 
 
 instance SMTLIB2 Bop where
@@ -153,23 +141,23 @@ instance SMTLIB2 Expr where
   smt2 env (ECon c)         = smt2 env c
   smt2 env (EVar x)         = smt2 env x
   smt2 env e@(EApp _ _)     = smt2App env e
-  smt2 env (ENeg e)         = build "(- {})" (Only $ smt2 env e)
-  smt2 env (EBin o e1 e2)   = build "({} {} {})" (smt2 env o, smt2 env e1, smt2 env e2)
-  smt2 env (EIte e1 e2 e3)  = build "(ite {} {} {})" (smt2 env e1, smt2 env e2, smt2 env e3)
+  smt2 env (ENeg e)         = parenSeq1s ["-", smt2 env e]
+  smt2 env (EBin o e1 e2)   = parenSeq1s [smt2 env o, smt2 env e1, smt2 env e2]
+  smt2 env (EIte e1 e2 e3)  = parenSeq1s ["ite", smt2 env e1, smt2 env e2, smt2 env e3]
   smt2 env (ECst e t)       = smt2Cast env e t
   smt2 _   (PTrue)          = "true"
   smt2 _   (PFalse)         = "false"
   smt2 _   (PAnd [])        = "true"
-  smt2 env (PAnd ps)        = build "(and {})"   (Only $ smt2s env ps)
+  smt2 env (PAnd ps)        = parenSeq1s ["and", smt2s env ps]
   smt2 _   (POr [])         = "false"
-  smt2 env (POr ps)         = build "(or  {})"   (Only $ smt2s env ps)
-  smt2 env (PNot p)         = build "(not {})"   (Only $ smt2  env p)
-  smt2 env (PImp p q)       = build "(=> {} {})" (smt2 env p, smt2 env q)
-  smt2 env (PIff p q)       = build "(= {} {})"  (smt2 env p, smt2 env q)
+  smt2 env (POr ps)         = parenSeq1s ["or", smt2s env ps] 
+  smt2 env (PNot p)         = parenSeq1s ["not", smt2  env p]
+  smt2 env (PImp p q)       = parenSeq1s ["=>", smt2 env p, smt2 env q]
+  smt2 env (PIff p q)       = parenSeq1s ["=", smt2 env p, smt2 env q]
   smt2 env (PExist [] p)    = smt2 env p
-  smt2 env (PExist bs p)    = build "(exists ({}) {})"  (smt2s env bs, smt2 env p)
+  smt2 env (PExist bs p)    = parenSeq1s ["exists", parens (smt2s env bs), smt2 env p]
   smt2 env (PAll   [] p)    = smt2 env p
-  smt2 env (PAll   bs p)    = build "(forall ({}) {})"  (smt2s env bs, smt2 env p)
+  smt2 env (PAll   bs p)    = parenSeq1s ["forall", parens (smt2s env bs), smt2 env p] 
   smt2 env (PAtom r e1 e2)  = mkRel env r e1 e2
   smt2 env (ELam b e)       = smt2Lam   env b e
   smt2 env (ECoerc t1 t2 e) = smt2Coerc env t1 t2 e
@@ -195,10 +183,10 @@ smtLamArg :: SymEnv -> Symbol -> Sort -> Builder.Builder
 smtLamArg env x t = symbolBuilder $ symbolAtName x env () (FFunc t FInt)
 
 smt2VarAs :: SymEnv -> Symbol -> Sort -> Builder.Builder
-smt2VarAs env x t = build "(as {} {})" (smt2 env x, smt2SortMono x env t)
+smt2VarAs env x t = parenSeq1s ["as", smt2 env x, smt2SortMono x env t]
 
 smt2Lam :: SymEnv -> (Symbol, Sort) -> Expr -> Builder.Builder
-smt2Lam env (x, xT) (ECst e eT) = build "({} {} {})" (smt2 env lambda, x', smt2 env e)
+smt2Lam env (x, xT) (ECst e eT) = parenSeq1s [smt2 env lambda, x', smt2 env e]
   where
     x'                          = smtLamArg env x xT
     lambda                      = symbolAtName lambdaName env () (FFunc xT eT)
@@ -209,19 +197,19 @@ smt2Lam _ _ e
 smt2App :: SymEnv -> Expr -> Builder.Builder
 smt2App env e@(EApp (EApp f e1) e2)
   | Just t <- unApplyAt f
-  = build "({} {})" (symbolBuilder (symbolAtName applyName env e t), smt2s env [e1, e2])
+  = parenSeq1s [symbolBuilder (symbolAtName applyName env e t), smt2s env [e1, e2]]
 smt2App env e
   | Just b <- Thy.smt2App smt2VarAs env f (smt2 env <$> es)
   = b
   | otherwise
-  = build "({} {})" (smt2 env f, smt2s env es)
+  = parenSeq1s [smt2 env f, smt2s env es]
   where
     (f, es)   = splitEApp' e
 
 smt2Coerc :: SymEnv -> Sort -> Sort -> Expr -> Builder.Builder
 smt2Coerc env t1 t2 e 
   | t1' == t2'  = smt2 env e
-  | otherwise = build "({} {})" (symbolBuilder coerceFn , smt2 env e)
+  | otherwise = parenSeq1s [symbolBuilder coerceFn , smt2 env e]
   where 
     coerceFn  = symbolAtName coerceName env (ECoerc t1 t2 e) t
     t         = FFunc t1 t2
@@ -238,34 +226,38 @@ splitEApp'            = go []
 mkRel :: SymEnv -> Brel -> Expr -> Expr -> Builder.Builder
 mkRel env Ne  e1 e2 = mkNe env e1 e2
 mkRel env Une e1 e2 = mkNe env e1 e2
-mkRel env r   e1 e2 = build "({} {} {})" (smt2 env r, smt2 env e1, smt2 env e2)
+mkRel env r   e1 e2 = parenSeq1s [smt2 env r, smt2 env e1, smt2 env e2]
 
 mkNe :: SymEnv -> Expr -> Expr -> Builder.Builder
-mkNe env e1 e2      = build "(not (= {} {}))" (smt2 env e1, smt2 env e2)
+mkNe env e1 e2      = key "not" (parenSeq1s ["=",  smt2 env e1, smt2 env e2])
 
 instance SMTLIB2 Command where
-  smt2 env (DeclData ds)       = build "(declare-datatypes {})"       (Only $ smt2data env ds)
-  smt2 env (Declare x ts t)    = build "(declare-fun {} ({}) {})"     (smt2 env x, smt2many (smt2 env <$> ts), smt2 env t)
-  smt2 env c@(Define t)        = build "(declare-sort {})"            (Only $ smt2SortMono c env t)
-  smt2 env (Assert Nothing p)  = build "(assert {})"                  (Only $ smt2 env p)
-  smt2 env (Assert (Just i) p) = build "(assert (! {} :named p-{}))"  (smt2 env p, i)
+  smt2 env (DeclData ds)       = key "declare-datatypes" (smt2data env ds)
+  smt2 env (Declare x ts t)    = parenSeq1s ["declare-fun", smt2 env x, parens (smt2many (smt2 env <$> ts)), smt2 env t]
+  smt2 env c@(Define t)        = key "declare-sort" (smt2SortMono c env t)
+  smt2 env (Assert Nothing p)  = key "assert" (smt2 env p)
+  smt2 env (Assert (Just i) p) = key "assert" (parens ("!"<+> smt2 env p <+> ":named p-" <> fromShow i))
   smt2 env (Distinct az)
     | length az < 2            = ""
-    | otherwise                = build "(assert (distinct {}))"       (Only $ smt2s env az)
-  smt2 env (AssertAx t)        = build "(assert {})"                  (Only $ smt2  env t)
+    | otherwise                = key "assert" (key "distinct" (smt2s env az))
+  smt2 env (AssertAx t)        = key "assert" (smt2 env t)
   smt2 _   (Push)              = "(push 1)"
   smt2 _   (Pop)               = "(pop 1)"
   smt2 _   (CheckSat)          = "(check-sat)"
-  smt2 env (GetValue xs)       = "(get-value (" <> smt2s env xs <> "))"
+  smt2 env (GetValue xs)       = key "key-value" (parens (smt2s env xs))
   smt2 env (CMany cmds)        = smt2many (smt2 env <$> cmds)
 
 instance SMTLIB2 (Triggered Expr) where
   smt2 env (TR NoTrigger e)       = smt2 env e
   smt2 env (TR _ (PExist [] p))   = smt2 env p
-  smt2 env t@(TR _ (PExist bs p)) = build "(exists ({}) (! {} :pattern({})))"  (smt2s env bs, smt2 env p, smt2s env (makeTriggers t))
+  smt2 env t@(TR _ (PExist bs p)) = smtTr env "exists" bs p t
   smt2 env (TR _ (PAll   [] p))   = smt2 env p
-  smt2 env t@(TR _ (PAll   bs p)) = build "(forall ({}) (! {} :pattern({})))"  (smt2s env bs, smt2 env p, smt2s env (makeTriggers t))
+  smt2 env t@(TR _ (PAll   bs p)) = smtTr env "forall" bs p t
   smt2 env (TR _ e)               = smt2 env e
+  
+{-# INLINE smtTr #-}
+smtTr :: SymEnv -> Builder.Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> Builder.Builder
+smtTr env q bs p t = key q (parens (smt2s env bs) <+> key "!" (smt2 env p <+> ":pattern" <> parens (smt2s env (makeTriggers t)))) 
 
 {-# INLINE smt2s #-}
 smt2s    :: SMTLIB2 a => SymEnv -> [a] -> Builder.Builder

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -129,7 +129,7 @@ bFun name xts out body = blt $ key "define-fun" (seqs [bb name, args, out, body]
     args = parenSeqs [parens (x <+> t) | (x, t) <- xts]
 
 bFun' :: Raw -> [B.Builder] -> B.Builder -> T.Text
-bFun' name ts out = blt $ key "define-fun" (seqs [bb name, args, out])
+bFun' name ts out = blt $ key "declare-fun" (seqs [bb name, args, out])
   where
     args = parenSeqs ts
 
@@ -262,7 +262,7 @@ stringPreamble cfg | stringTheory cfg
 
 stringPreamble _
   = [ bSort string "Int"
-    , bFun' strLen ["String"] "Int" 
+    , bFun' strLen [bb string] "Int" 
     , bFun' strSubstr [bb string, "Int", "Int"] (bb string)
     , bFun' strConcat [bb string, bb string] (bb string)
     ]
@@ -283,8 +283,8 @@ smt2SmtSort SBool        = "Bool"
 smt2SmtSort SString      = bb string
 smt2SmtSort SSet         = bb set
 smt2SmtSort SMap         = bb map
-smt2SmtSort (SBitVec n)  = key "_ BitVec" (fromShow n)
-smt2SmtSort (SVar n)     = "T" <> fromShow n
+smt2SmtSort (SBitVec n)  = key "_ BitVec" (bShow n)
+smt2SmtSort (SVar n)     = "T" <> bShow n
 smt2SmtSort (SData c []) = symbolBuilder c
 smt2SmtSort (SData c ts) = parenSeqs [symbolBuilder c, smt2SmtSorts ts]
 

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -124,14 +124,14 @@ string :: Raw
 string = strConName
 
 bFun :: Raw -> [(B.Builder, B.Builder)] -> B.Builder -> B.Builder -> T.Text
-bFun name xts out body = blt $ key "define-fun" (seq1s [bb name, args, out, body])
+bFun name xts out body = blt $ key "define-fun" (seqs [bb name, args, out, body])
   where
-    args = parenSeq1s [parens (x <+> t) | (x, t) <- xts]
+    args = parenSeqs [parens (x <+> t) | (x, t) <- xts]
 
 bFun' :: Raw -> [B.Builder] -> B.Builder -> T.Text
-bFun' name ts out = blt $ key "define-fun" (seq1s [bb name, args, out])
+bFun' name ts out = blt $ key "define-fun" (seqs [bb name, args, out])
   where
-    args = parenSeq1s ts
+    args = parenSeqs ts
 
 bSort :: Raw -> B.Builder -> T.Text
 bSort name def = blt $ key "define-sort" (bb name <+> "()" <+> def)
@@ -286,7 +286,7 @@ smt2SmtSort SMap         = bb map
 smt2SmtSort (SBitVec n)  = key "_ BitVec" (fromShow n)
 smt2SmtSort (SVar n)     = "T" <> fromShow n
 smt2SmtSort (SData c []) = symbolBuilder c
-smt2SmtSort (SData c ts) = parenSeq1s [symbolBuilder c, smt2SmtSorts ts]
+smt2SmtSort (SData c ts) = parenSeqs [symbolBuilder c, smt2SmtSorts ts]
 
 -- smt2SmtSort (SApp ts)    = build "({} {})" (symbolBuilder tyAppName, smt2SmtSorts ts)
 

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -50,10 +50,9 @@ import           Language.Fixpoint.Smt.Types
 import           Data.Maybe (catMaybes)
 import qualified Data.Text.Lazy           as T
 import qualified Data.Text.Lazy.Builder   as Builder
-import           Data.Text.Format
+-- import           Data.Text.Format
 import qualified Data.Text
 import           Data.String                 (IsString(..))
-
 
 {- | [NOTE:Adding-Theories] To add new (SMTLIB supported) theories to
      liquid-fixpoint and upstream, grep for "Map_default" and then add

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -49,10 +49,11 @@ import           Language.Fixpoint.Smt.Types
 -- import qualified Data.HashMap.Strict      as M
 import           Data.Maybe (catMaybes)
 import qualified Data.Text.Lazy           as T
-import qualified Data.Text.Lazy.Builder   as Builder
+import qualified Data.Text.Lazy.Builder   as B
 -- import           Data.Text.Format
 import qualified Data.Text
 import           Data.String                 (IsString(..))
+import Language.Fixpoint.Utils.Builder
 
 {- | [NOTE:Adding-Theories] To add new (SMTLIB supported) theories to
      liquid-fixpoint and upstream, grep for "Map_default" and then add
@@ -122,167 +123,197 @@ concatstrSort = mkFFunc 0 [strSort, strSort, strSort]
 string :: Raw
 string = strConName
 
+bFun :: Raw -> [(B.Builder, B.Builder)] -> B.Builder -> B.Builder -> T.Text
+bFun name xts out body = blt $ key "define-fun" (seq1s [bb name, args, out, body])
+  where
+    args = parenSeq1s [parens (x <+> t) | (x, t) <- xts]
+
+bFun' :: Raw -> [B.Builder] -> B.Builder -> T.Text
+bFun' name ts out = blt $ key "define-fun" (seq1s [bb name, args, out])
+  where
+    args = parenSeq1s ts
+
+bSort :: Raw -> B.Builder -> T.Text
+bSort name def = blt $ key "define-sort" (bb name <+> "()" <+> def)
+
 z3Preamble :: Config -> [T.Text]
 z3Preamble u
   = stringPreamble u ++
-    [ format "(define-sort {} () Int)"
-        (Only elt)
-    , format "(define-sort {} () (Array {} Bool))"
-        (set, elt)
-    , format "(define-fun {} () {} ((as const {}) false))"
-        (emp, set, set)
-    , format "(define-fun {} ((x {}) (s {})) Bool (select s x))"
-        (mem, elt, set)
-    , format "(define-fun {} ((s {}) (x {})) {} (store s x true))"
-        (add, set, elt, set)
-    , format "(define-fun {} ((s1 {}) (s2 {})) {} ((_ map or) s1 s2))"
-        (cup, set, set, set)
-    , format "(define-fun {} ((s1 {}) (s2 {})) {} ((_ map and) s1 s2))"
-        (cap, set, set, set)
-    , format "(define-fun {} ((s {})) {} ((_ map not) s))"
-        (com, set, set)
-    , format "(define-fun {} ((s1 {}) (s2 {})) {} ({} s1 ({} s2)))"
-        (dif, set, set, set, cap, com)
-    , format "(define-fun {} ((s1 {}) (s2 {})) Bool (= {} ({} s1 s2)))"
-        (sub, set, set, emp, dif)
-    , format "(define-sort {} () (Array {} {}))"
-        (map, elt, elt)
-    , format "(define-fun {} ((m {}) (k {})) {} (select m k))"
-        (sel, map, elt, elt)
-    , format "(define-fun {} ((m {}) (k {}) (v {})) {} (store m k v))"
-        (sto, map, elt, elt, map)
-    , format "(define-fun {} ((m1 {}) (m2 {})) {} ((_ map (+ ({} {}) {})) m1 m2))"
-        (mcup, map, map, map, elt, elt, elt)
-    , format "(define-fun {} ((v {})) {} ((as const ({})) v))"
-        (mdef, elt, map, map)
-    , format "(define-fun {} ((b Bool)) Int (ite b 1 0))"
-        (Only (boolToIntName :: T.Text))
-    , uifDef u (symbolText mulFuncName) ("*"   :: T.Text)
-    , uifDef u (symbolText divFuncName) "div"
+    [ bSort elt 
+        "Int"
+    , bSort set 
+        (key2 "Array" (bb elt) "Bool")
+    , bFun emp 
+        [] 
+        (bb set) 
+        (parens (key "as const" (bb set) <+> "false"))
+    , bFun mem 
+        [("x", bb elt), ("s", bb set)] 
+        "Bool"
+        "(select s x)"
+    , bFun add
+        [("s", bb set), ("x", bb elt)] 
+        (bb set)
+        "(store s x true)"
+    , bFun cup 
+        [("s1", bb set), ("s2", bb set)] 
+        (bb set)
+        "((_ map or) s1 s2)"
+    , bFun cap 
+        [("s1", bb set), ("s2", bb set)] 
+        (bb set)
+        "((_ map and) s1 s2)"
+    , bFun com
+        [("s", bb set)] 
+        (bb set)
+        "((_ map not) s)"
+    , bFun dif 
+        [("s1", bb set), ("s2", bb set)] 
+        (bb set)
+        (key2 (bb cap) "s1" (key (bb com) "s2"))
+    , bFun sub
+        [("s1", bb set), ("s2", bb set)]
+        "Bool"
+        (key2 "=" (bb emp) (key2 (bb dif) "s1" "s2")) 
+
+    -- Maps    
+    , bSort map
+        (key2 "Array" (bb elt) (bb elt))
+    , bFun sel
+        [("m", bb map), ("k", bb elt)]
+        (bb elt)    
+        "(select m k)"
+    , bFun sto
+        [("m", bb map), ("k", bb elt), ("v", bb elt)]
+        (bb map)    
+        "(store m k v)"
+    , bFun mcup
+        [("m1", bb map), ("m2", bb map)]
+        (bb map)
+        (key2 (key "_ map" (key2 "+" (parens (bb elt <+> bb elt)) (bb elt))) "m1" "m2")
+    , bFun mdef
+        [("v", bb elt)]
+        (bb map)
+        (key (key "as const" (parens (bb map))) "v")
+    , bFun boolToIntName
+        [("b", "Bool")]
+        "Int"
+        "(ite b 1 0)"
+
+    , uifDef u (symbolLText mulFuncName) "*" 
+    , uifDef u (symbolLText divFuncName) "div"
     ]
+
+symbolLText :: Symbol -> T.Text
+symbolLText = T.fromStrict . symbolText 
 
 -- RJ: Am changing this to `Int` not `Real` as (1) we usually want `Int` and
 -- (2) have very different semantics. TODO: proper overloading, post genEApp
-uifDef :: Config -> Data.Text.Text -> T.Text -> T.Text
+uifDef :: Config -> T.Text -> T.Text -> T.Text
 uifDef cfg f op
   | linear cfg || Z3 /= solver cfg
-  = format "(declare-fun {} (Int Int) Int)" (Only f)
+  = bFun' f ["Int", "Int"] "Int" 
   | otherwise
-  = format "(define-fun {} ((x Int) (y Int)) Int ({} x y))" (f, op)
+  = bFun f [("x", "Int"), ("y", "Int")] "Int" (key2 (bb op) "x" "y")
 
 cvc4Preamble :: Config -> [T.Text]
-cvc4Preamble _ --TODO use uif flag u (see z3Preamble)
-  = [        "(set-logic ALL_SUPPORTED)"
-    , format "(define-sort {} () Int)"       (Only elt)
-    , format "(define-sort {} () Int)"       (Only set)
-    , format "(define-sort {} () Int)"       (Only string)
-    , format "(declare-fun {} () {})"        (emp, set)
-    , format "(declare-fun {} ({} {}) {})"   (add, set, elt, set)
-    , format "(declare-fun {} ({} {}) {})"   (cup, set, set, set)
-    , format "(declare-fun {} ({} {}) {})"   (cap, set, set, set)
-    , format "(declare-fun {} ({} {}) {})"   (dif, set, set, set)
-    , format "(declare-fun {} ({} {}) Bool)" (sub, set, set)
-    , format "(declare-fun {} ({} {}) Bool)" (mem, elt, set)
-    , format "(define-sort {} () (Array {} {}))"
-        (map, elt, elt)
-    , format "(define-fun {} ((m {}) (k {})) {} (select m k))"
-        (sel, map, elt, elt)
-    , format "(define-fun {} ((m {}) (k {}) (v {})) {} (store m k v))"
-        (sto, map, elt, elt, map)
-    , format "(define-fun {} ((b Bool)) Int (ite b 1 0))"
-        (Only (boolToIntName :: Raw))
+cvc4Preamble z
+  = [        "(set-logic ALL_SUPPORTED)"]
+  ++ commonPreamble z
+  ++ cvc4MapPreamble z
+
+commonPreamble :: Config -> [T.Text]
+commonPreamble _ --TODO use uif flag u (see z3Preamble)
+  = [ bSort elt    "Int"
+    , bSort set    "Int"
+    , bSort string "Int"
+    , bFun' emp []               (bb set) 
+    , bFun' add [bb set, bb elt] (bb set)
+    , bFun' cup [bb set, bb set] (bb set)
+    , bFun' cap [bb set, bb set] (bb set)
+    , bFun' dif [bb set, bb set] (bb set)
+    , bFun' sub [bb set, bb set] "Bool"
+    , bFun' mem [bb elt, bb set] "Bool"
+    , bFun boolToIntName [("b", "Bool")] "Int" "(ite b 1 0)"
+    ]
+
+cvc4MapPreamble :: Config -> [T.Text]
+cvc4MapPreamble _ =      
+    [ bSort map    (key2 "Array" (bb elt) (bb elt))
+    , bFun sel [("m", bb map), ("k", bb elt)]                (bb elt) "(select m k)"
+    , bFun sto [("m", bb map), ("k", bb elt), ("v", bb elt)] (bb map) "(store m k v)"
     ]
 
 smtlibPreamble :: Config -> [T.Text]
-smtlibPreamble _ --TODO use uif flag u (see z3Preamble)
-  = [       --  "(set-logic QF_AUFRIA)",
-      format "(define-sort {} () Int)"       (Only elt)
-    , format "(define-sort {} () Int)"       (Only set)
-    , format "(declare-fun {} () {})"        (emp, set)
-    , format "(declare-fun {} ({} {}) {})"   (add, set, elt, set)
-    , format "(declare-fun {} ({} {}) {})"   (cup, set, set, set)
-    , format "(declare-fun {} ({} {}) {})"   (cap, set, set, set)
-    , format "(declare-fun {} ({} {}) {})"   (dif, set, set, set)
-    , format "(declare-fun {} ({} {}) Bool)" (sub, set, set)
-    , format "(declare-fun {} ({} {}) Bool)" (mem, elt, set)
-    , format "(define-sort {} () Int)"       (Only map)
-    , format "(declare-fun {} ({} {}) {})"    (sel, map, elt, elt)
-    , format "(declare-fun {} ({} {} {}) {})" (sto, map, elt, elt, map)
-    , format "(declare-fun {} ({} {} {}) {})" (sto, map, elt, elt, map)
-    , format "(define-fun {} ((b Bool)) Int (ite b 1 0))" (Only (boolToIntName :: Raw))
+smtlibPreamble z --TODO use uif flag u (see z3Preamble)
+  = commonPreamble z 
+ ++ [ bSort map "Int"
+    , bFun' sel [bb map, bb elt] (bb elt)
+    , bFun' sto [bb map, bb elt, bb elt] (bb map)
     ]
-
 
 stringPreamble :: Config -> [T.Text]
 stringPreamble cfg | stringTheory cfg
-  = [
-      format "(define-sort {} () String)" (Only string)
-    , format "(define-fun {} ((s {})) Int ({} s))"
-        (strLen :: Raw, string, z3strlen)
-    , format "(define-fun {} ((s {}) (i Int) (j Int)) {} ({} s i j))"
-        (strSubstr :: Raw, string, string, z3strsubstr)
-    , format "(define-fun {} ((x {}) (y {})) {} ({} x y))"
-        (strConcat :: Raw, string, string, string, z3strconcat)
+  = [ bSort string "String" 
+    , bFun strLen [("s", bb string)] "Int" (key (bb z3strlen) "s")
+    , bFun strSubstr [("s", bb string), ("i", "Int"), ("j", "Int")] (bb string) (key (bb z3strsubstr) "s i j")
+    , bFun strConcat [("x", bb string), ("y", "string")] (bb string) (key (bb z3strconcat) "x y")
     ]
+
 stringPreamble _
-  = [
-      format "(define-sort {} () Int)" (Only string)
-    , format "(declare-fun {} ({}) Int)"
-        (strLen :: Raw, string)
-    , format "(declare-fun {} ({} Int Int) {})"
-        (strSubstr :: Raw, string, string)
-    , format "(declare-fun {} ({} {}) {})"
-        (strConcat :: Raw, string, string, string)
+  = [ bSort string "Int"
+    , bFun' strLen ["String"] "Int" 
+    , bFun' strSubstr [bb string, "Int", "Int"] (bb string)
+    , bFun' strConcat [bb string, bb string] (bb string)
     ]
-
-
 
 --------------------------------------------------------------------------------
 -- | Exported API --------------------------------------------------------------
 --------------------------------------------------------------------------------
-smt2Symbol :: SymEnv -> Symbol -> Maybe Builder.Builder
-smt2Symbol env x = Builder.fromLazyText . tsRaw <$> symEnvTheory x env
+smt2Symbol :: SymEnv -> Symbol -> Maybe B.Builder
+smt2Symbol env x = B.fromLazyText . tsRaw <$> symEnvTheory x env
 
 instance SMTLIB2 SmtSort where
   smt2 _ = smt2SmtSort
 
-smt2SmtSort :: SmtSort -> Builder.Builder
+smt2SmtSort :: SmtSort -> B.Builder
 smt2SmtSort SInt         = "Int"
 smt2SmtSort SReal        = "Real"
 smt2SmtSort SBool        = "Bool"
-smt2SmtSort SString      = build "{}" (Only string)
-smt2SmtSort SSet         = build "{}" (Only set)
-smt2SmtSort SMap         = build "{}" (Only map)
-smt2SmtSort (SBitVec n)  = build "(_ BitVec {})" (Only n)
-smt2SmtSort (SVar n)     = build "T{}" (Only n)
+smt2SmtSort SString      = bb string
+smt2SmtSort SSet         = bb set
+smt2SmtSort SMap         = bb map
+smt2SmtSort (SBitVec n)  = key "_ BitVec" (fromShow n)
+smt2SmtSort (SVar n)     = "T" <> fromShow n
 smt2SmtSort (SData c []) = symbolBuilder c
-smt2SmtSort (SData c ts) = build "({} {})" (symbolBuilder c        , smt2SmtSorts ts)
+smt2SmtSort (SData c ts) = parenSeq1s [symbolBuilder c, smt2SmtSorts ts]
+
 -- smt2SmtSort (SApp ts)    = build "({} {})" (symbolBuilder tyAppName, smt2SmtSorts ts)
 
-smt2SmtSorts :: [SmtSort] -> Builder.Builder
+smt2SmtSorts :: [SmtSort] -> B.Builder
 smt2SmtSorts = buildMany . fmap smt2SmtSort
 
-type VarAs = SymEnv -> Symbol -> Sort -> Builder.Builder
+type VarAs = SymEnv -> Symbol -> Sort -> B.Builder
 --------------------------------------------------------------------------------
-smt2App :: VarAs -> SymEnv -> Expr -> [Builder.Builder] -> Maybe Builder.Builder
+smt2App :: VarAs -> SymEnv -> Expr -> [B.Builder] -> Maybe B.Builder
 --------------------------------------------------------------------------------
 smt2App _ _ (ECst (EVar f) _) [d]
-  | f == setEmpty = Just $ build "{}"             (Only emp)
-  | f == setEmp   = Just $ build "(= {} {})"      (emp, d)
-  | f == setSng   = Just $ build "({} {} {})"     (add, emp, d)
+  | f == setEmpty = Just (bb emp)
+  | f == setEmp   = Just (key2 "=" (bb emp) d)
+  | f == setSng   = Just (key2 (bb add) (bb emp) d)
 
 smt2App k env f (d:ds)
   | Just fb <- smt2AppArg k env f
-  = Just $ build "({} {})" (fb, d <> mconcat [ " " <> d | d <- ds])
+  = Just $ key fb (d <> mconcat [ " " <> d | d <- ds])
 
 smt2App _ _ _ _    = Nothing
 
-smt2AppArg :: VarAs -> SymEnv -> Expr -> Maybe Builder.Builder
+smt2AppArg :: VarAs -> SymEnv -> Expr -> Maybe B.Builder
 smt2AppArg k env (ECst (EVar f) t)
   | Just fThy <- symEnvTheory f env
   = Just $ if isPolyCtor fThy t
             then (k env f (ffuncOut t))
-            else (build "{}" (Only (tsRaw fThy)))
+            else bb (tsRaw fThy)
 
 smt2AppArg _ _ _
   = Nothing

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -4,22 +4,33 @@
 
 module Language.Fixpoint.Utils.Builder where
 
-import qualified Data.Text.Lazy.Builder as Builder
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy         as LT
 
-parens :: Builder.Builder -> Builder.Builder
+parens :: B.Builder -> B.Builder
 parens b = "(" <>  b <> ")"
 
-(<+>) :: Builder.Builder -> Builder.Builder -> Builder.Builder 
+(<+>) :: B.Builder -> B.Builder -> B.Builder 
 x <+> y = x <> " " <> y
 
-parenSeq1s :: [Builder.Builder] -> Builder.Builder
+parenSeq1s :: [B.Builder] -> B.Builder
 parenSeq1s = parens . seq1s
 
-key :: Builder.Builder -> Builder.Builder -> Builder.Builder
+key :: B.Builder -> B.Builder -> B.Builder
 key k b = parenSeq1s [k, b]
 
-seq1s :: [Builder.Builder] -> Builder.Builder
+key2 :: B.Builder -> B.Builder ->  B.Builder -> B.Builder
+key2 k b1 b2 = parenSeq1s [k, b1, b2]
+
+seq1s :: [B.Builder] -> B.Builder
 seq1s = foldr1 (<+>)
 
-fromShow :: (Show a) => a -> Builder.Builder
-fromShow = Builder.fromString . show
+fromShow :: (Show a) => a -> B.Builder
+fromShow = B.fromString . show
+
+bb :: LT.Text -> B.Builder
+bb = B.fromLazyText
+
+blt :: B.Builder -> LT.Text
+blt = B.toLazyText
+

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -13,17 +13,17 @@ parens b = "(" <>  b <> ")"
 (<+>) :: B.Builder -> B.Builder -> B.Builder 
 x <+> y = x <> " " <> y
 
-parenSeq1s :: [B.Builder] -> B.Builder
-parenSeq1s = parens . seq1s
+parenSeqs :: [B.Builder] -> B.Builder
+parenSeqs = parens . seqs
 
 key :: B.Builder -> B.Builder -> B.Builder
-key k b = parenSeq1s [k, b]
+key k b = parenSeqs [k, b]
 
 key2 :: B.Builder -> B.Builder ->  B.Builder -> B.Builder
-key2 k b1 b2 = parenSeq1s [k, b1, b2]
+key2 k b1 b2 = parenSeqs [k, b1, b2]
 
-seq1s :: [B.Builder] -> B.Builder
-seq1s = foldr1 (<+>)
+seqs :: [B.Builder] -> B.Builder
+seqs = foldr (<+>) mempty
 
 fromShow :: (Show a) => a -> B.Builder
 fromShow = B.fromString . show

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings    #-}
+
+-- | Wrapper around `Data.Text.Builder` that exports some useful combinators
+
+module Language.Fixpoint.Utils.Builder where
+
+import qualified Data.Text.Lazy.Builder as Builder
+
+parens :: Builder.Builder -> Builder.Builder
+parens b = "(" <>  b <> ")"
+
+(<+>) :: Builder.Builder -> Builder.Builder -> Builder.Builder 
+x <+> y = x <> " " <> y
+
+parenSeq1s :: [Builder.Builder] -> Builder.Builder
+parenSeq1s = parens . seq1s
+
+key :: Builder.Builder -> Builder.Builder -> Builder.Builder
+key k b = parenSeq1s [k, b]
+
+seq1s :: [Builder.Builder] -> Builder.Builder
+seq1s = foldr1 (<+>)
+
+fromShow :: (Show a) => a -> Builder.Builder
+fromShow = Builder.fromString . show

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -6,6 +6,8 @@ module Language.Fixpoint.Utils.Builder where
 
 import qualified Data.Text.Lazy.Builder as B
 import qualified Data.Text.Lazy         as LT
+import qualified Data.Text              as T
+import qualified Data.List              as L
 
 parens :: B.Builder -> B.Builder
 parens b = "(" <>  b <> ")"
@@ -23,13 +25,16 @@ key2 :: B.Builder -> B.Builder ->  B.Builder -> B.Builder
 key2 k b1 b2 = parenSeqs [k, b1, b2]
 
 seqs :: [B.Builder] -> B.Builder
-seqs = foldr (<+>) mempty
+seqs = foldr (<>) mempty . L.intersperse " "
 
-fromShow :: (Show a) => a -> B.Builder
-fromShow = B.fromString . show
+bShow :: (Show a) => a -> B.Builder
+bShow = B.fromString . show
 
 bb :: LT.Text -> B.Builder
 bb = B.fromLazyText
+
+lbb :: T.Text -> B.Builder
+lbb = bb . LT.fromStrict
 
 blt :: B.Builder -> LT.Text
 blt = B.toLazyText

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -8,6 +8,7 @@ import qualified Data.Text.Lazy.Builder as B
 import qualified Data.Text.Lazy         as LT
 import qualified Data.Text              as T
 import qualified Data.List              as L
+import qualified Numeric 
 
 parens :: B.Builder -> B.Builder
 parens b = "(" <>  b <> ")"
@@ -29,6 +30,9 @@ seqs = foldr (<>) mempty . L.intersperse " "
 
 bShow :: (Show a) => a -> B.Builder
 bShow = B.fromString . show
+
+bFloat :: RealFloat a => a -> B.Builder
+bFloat d = B.fromString (Numeric.showFFloat Nothing d "") 
 
 bb :: LT.Text -> B.Builder
 bb = B.fromLazyText

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,5 +20,4 @@ extra-deps:
 - fgl-visualize-0.1.0.1
 - intern-0.9.2
 - located-base-0.1.1.1
-- text-format-0.3.2
 - tasty-rerun-1.1.14

--- a/tests/pos/float.fq
+++ b/tests/pos/float.fq
@@ -2,10 +2,10 @@
 
 bind 50 x : {v1 : real | [(v1 = 0.2)]}
 bind 56 y : {v2 : real | [(v2 = 0.8 + x)]}
+bind 57 z : {v3 : real | [(v3 = 0.00014)]} 
 
 constraint:
-  env [50;
-       56]
+  env [50; 56; 57]
   lhs {VV#F3 : int | []}
   rhs {VV#F3 : int | [(y = 1.0)]}
   id 3 tag [1]


### PR DESCRIPTION
Because it depends on `double-conversion` which seems to cause problems on MacOS.

Matches https://github.com/ucsd-progsys/liquidhaskell/pull/1789
