### PR TITLE
Fix small glitch in 'stringPreamble'

### DIFF
--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -263,7 +263,7 @@ stringPreamble cfg | stringTheory cfg
   = [ bSort string "String" 
     , bFun strLen [("s", bb string)] "Int" (key (bb z3strlen) "s")
     , bFun strSubstr [("s", bb string), ("i", "Int"), ("j", "Int")] (bb string) (key (bb z3strsubstr) "s i j")
-    , bFun strConcat [("x", bb string), ("y", "string")] (bb string) (key (bb z3strconcat) "x y")
+    , bFun strConcat [("x", bb string), ("y", bb string)] (bb string) (key (bb z3strconcat) "x y")
     ]
 
 stringPreamble _


### PR DESCRIPTION
Otherwise when `stringPreamble` is on, Z3 responds always:

```
invalid sorted variables: unknown sort 'string'
```