### PR TITLE
Only perform PLE on unsafe constraints

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -207,8 +207,7 @@ simplifyFInfo !cfg !fi0 = do
   loudDump 2 cfg si4
   let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
   loudDump 3 cfg si5
-  let si6  = if extensionality cfg then {-# SCC "expand"     #-} expand cfg si5 else si5
-  instantiate cfg $!! si6
+  return $ if extensionality cfg then {-# SCC "expand"     #-} expand cfg si5 else si5
 
 
 solveNative' !cfg !fi0 = do

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -48,6 +48,7 @@ import           Language.Fixpoint.Graph
 import           Language.Fixpoint.Parse            (rr')
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
+import           Language.Fixpoint.Solver.Instantiate (instantiate)
 import           Control.DeepSeq
 
 ---------------------------------------------------------------------------
@@ -206,7 +207,10 @@ simplifyFInfo !cfg !fi0 = do
   loudDump 2 cfg si4
   let si5  = {-# SCC "elaborate"  #-} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
   loudDump 3 cfg si5
-  return $ if extensionality cfg then {-# SCC "expand"     #-} expand cfg si5 else si5
+  let si6 = if extensionality cfg then {-# SCC "expand"     #-} expand cfg si5 else si5
+  if rewriteAxioms cfg && noLazyPLE cfg
+    then instantiate cfg si6 $!! Nothing
+    else return si6
 
 
 solveNative' !cfg !fi0 = do

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -48,7 +48,6 @@ import           Language.Fixpoint.Graph
 import           Language.Fixpoint.Parse            (rr')
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
-import           Language.Fixpoint.Solver.Instantiate (instantiate)
 import           Control.DeepSeq
 
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -25,6 +25,7 @@ module Language.Fixpoint.Solver.Monad
        , tickIter
        , stats
        , numIter
+       , SolverState(..)
        )
        where
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -58,9 +58,10 @@ traceE (e,e')
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE 
 --------------------------------------------------------------------------------
-instantiate :: (Loc a) => Config -> SInfo a -> [SubcId] -> IO (SInfo a)
+instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
 instantiate cfg fi' subcIds = do
-    let cs = [ (i, c) | (i, c) <- M.toList (cm fi), isPleCstr aEnv i c, i `L.elem` subcIds ]
+    let cs = [ (i, c) | (i, c) <- M.toList (cm fi), isPleCstr aEnv i c,
+               maybe True (i `L.elem`) subcIds ]
     let t  = mkCTrie cs                                               -- 1. BUILD the Trie
     res   <- withProgress (1 + length cs) $
                withCtx cfg file sEnv (pleTrie t . instEnv cfg fi cs)  -- 2. TRAVERSE Trie to compute InstRes

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -58,11 +58,11 @@ traceE (e,e')
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE 
 --------------------------------------------------------------------------------
-instantiate :: (Loc a) => Config -> SInfo a -> IO (SInfo a)
-instantiate cfg fi' = do 
-    let cs = [ (i, c) | (i, c) <- M.toList (cm fi), isPleCstr aEnv i c ] 
+instantiate :: (Loc a) => Config -> SInfo a -> [SubcId] -> IO (SInfo a)
+instantiate cfg fi' subcIds = do
+    let cs = [ (i, c) | (i, c) <- M.toList (cm fi), isPleCstr aEnv i c, i `L.elem` subcIds ]
     let t  = mkCTrie cs                                               -- 1. BUILD the Trie
-    res   <- withProgress (1 + length cs) $ 
+    res   <- withProgress (1 + length cs) $
                withCtx cfg file sEnv (pleTrie t . instEnv cfg fi cs)  -- 2. TRAVERSE Trie to compute InstRes
     return $ resSInfo cfg sEnv fi res                                 -- 3. STRENGTHEN SInfo using InstRes
   where

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -11,7 +11,7 @@
 module Language.Fixpoint.Solver.Solve (solve, solverInfo) where
 
 import           Control.Monad (when, filterM)
-import           Control.Monad.State.Strict (lift)
+import           Control.Monad.State.Strict (liftIO, modify, lift)
 import           Language.Fixpoint.Misc
 import qualified Language.Fixpoint.Misc            as Misc
 import qualified Language.Fixpoint.Types           as F
@@ -32,6 +32,9 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet        as S
 -- import qualified Data.Maybe          as Mb 
 import qualified Data.List           as L
+import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
+import qualified Language.Fixpoint.Types.Config as C
+import Language.Fixpoint.Solver.Instantiate (instantiate)
 
 --------------------------------------------------------------------------------
 solve :: (NFData a, F.Fixpoint a, Show a, F.Loc a) => Config -> F.SInfo a -> IO (F.Result (Integer, a))
@@ -76,6 +79,17 @@ solverInfo cfg fI
 siKvars :: F.SInfo a -> S.HashSet F.KVar
 siKvars = S.fromList . M.keys . F.ws
 
+
+doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM ()
+doPLE cfg fi0 subcIds = do
+  fi <- liftIO $ instantiate cfg fi0 subcIds
+  modify $ update' fi
+  where
+    update' fi ss = ss{ssBinds = F.bs fi'}
+      where
+        fi' = (siQuery sI) {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
+        sI  = solverInfo cfg fi
+
 --------------------------------------------------------------------------------
 solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
        => Config
@@ -87,10 +101,16 @@ solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
 --------------------------------------------------------------------------------
 solve_ cfg fi s0 ks wkl = do
   let s1   = {-# SCC "sol-init" #-} S.init cfg fi ks
-  let s2   = mappend s0 s1 
-  -- let s3   = solveEbinds fi s2 
-  s       <- {-# SCC "sol-refine" #-} refine s2 wkl
-  res     <- {-# SCC "sol-result" #-} result cfg wkl s
+  let s2   = mappend s0 s1
+  -- let s3   = solveEbinds fi s2
+  s3       <- {-# SCC "sol-refine" #-} refine s2 wkl
+  res0     <- {-# SCC "sol-result" #-} result cfg wkl s3
+  res      <- case resStatus res0 of
+    Unsafe _ bads | rewriteAxioms cfg -> do
+      doPLE cfg fi (map fst bads)
+      s4 <- {-# SCC "sol-refine" #-} refine s3 wkl
+      result cfg wkl s4
+    _ -> return res0
   st      <- stats
   let res' = {-# SCC "sol-tidy"   #-} tidyResult res
   return $!! (res', st)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -82,7 +82,7 @@ siKvars = S.fromList . M.keys . F.ws
 
 doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM ()
 doPLE cfg fi0 subcIds = do
-  fi <- liftIO $ instantiate cfg fi0 subcIds
+  fi <- liftIO $ instantiate cfg fi0 (Just subcIds)
   modify $ update' fi
   where
     update' fi ss = ss{ssBinds = F.bs fi'}
@@ -106,7 +106,7 @@ solve_ cfg fi s0 ks wkl = do
   s3       <- {-# SCC "sol-refine" #-} refine s2 wkl
   res0     <- {-# SCC "sol-result" #-} result cfg wkl s3
   res      <- case resStatus res0 of
-    Unsafe _ bads | rewriteAxioms cfg -> do
+    Unsafe _ bads | not (noLazyPLE cfg) && rewriteAxioms cfg -> do
       doPLE cfg fi (map fst bads)
       s4 <- {-# SCC "sol-refine" #-} refine s3 wkl
       result cfg wkl s4

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -95,6 +95,7 @@ data Config = Config
   , rwTerminationCheck  :: Bool
   , stdin               :: Bool        -- ^ Read input query from stdin  
   , json                :: Bool        -- ^ Render output in JSON format
+  , noLazyPLE           :: Bool
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -187,6 +188,7 @@ defConfig = Config {
   , rwTerminationCheck       = False   &= help "Disable rewrite divergence checker"
   , stdin                    = False   &= help "Read input query from stdin"
   , json                     = False   &= help "Render result in JSON"
+  , noLazyPLE                = False   &= help "Don't use lazy PLE"
   }
   &= verbosity
   &= program "fixpoint"


### PR DESCRIPTION
"Lazy PLE" changes LH to use the following behavior:

1. First check all constraints without PLE
2. Run PLE on any unsafe constraints, then recheck them

This can result in a speedup if constraints are already safe without PLE.