### PR TITLE
Update Rewriting

### DIFF
--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -298,7 +298,7 @@ unifyAll freeVars (template:xs) (seen:ys) =
     let ys' = map (subst rs) ys
     (Su s2) <- unifyAll (freeVars L.\\ M.keys s1) xs' ys'
     return $ Su (M.union s1 s2)
-unifyAll _ _ _ = undefined
+unifyAll _ _ _ = Nothing
 
 unify :: [Symbol] -> Expr -> Expr -> Maybe Subst
 unify _ template seenExpr | template == seenExpr = Just (Su M.empty)


### PR DESCRIPTION
Some improvements to rewriting:

- Refinements of the form `t1 <=> t2` can now be turned into rewrite rules (previously only `t1 = t2` was accepted)
- For functions of the form `t1: a -> t2: b -> { r }`, we now generate the rewrite rule `r -> true` (this can be disabled with the flag `--only-rw-eqs`)
- We now support the (slightly strange) rewrite rule `(t1 == t2) -> true`. To accomplish this, `t1 == t2` is now considered a redex in PLE. Will this break anything?
- For conditional rewriting (i.e `{t1 : a | r1} -> {t2: b | r2} -> { r }`), when checking for a substitution, we check if there is any rewrites that can be used to satisfy the refinements r1 and r2. Previously the rewrite would only occur if r1 and r2 were already valid via SMT.

Related PR: https://github.com/ucsd-progsys/liquidhaskell/pull/1799