### PR TITLE
flatten and dedupe PAnd exprs

### DIFF
--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -102,7 +102,7 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
-import           Data.List                 (foldl', partition)
+import           Data.List                 (foldl', partition, nub)
 import           Data.String
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
@@ -726,7 +726,13 @@ isSingletonExpr v (PIff e1 e2)
 isSingletonExpr _ _        = Nothing
 
 pAnd, pOr     :: ListNE Pred -> Pred
-pAnd          = simplify . PAnd
+pAnd          = simplify . PAnd . nub . flatten
+  where
+    flatten ps = foldl' go [] ps
+  
+    go acc (PAnd ps) = flatten ps ++ acc
+    go acc p         = p : acc
+  
 pOr           = simplify . POr
 
 (&.&) :: Pred -> Pred -> Pred

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -728,7 +728,7 @@ isSingletonExpr _ _        = Nothing
 pAnd, pOr     :: ListNE Pred -> Pred
 pAnd          = simplify . PAnd . nub . flatten
   where
-    flatten ps = foldl' go [] ps
+    flatten ps = foldl' go [] $ reverse ps
   
     go acc (PAnd ps) = flatten ps ++ acc
     go acc p         = p : acc


### PR DESCRIPTION
In the BindEnvs used by the Solver, the refinement types can contain repetitions of the same conjuncts, which significantly increases the size of the larger Exprs and the resulting queries and SMT instances. This will speed up the solver.

This changes the pAnd smart constructor to flatten nested PAnd lists into a single level and then deduplicate.