### PR TITLE
Human readable dumps of formulas

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -65,11 +65,13 @@ library
                     Language.Fixpoint.Smt.Types
                     Language.Fixpoint.Solver
                     Language.Fixpoint.Solver.Eliminate
+                    Language.Fixpoint.Solver.EnvironmentReduction
                     Language.Fixpoint.Solver.GradualSolution
                     Language.Fixpoint.Solver.Instantiate
                     Language.Fixpoint.Solver.PLE
                     Language.Fixpoint.Solver.Monad
                     Language.Fixpoint.Solver.Rewrite
+                    Language.Fixpoint.Solver.Prettify
                     Language.Fixpoint.Solver.Sanitize
                     Language.Fixpoint.Solver.Solution
                     Language.Fixpoint.Solver.Solve
@@ -104,7 +106,8 @@ library
                     Language.Fixpoint.Utils.Statistics
                     Language.Fixpoint.Utils.Trie
                     Text.PrettyPrint.HughesPJ.Compat
-  other-modules:    Paths_liquid_fixpoint
+  other-modules:    Data.ShareMap
+                    Paths_liquid_fixpoint
   hs-source-dirs:   src
   build-depends:    base                 >= 4.9.1.0 && < 5
                   , ansi-terminal

--- a/src/Data/ShareMap.hs
+++ b/src/Data/ShareMap.hs
@@ -1,0 +1,151 @@
+module Data.ShareMap
+  ( ShareMap
+  , empty
+  , toHashMap
+  , insertWith
+  , map
+  , mergeKeysWith
+  ) where
+
+import           Data.Hashable (Hashable)
+import           Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import           Data.Maybe (fromMaybe)
+import           Prelude hiding (map)
+
+-- | A HashMap that can share the values of some entries
+--
+-- If two keys @k1@ and @k2@ are mapped to single @v@, updating
+-- the entry for @k1@ also updates the entry for @k2@ and viceversa.
+--
+-- The user of the map is responsible for indicating which keys are
+-- going to share their values.
+--
+-- Keys can be updated with 'shareMapInsertWith' and 'mergeKeysWith'.
+data ShareMap k v = ShareMap
+  { -- | @(k, v)@ pairs in the map.
+    --
+    -- Contains at least an entry for each key in the values of
+    -- of 'shareMap'.
+    unsharedMap :: HashMap k v
+  , -- | If @k1@ is mapped to @k2@, then both keys are considered
+    -- associated to the value of @k2@ in 'unsharedMap'.
+    --
+    -- Contains an entry for each key in the 'ShareMap'.
+    shareMap :: ReversibleMap k k
+  }
+  deriving Show
+
+empty :: ShareMap k v
+empty = ShareMap HashMap.empty emptyReversibleMap
+
+toHashMap :: (Hashable k, Eq k) => ShareMap k v -> HashMap k v
+toHashMap sm =
+  HashMap.foldlWithKey' expand HashMap.empty (directMap $ shareMap sm)
+  where
+    expand m k k' =
+      maybe m (\v -> HashMap.insert k v m) (HashMap.lookup k' $ unsharedMap sm)
+
+-- | @insertWith f k v m@ is the map @m@ plus key @k@ being associated to
+-- value @v@.
+--
+-- If @k@ is present in @m@, then @k@ and any other key sharing its value
+-- will be associated to @f v (m ! k)@.
+--
+insertWith
+  :: (Hashable k, Eq k)
+  => (v -> v -> v)
+  -> k
+  -> v
+  -> ShareMap k v
+  -> ShareMap k v
+insertWith f k v sm =
+  case HashMap.lookup k $ directMap $ shareMap sm of
+    Just k' -> sm
+      { unsharedMap = HashMap.insertWith f k' v (unsharedMap sm)
+      }
+    Nothing -> ShareMap
+      { unsharedMap = HashMap.insertWith f k v (unsharedMap sm)
+      , shareMap = insertReversibleMap k k (shareMap sm)
+      }
+
+-- | @mergeKeysWith f k0 k1 m@ updates the @k0@ value to @f (m ! k0) (m ! k1)@
+-- and @k1@ shares the value with @k0@.
+--
+-- If @k0@ and @k1@ are already sharing their values in @m@, or both keys are
+-- missing, this operation returns @m@ unmodified.
+--
+-- If only one of the keys is present, the other key is associated with the
+-- existing value.
+mergeKeysWith
+  :: (Hashable k, Eq k)
+  => (v -> v -> v)
+  -> k
+  -> k
+  -> ShareMap k v
+  -> ShareMap k v
+mergeKeysWith f k0 k1 sm | k0 /= k1 =
+  case lookupReversibleMap k1 (shareMap sm) of
+    Just k1' | k0 /= k1' -> case HashMap.lookup k1' (unsharedMap sm) of
+      Just v1 -> case lookupReversibleMap k0 (shareMap sm) of
+        Just k0' | k0' /= k1' ->
+          ShareMap
+            { unsharedMap = HashMap.insertWith (flip f) k0' v1 (unsharedMap sm)
+            , shareMap = -- Any values pointing to k1 are redirected to k0':
+                HashSet.foldl' (\m k -> insertReversibleMap k k0' m) (shareMap sm) $
+                reverseLookup k1 $ shareMap sm
+            }
+        Nothing ->
+          sm { shareMap = insertReversibleMap k0 k1' (shareMap sm) }
+        _ ->
+          sm
+      Nothing -> error "mergeKeysWith: broken invariant: unexpected missing key in unsharedMap"
+    Nothing ->
+      case HashMap.lookup k0 (directMap $ shareMap sm) of
+        Just k0' ->
+          sm { shareMap = insertReversibleMap k1 k0' (shareMap sm) }
+        Nothing ->
+          sm
+    _ ->
+      sm
+mergeKeysWith _ _ _ sm = sm
+
+map :: (a -> b) -> ShareMap k a -> ShareMap k b
+map f sm = sm { unsharedMap = HashMap.map f (unsharedMap sm) }
+
+-- | A map with an efficient 'reverseLookup'
+data ReversibleMap k v = ReversibleMap
+  { directMap :: HashMap k v
+  , -- |
+    -- > forall (v, ks) in reversedMap.
+    -- >   forall k in ks.
+    -- >     (k, v) is in directMap
+    reversedMap :: HashMap v (HashSet k)
+  }
+  deriving Show
+
+emptyReversibleMap :: ReversibleMap k v
+emptyReversibleMap = ReversibleMap HashMap.empty HashMap.empty
+
+insertReversibleMap
+  :: (Hashable k, Eq k, Hashable v, Eq v)
+  => k
+  -> v
+  -> ReversibleMap k v
+  -> ReversibleMap k v
+insertReversibleMap k v rm = ReversibleMap
+  { directMap = HashMap.insert k v (directMap rm)
+  , reversedMap =
+      let m' = case HashMap.lookup k (directMap rm) of
+            Nothing -> reversedMap rm
+            Just oldv -> HashMap.adjust (HashSet.delete k) oldv (reversedMap rm)
+       in HashMap.insertWith HashSet.union v (HashSet.singleton k) m'
+  }
+
+reverseLookup :: (Hashable v, Eq v) => v -> ReversibleMap k v -> HashSet k
+reverseLookup v rm = fromMaybe HashSet.empty $ HashMap.lookup v (reversedMap rm)
+
+lookupReversibleMap :: (Hashable k, Eq k) => k -> ReversibleMap k v -> Maybe v
+lookupReversibleMap k rm = HashMap.lookup k (directMap rm)

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -1,0 +1,724 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Functions to make environments smaller
+module Language.Fixpoint.Solver.EnvironmentReduction
+  ( reduceEnvironments
+  , simplifyBindings
+  , dropLikelyIrrelevantBindings
+  , axiomEnvSymbols
+  , inlineInSortedReft
+  , mergeDuplicatedBindings
+  , simplifyBooleanRefts
+  , undoANF
+  ) where
+
+import           Control.Monad (guard, mplus, msum)
+import           Data.Hashable (Hashable)
+import           Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.HashMap.Strict as HashMap.Strict
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import           Data.List (foldl', nub, partition)
+import           Data.Maybe (fromMaybe)
+import           Data.ShareMap (ShareMap)
+import qualified Data.ShareMap as ShareMap
+import           Language.Fixpoint.Types.Constraints
+import           Language.Fixpoint.Types.Environments
+  ( BindEnv
+  , BindId
+  , IBindEnv
+  , beBinds
+  , diffIBindEnv
+  , elemsIBindEnv
+  , emptyIBindEnv
+  , filterIBindEnv
+  , fromListIBindEnv
+  , insertsIBindEnv
+  , insertBindEnv
+  , lookupBindEnv
+  , memberIBindEnv
+  , unionIBindEnv
+  , unionsIBindEnv
+  )
+import           Language.Fixpoint.Types.Names (Symbol, anfPrefix, isPrefixOfSym)
+import           Language.Fixpoint.Types.PrettyPrint
+import           Language.Fixpoint.Types.Refinements
+  ( Brel(..)
+  , Expr(..)
+  , KVar(..)
+  , SortedReft(..)
+  , Subst(..)
+  , pattern PTrue
+  , pattern PFalse
+  , conjuncts
+  , expr
+  , exprKVars
+  , exprSymbolsSet
+  , mapPredReft
+  , onEverySubexpr
+  , pAnd
+  , reft
+  , reftBind
+  , reftPred
+  , sortedReftSymbols
+  , subst1
+  )
+import           Language.Fixpoint.Types.Sorts (boolSort, sortSymbols)
+
+-- | Strips from all the constraint environments the bindings that are
+-- irrelevant for their respective constraints.
+--
+-- Environment reduction has the following stages.
+--
+-- Stage 1)
+-- Compute the binding dependencies of each constraint ignoring KVars.
+--
+-- A binding is a dependency of a constraint if it is mentioned in the lhs, or
+-- the rhs of the constraint, or in a binding that is a dependency, or in a
+-- @define@ or @match@ clause that is mentioned in the lhs or rhs or another
+-- binding dependency, or if it appears in the environment of the constraint and
+-- can't be discarded as trivial (see 'dropIrrelevantBindings').
+--
+-- Stage 2)
+-- Compute the binding dependencies of KVars.
+--
+-- A binding is a dependency of a KVar K1 if it is a dependency of a constraint
+-- in which the K1 appears, or if it is a dependency of another KVar appearing
+-- in a constraint in which K1 appears.
+--
+-- Stage 3)
+-- Drop from the environment of each constraint the bindings that aren't
+-- dependencies of the constraint, or that aren't dependencies of any KVar
+-- appearing in the constraint.
+--
+--
+-- Note on SInfo:
+--
+-- This function can be changed to work on 'SInfo' rather than 'FInfo'. However,
+-- this causes some tests to fail. At least:
+--
+--    liquid-fixpoint/tests/proof/rewrite.fq
+--    tests/import/client/ReflectClient4a.hs
+--
+-- lhs bindings are numbered with the highest numbers when FInfo
+-- is converted to SInfo. Environment reduction, however, rehashes
+-- the binding identifiers and lhss could end up with a lower numbering.
+-- For most of the tests, this doesn't seem to make a difference, but it
+-- causes the two tests referred above to fail.
+--
+-- See #473 for more discussion.
+--
+reduceEnvironments :: FInfo a -> FInfo a
+reduceEnvironments fi =
+  let constraints = HashMap.Strict.toList $ cm fi
+      aenvMap = axiomEnvSymbols (ae fi)
+      reducedEnvs = map (reduceConstraintEnvironment (bs fi) aenvMap) constraints
+      (cm', ws') = reduceWFConstraintEnvironments (bs fi) (reducedEnvs, ws fi)
+      bs' = (bs fi) { beBinds = dropBindsMissingFrom (beBinds $ bs fi) cm' ws' }
+
+   in fi
+     { bs = bs'
+     , cm = HashMap.fromList cm'
+     , ws = ws'
+     , ebinds = updateEbinds bs' (ebinds fi)
+     , bindInfo = updateBindInfoKeys bs' $ bindInfo fi
+     }
+
+  where
+    dropBindsMissingFrom
+      :: HashMap BindId (Symbol, SortedReft)
+      -> [(SubcId, SubC a)]
+      -> HashMap KVar (WfC a)
+      -> HashMap BindId (Symbol, SortedReft)
+    dropBindsMissingFrom be cs ws =
+      let ibindEnv = unionsIBindEnv $
+            map (senv . snd) cs ++
+            map wenv (HashMap.elems ws)
+       in
+          HashMap.filterWithKey (\bId _ -> memberIBindEnv bId ibindEnv) be
+
+    -- Updates BindIds in an ebinds list
+    updateEbinds be = filter (`HashMap.member` beBinds be)
+
+    -- Updates BindId keys in a bindInfos map
+    updateBindInfoKeys be oldBindInfos =
+      HashMap.intersection oldBindInfos (beBinds be)
+
+-- | Reduces the environments of WF constraints.
+--
+-- @reduceWFConstraintEnvironments bindEnv (cs, ws)@
+--  * enlarges the environments in cs with bindings needed by the kvars they use
+--  * replaces the environment in ws with reduced environments
+--
+-- Reduction of wf environments gets rid of any bindings not mentioned by
+-- 'relatedKVarBinds' or any substitution on the corresponding KVar anywhere.
+--
+reduceWFConstraintEnvironments
+  :: BindEnv    -- ^ Environment before reduction
+  -> ([ReducedConstraint a], HashMap KVar (WfC a))
+     -- ^ @(cs, ws)@:
+     --  * @cs@ are the constraints with reduced environments
+     --  * @ws@ are the wf constraints in which to reduce environments
+  -> ([(SubcId, SubC a)], HashMap KVar (WfC a))
+reduceWFConstraintEnvironments bindEnv (cs, wfs) =
+  let
+      (kvarsBinds, kvarSubstSymbols, kvarsBySubC) = relatedKVarBinds bindEnv cs
+
+      wfBindsPlusSortSymbols =
+        HashMap.unionWith HashSet.union kvarsBinds $
+        HashMap.map (sortSymbols . (\(_, b, _) -> b) . wrft) wfs
+
+      kvarsRelevantBinds =
+        HashMap.unionWith HashSet.union wfBindsPlusSortSymbols $
+        kvarSubstSymbols
+
+      ws' =
+        HashMap.mapWithKey
+          (reduceWFConstraintEnvironment bindEnv kvarsRelevantBinds)
+          wfs
+
+      wsSymbols = HashMap.map (asSymbolSet bindEnv . wenv) ws'
+
+      kvarsWsBinds =
+        HashMap.unionWith HashSet.intersection wfBindsPlusSortSymbols wsSymbols
+
+      cs' = zipWith
+              (updateSubcEnvsWithKVarBinds bindEnv kvarsWsBinds)
+              kvarsBySubC
+              cs
+   in
+      (cs', ws')
+
+  where
+    -- Initially, the constraint environment only includes the information
+    -- relevant to the rhs and the lhs. If a kvar is present, it may need
+    -- additional bindings that are required by the kvar. These are added
+    -- in this function.
+    updateSubcEnvsWithKVarBinds
+      :: BindEnv
+      -> HashMap KVar (HashSet Symbol)
+      -> [KVar]
+      -> ReducedConstraint a
+      -> (SubcId, SubC a)
+    updateSubcEnvsWithKVarBinds be kvarsBinds kvs c =
+      let updateIBindEnv oldEnv =
+            unionIBindEnv (reducedEnv c) $
+            fromListIBindEnv
+              [ bId
+              | kv <- kvs
+              , Just kbindSyms <- [HashMap.lookup kv kvarsBinds]
+              , bId <- elemsIBindEnv oldEnv
+              , let (s, _) = lookupBindEnv bId be
+              , HashSet.member s kbindSyms
+              ]
+       in (constraintId c, updateSEnv (originalConstraint c) updateIBindEnv)
+
+    -- @reduceWFConstraintEnvironment be kbinds k c@ drops bindings from @c@
+    -- that aren't present in @kbinds ! k@.
+    reduceWFConstraintEnvironment
+      :: BindEnv
+      -> HashMap KVar (HashSet Symbol)
+      -> KVar
+      -> WfC a
+      -> WfC a
+    reduceWFConstraintEnvironment bindEnv kvarBinds k c =
+      case HashMap.lookup k kvarBinds of
+        Nothing -> c { wenv = emptyIBindEnv }
+        Just kbindSymbols ->
+          c { wenv = filterIBindEnv (relevantBindIds kbindSymbols) (wenv c) }
+      where
+        relevantBindIds :: HashSet Symbol -> BindId -> Bool
+        relevantBindIds kbindSymbols bId =
+          let (s, _) = lookupBindEnv bId bindEnv
+           in HashSet.member s kbindSymbols
+
+data ReducedConstraint a = ReducedConstraint
+  { reducedEnv :: IBindEnv       -- ^ Environment which has been reduced
+  , originalConstraint :: SubC a -- ^ The original constraint
+  , constraintId :: SubcId       -- ^ Id of the constraint
+  }
+
+reduceConstraintEnvironment
+  :: BindEnv
+  -> HashMap Symbol (HashSet Symbol)
+  -> (SubcId, SubC a)
+  -> ReducedConstraint a
+reduceConstraintEnvironment bindEnv aenvMap (cid, c) =
+  let env = [ (s, bId, sr)
+            | bId <- elemsIBindEnv $ senv c
+            , let (s, sr) = lookupBindEnv bId bindEnv
+            ]
+      prunedEnv =
+        fromListIBindEnv
+        [ bId | (_, bId, _) <- dropIrrelevantBindings aenvMap constraintSymbols env ]
+      constraintSymbols =
+        HashSet.union (sortedReftSymbols $ slhs c) (sortedReftSymbols $ srhs c)
+   in ReducedConstraint
+        { reducedEnv = prunedEnv
+        , originalConstraint = c
+        , constraintId = cid
+        }
+
+-- | @dropIrrelevantBindings aenvMap ss env@ drops bindings from @env@ which
+-- aren't referenced neither in a refinement type in the environment nor in
+-- @ss@, and not reachable in definitions of @aenv@ referred from @env@ or
+-- @ss@, and which can't possibly affect the outcome of verification.
+--
+-- Right now, it drops bindings of the form @a : {v | true }@ and
+-- @b : {v | v [>=|<=|=|!=|etc] e }@
+-- whenever @a@ and @b@ aren't referenced from any formulas.
+--
+dropIrrelevantBindings
+  :: HashMap Symbol (HashSet Symbol)
+  -> HashSet Symbol
+  -> [(Symbol, BindId, SortedReft)]
+  -> [(Symbol, BindId, SortedReft)]
+dropIrrelevantBindings aenvMap extraSymbols env =
+  filter relevantBind env
+  where
+    allSymbols =
+      reachableSymbols (HashSet.union extraSymbols envSymbols) aenvMap
+    envSymbols =
+      HashSet.unions $ map (\(_, _, sr) -> sortedReftSymbols sr) env
+
+    relevantBind (s, _, sr)
+      | HashSet.member s allSymbols = True
+      | otherwise = case reftPred (sr_reft sr) of
+          PTrue -> False
+          PAtom _ (dropECst -> EVar sym) _e -> sym /= reftBind (sr_reft sr)
+          PAtom _ _e (dropECst -> EVar sym) -> sym /= reftBind (sr_reft sr)
+          _ -> True
+
+-- | For each Equation and Rewrite, collects the symbols that it needs.
+axiomEnvSymbols :: AxiomEnv -> HashMap Symbol (HashSet Symbol)
+axiomEnvSymbols ae =
+  HashMap.union
+    (HashMap.fromList $ map eqSymbols $ aenvEqs ae)
+    (HashMap.fromList $ map rewriteSymbols $ aenvSimpl ae)
+  where
+    eqSymbols eq =
+      let bodySymbols =
+            HashSet.difference
+              (exprSymbolsSet (eqBody eq) `HashSet.union` sortSymbols (eqSort eq))
+              (HashSet.fromList $ map fst $ eqArgs eq)
+          sortSyms = HashSet.unions $ map (sortSymbols . snd) $ eqArgs eq
+          allSymbols =
+            if eqRec eq then
+              HashSet.insert (eqName eq) (bodySymbols `HashSet.union` sortSyms)
+            else
+              bodySymbols `HashSet.union` sortSyms
+       in
+          (eqName eq, allSymbols)
+
+    rewriteSymbols rw =
+      let bodySymbols =
+            HashSet.difference
+              (exprSymbolsSet (smBody rw))
+              (HashSet.fromList $ smArgs rw)
+          rwSymbols = HashSet.insert (smDC rw) bodySymbols
+       in (smName rw, rwSymbols)
+
+unconsHashSet :: (Hashable a, Eq a) => HashSet a -> Maybe (a, HashSet a)
+unconsHashSet xs = case HashSet.toList xs of
+  [] -> Nothing
+  (x : _) -> Just (x, HashSet.delete x xs)
+
+setOf :: (Hashable k, Eq k) => HashMap k (HashSet a) -> k -> HashSet a
+setOf m x = fromMaybe HashSet.empty (HashMap.lookup x m)
+
+mapOf :: (Hashable k, Eq k) => HashMap k (HashMap a b) -> k -> HashMap a b
+mapOf m x = fromMaybe HashMap.empty (HashMap.lookup x m)
+
+-- @relatedKVarBinds binds cs@ yields:
+-- 1) the set of all bindings that might be needed by each KVar mentioned
+-- in the constraints @cs@, and
+-- 2) the set of symbols appearing in substitutions of the KVar in any
+-- constraint. That is: @kv@ is associated with @i@, @j@, and @h@ if there
+-- is some constraint with the KVar substitution @kv[i:=e0][j:=e1]@ and
+-- some constraint with the KVar substitution @kv[h:=e2]@ appearing in
+-- the rhs, lhs, or the environment.
+-- 3) The list of kvars used in each constraint.
+--
+-- We assume that if a KVar is mentioned in a constraint or in its
+-- environment, then all the bindings in the environment of the constraint
+-- might be needed by the KVar.
+--
+-- Moreover, if two KVars are mentioned together in the same constraint,
+-- then the bindings that might be needed for either of them might
+-- be needed by the other.
+--
+relatedKVarBinds
+  :: BindEnv
+  -> [ReducedConstraint a]
+  -> (HashMap KVar (HashSet Symbol), HashMap KVar (HashSet Symbol), [[KVar]])
+relatedKVarBinds bindEnv cs =
+  let kvarsSubstSymbolsBySubC = map kvarBindsFromSubC cs
+      kvarsBySubC = map HashMap.keys kvarsSubstSymbolsBySubC
+      bindIdsByKVar =
+       ShareMap.toHashMap $
+       ShareMap.map (asSymbolSet bindEnv) $
+       groupIBindEnvByKVar $ zip (map reducedEnv cs) kvarsBySubC
+      substsByKVar =
+        foldl' (HashMap.unionWith HashSet.union) HashMap.empty kvarsSubstSymbolsBySubC
+   in
+      (bindIdsByKVar, substsByKVar, kvarsBySubC)
+  where
+    kvarsByBindId :: HashMap BindId (HashMap KVar [Subst])
+    kvarsByBindId =
+      HashMap.map (exprKVars . reftPred . sr_reft . snd) $ beBinds bindEnv
+
+    -- Returns all of the KVars used in the constraint, together with
+    -- the symbols that appear in substitutions of those KVars.
+    kvarBindsFromSubC :: ReducedConstraint a -> HashMap KVar (HashSet Symbol)
+    kvarBindsFromSubC sc =
+      let c = originalConstraint sc
+          unSubst (Su su) = su
+          substsToHashSet =
+            HashSet.fromList . HashMap.keys . HashMap.unions . map unSubst
+       in foldl' (HashMap.unionWith HashSet.union) HashMap.empty $
+          map (HashMap.map substsToHashSet) $
+          (exprKVars (reftPred $ sr_reft $ srhs c) :) $
+          (exprKVars (reftPred $ sr_reft $ slhs c) :) $
+          map (mapOf kvarsByBindId) $
+          elemsIBindEnv (reducedEnv sc)
+
+    -- @groupIBindEnvByKVar kvs@ is a map of KVars to all the bindings that
+    -- they can potentially use.
+    --
+    -- @kvars@ tells for each environment what KVars it uses.
+    groupIBindEnvByKVar :: [(IBindEnv, [KVar])] -> ShareMap KVar IBindEnv
+    groupIBindEnvByKVar = foldl' mergeBinds ShareMap.empty
+
+    -- @mergeBinds sm bs (bindIds, kvars)@ merges the binds used by all KVars in
+    -- @kvars@ and also adds to the result the bind Ids in @bindIds@.
+    mergeBinds
+      :: ShareMap KVar IBindEnv
+      -> (IBindEnv, [KVar])
+      -> ShareMap KVar IBindEnv
+    mergeBinds sm (bindIds, kvars) = case kvars of
+      [] -> sm
+      k : ks ->
+        let sm' = ShareMap.insertWith unionIBindEnv k bindIds sm
+         in foldr (ShareMap.mergeKeysWith unionIBindEnv k) sm' ks
+
+asSymbolSet :: BindEnv -> IBindEnv -> HashSet Symbol
+asSymbolSet be ibinds =
+  HashSet.fromList
+    [ s
+    | bId <- elemsIBindEnv ibinds
+    , let (s, _) = lookupBindEnv bId be
+    ]
+
+-- | @reachableSymbols x r@ computes the set of symbols reachable from @x@
+-- in the graph represented by @r@. Includes @x@ in the result.
+reachableSymbols :: HashSet Symbol -> HashMap Symbol (HashSet Symbol) -> HashSet Symbol
+reachableSymbols ss0 outgoingEdges = go HashSet.empty ss0
+  where
+    -- @go acc ss@ contains @acc@ and @ss@ plus any symbols reachable from @ss@
+    go :: HashSet Symbol -> HashSet Symbol -> HashSet Symbol
+    go acc ss = case unconsHashSet ss of
+      Nothing -> acc
+      Just (x, xs) ->
+        if x `HashSet.member` acc then go acc xs
+        else
+          let relatedToX = setOf outgoingEdges x
+           in go (HashSet.insert x acc) (HashSet.union relatedToX xs)
+
+-- | Simplifies bindings in constraint environments.
+--
+-- It runs 'mergeDuplicatedBindings' and 'simplifyBooleanRefts'
+-- on the environment of each constraint.
+simplifyBindings :: FInfo a -> FInfo a
+simplifyBindings fi =
+  let (bs', cm', oldToNew) = simplifyConstraints (bs fi) (cm fi)
+   in fi
+        { bs = bs'
+        , cm = cm'
+        , ebinds = updateEbinds oldToNew (ebinds fi)
+        , bindInfo = updateBindInfoKeys oldToNew $ bindInfo fi
+        }
+  where
+    updateEbinds :: HashMap BindId [BindId] -> [BindId] -> [BindId]
+    updateEbinds oldToNew ebs =
+      nub $
+      concat [ bId : fromMaybe [] (HashMap.lookup bId oldToNew) | bId <- ebs ]
+
+    updateBindInfoKeys
+      :: HashMap BindId [BindId] -> HashMap BindId a -> HashMap BindId a
+    updateBindInfoKeys oldToNew infoMap =
+      HashMap.fromList
+        [ (n, a)
+        | (bId, a) <- HashMap.toList infoMap
+        , Just news <- [HashMap.lookup bId oldToNew]
+        , n <- bId : news
+        ]
+
+    simplifyConstraints
+      :: BindEnv
+      -> HashMap SubcId (SubC a)
+      -> (BindEnv, HashMap SubcId (SubC a), HashMap BindId [BindId])
+    simplifyConstraints be cs =
+      let (be', cs', newToOld) =
+             HashMap.foldlWithKey' simplifyConstraintBindings (be, [], []) cs
+          oldToNew =
+            HashMap.fromListWith (++) $
+            concatMap (\(n, olds) -> map (\o -> (o, [n])) olds) newToOld
+       in
+          (be', HashMap.fromList cs', oldToNew)
+
+    simplifyConstraintBindings
+      :: (BindEnv, [(SubcId, SubC a)], [(BindId, [BindId])])
+      -> SubcId
+      -> SubC a
+      -> (BindEnv, [(SubcId, SubC a)], [(BindId, [BindId])])
+    simplifyConstraintBindings (bindEnv, cs, newToOld) cid c =
+      let env =
+            [ (s, ([bId], sr))
+            | bId <- elemsIBindEnv $ senv c
+            , let (s, sr) = lookupBindEnv bId bindEnv
+            ]
+          boolSimplEnv = simplifyBooleanRefts (mergeDuplicatedBindings env)
+
+          modifiedBinds = HashMap.toList boolSimplEnv
+
+          modifiedBindIds = map (fst . snd) modifiedBinds
+
+          unchangedBindIds = senv c `diffIBindEnv` fromListIBindEnv (concat modifiedBindIds)
+
+          (newBindIds, bindEnv') = insertBinds ([], bindEnv) modifiedBinds
+
+          newIBindEnv = insertsIBindEnv newBindIds unchangedBindIds
+
+          newToOld' = zip newBindIds modifiedBindIds ++ newToOld
+       in
+          (bindEnv', (cid, updateSEnv c (const newIBindEnv)) : cs, newToOld')
+
+    insertBinds = foldl' $ \(xs, be) (s, (_, sr)) ->
+      let (bId, be') = insertBindEnv s sr be
+       in (bId : xs, be')
+
+-- | If the environment contains duplicated bindings, they are
+-- combined with conjunctions.
+--
+-- This means that @[ a : {v | P v }, a : {z | Q z }, b : {v | S v} ]@
+-- is combined into @[ a : {v | P v && Q v }, b : {v | S v} ]@
+--
+-- If a symbol has two bindings with different sorts, none of the bindings
+-- for that symbol are merged.
+mergeDuplicatedBindings
+  :: Semigroup m
+  => [(Symbol, (m, SortedReft))]
+  -> HashMap Symbol (m, SortedReft)
+mergeDuplicatedBindings xs =
+    HashMap.mapMaybe dropNothings $
+    HashMap.fromListWith mergeSortedReft $
+    map (fmap (fmap Just)) xs
+  where
+    dropNothings (m, msr) = (,) m <$> msr
+
+    mergeSortedReft (bs0, msr0) (bs1, msr1) =
+      let msr = do
+            sr0 <- msr0
+            sr1 <- msr1
+            guard (sr_sort sr0 == sr_sort sr1)
+            Just sr0 { sr_reft = mergeRefts (sr_reft sr0) (sr_reft sr1) }
+       in
+          (bs0 <> bs1, msr)
+
+    mergeRefts r0 r1 =
+      reft
+        (reftBind r0)
+        (pAnd
+          [ reftPred r0
+          , subst1 (reftPred r1) (reftBind r1, expr (reftBind r0))
+          ]
+        )
+
+-- | Inlines some of the bindings introduced by ANF normalization
+-- at their use sites.
+--
+-- Only modified bindings are returned.
+--
+-- Only bindings with prefix lq_anf... might be inlined.
+--
+-- Doesn't inline bindings having more than @maxConjuncts@ conjuncts.
+undoANF :: Int -> HashMap Symbol (m, SortedReft) -> HashMap Symbol (m, SortedReft)
+undoANF maxConjuncts env =
+    -- Circular program here. This should terminate as long as the
+    -- bindings introduced by ANF don't form cycles.
+    let env' = HashMap.map (inlineInSortedReftChanged maxConjuncts env') env
+     in HashMap.mapMaybe dropUnchanged env'
+  where
+    dropUnchanged ((m, b), sr) = do
+      guard b
+      Just (m, sr)
+
+inlineInSortedReft
+  :: Int -> HashMap Symbol (m, SortedReft) -> SortedReft -> SortedReft
+inlineInSortedReft maxConjuncts env sr =
+  snd $ inlineInSortedReftChanged maxConjuncts env (error "never should evaluate", sr)
+
+-- | Inlines bindings in env in the given 'SortedReft'.
+-- Attaches a 'Bool' telling if the 'SortedReft' was changed.
+inlineInSortedReftChanged
+  :: Int
+  -> HashMap Symbol (a, SortedReft)
+  -> (m, SortedReft)
+  -> ((m, Bool), SortedReft)
+inlineInSortedReftChanged maxConjuncts env (m, sr) =
+  let e = reftPred (sr_reft sr)
+      e' = inlineInExpr maxConjuncts env e
+   in ((m, e /= e'), sr { sr_reft = mapPredReft (const e') (sr_reft sr) })
+
+-- | Inlines bindings preffixed with @lq_anf@ in the given expression
+-- if they appear in equalities.
+--
+-- Given a binding like @a : { v | v = e1 && e2 }@ and an expression @... e0 = a ...@,
+-- this function produces the expression @... (v = e1 && e2)[v:=e0] ...@
+-- if @v@ does not appear free in @e1@.
+--
+-- @... e0 = (a : s) ...@ is equally transformed to
+-- @... (v = (e1 : s) && e2)[v:=e0] ...@
+--
+-- Given a binding like @a : { v | v = e1 }@ and an expression @... a ...@,
+-- this function produces the expression @... e1 ...@ if @v@ does not
+-- appear free in @e1@.
+--
+-- The first parameter indicates the maximum amount of conjuncts that a
+-- binding is allowed to have. If the binding exceeds this threshold, it
+-- is not inlined.
+inlineInExpr :: Int -> HashMap Symbol (m, SortedReft) -> Expr -> Expr
+inlineInExpr maxConjuncts env = simplify . onEverySubexpr inlineExpr
+  where
+    inlineExpr (EVar sym)
+      | anfPrefix `isPrefixOfSym` sym
+      , Just (_, sr) <- HashMap.lookup sym env
+      , let r = sr_reft sr
+      , sortedReftConjuncts sr <= maxConjuncts
+      , Just e <- isSingletonE (reftBind r) (reftPred r)
+      = e
+    inlineExpr (PAtom Eq e0 (dropECst -> EVar sym))
+      | anfPrefix `isPrefixOfSym` sym
+      , Just (_, sr) <- HashMap.lookup sym env
+      , let r = sr_reft sr
+      , sortedReftConjuncts sr <= maxConjuncts
+      , Just _ <- isSingletonE (reftBind r) (reftPred r)
+      =
+        subst1 (reftPred r) (reftBind r, e0)
+    inlineExpr e = e
+
+    sortedReftConjuncts = length . conjuncts . reftPred . sr_reft
+
+    isSingletonE v (PAtom br e0 e1)
+      | isEq br = isSingEq v e0 e1 `mplus` isSingEq v e1 e0
+    isSingletonE v (PIff e0 e1) =
+      isSingEq v e0 e1 `mplus` isSingEq v e1 e0
+    isSingletonE v (PAnd cs) =
+      msum $ map (isSingletonE v) cs
+    isSingletonE _ _ =
+      Nothing
+
+    isSingEq v e0 e1 = do
+      guard $ EVar v == dropECst e0 && not (HashSet.member v $ exprSymbolsSet e1)
+      Just e1
+
+    isEq r = r == Eq || r == Ueq
+
+dropECst :: Expr -> Expr
+dropECst = \case
+  ECst e _t -> dropECst e
+  e -> e
+
+-- | Transforms bindings of the form @{v:bool | v && P v}@ into
+-- @{v:Bool | v && P true}@, and bindings of the form @{v:bool | ~v && P v}@
+-- into @{v:bool | ~v && P false}@.
+--
+-- Only yields the modified bindings.
+simplifyBooleanRefts
+  :: HashMap Symbol (m, SortedReft) -> HashMap Symbol (m, SortedReft)
+simplifyBooleanRefts = HashMap.mapMaybe simplifyBooleanSortedReft
+  where
+    simplifyBooleanSortedReft (m, sr)
+      | sr_sort sr == boolSort
+      , let r = sr_reft sr
+      , Just (e, rest) <- symbolUsedAtTopLevelAnd (reftBind r) (reftPred r)
+      = let e' = pAnd $ e : map (`subst1` (reftBind r, atomToBool e)) rest
+            atomToBool a = if a == EVar (reftBind r) then PTrue else PFalse
+         in Just (m, sr { sr_reft = mapPredReft (const e') r })
+    simplifyBooleanSortedReft _ = Nothing
+
+    symbolUsedAtTopLevelAnd s (PAnd ps) =
+      findExpr (EVar s) ps `mplus` findExpr (PNot (EVar s)) ps
+    symbolUsedAtTopLevelAnd _ _ = Nothing
+
+    findExpr e es = do
+      case partition (e ==) es of
+        ([], _) -> Nothing
+        (e:_, rest) -> Just (e, rest)
+
+-- | @dropLikelyIrrelevantBindings ss env@ is like @dropIrrelevantBindings@
+-- but drops bindings that could potentially be necessary to validate a
+-- constraint.
+--
+-- This function drops any bindings in the reachable set of symbols of @ss@.
+-- See 'relatedSymbols'.
+--
+-- A constraint might be rendered unverifiable if the verification depends on
+-- the environment being inconsistent. For instance, suppose the constraint
+-- is @a < 0@ and we call this function like
+--
+-- > dropLikelyIrrelevantBindings ["a"] [a : { v | v > 0 }, b : { v | false }]
+-- >   == [a : { v | v > 0 }]
+--
+-- The binding for @b@ is dropped since it is not otherwise related to @a@,
+-- making the corresponding constraint unverifiable.
+--
+dropLikelyIrrelevantBindings
+  :: HashMap Symbol (HashSet Symbol)
+  -> HashSet Symbol
+  -> HashMap Symbol SortedReft
+  -> HashMap Symbol SortedReft
+dropLikelyIrrelevantBindings aenvMap ss env = HashMap.filterWithKey reachable env
+  where
+    relatedSyms = reachableSymbols (relatedSymbols ss env) aenvMap
+
+    reachable s _sr = s `HashSet.member` relatedSyms
+
+-- | @relatedSymbols ss env@ is the set of all symbols used transitively
+-- by @ss@ in @env@ or used together with it in a refinement type.
+-- The output includes @ss@.
+--
+-- For instance, say @ss@ contains @a@, and the environment is
+--
+-- > a : { v | v > b }, b : int, c : { v | v >= b && b >= d}, d : int
+--
+-- @a@ uses @b@. Because the predicate of @c@ relates @b@ with @d@,
+-- @d@ can also influence the validity of the predicate of @a@, and therefore
+-- we include both @b@, @c@, and @d@ in the set of related symbols.
+relatedSymbols :: HashSet Symbol -> HashMap Symbol SortedReft -> HashSet Symbol
+relatedSymbols ss0 env = go HashSet.empty ss0
+  where
+    directlyUses = HashMap.map (exprSymbolsSet . reftPred . sr_reft) env
+    usedBy = HashMap.fromListWith HashSet.union
+               [ (x, HashSet.singleton s)
+               | (s, xs) <- HashMap.toList directlyUses
+               , x <- HashSet.toList xs
+               ]
+
+    -- @go acc ss@ contains @acc@ and @ss@ plus any symbols reachable from @ss@
+    go :: HashSet Symbol -> HashSet Symbol -> HashSet Symbol
+    go acc ss = case unconsHashSet ss of
+      Nothing -> acc
+      Just (x, xs) ->
+        if x `HashSet.member` acc then go acc xs
+        else
+          let usersOfX = usedBy `setOf` x
+              relatedToX = HashSet.unions $
+                usersOfX : map (directlyUses `setOf`) (x : HashSet.toList usersOfX)
+           in go (HashSet.insert x acc) (HashSet.union relatedToX xs)

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Functions to make environments easier to read
+module Language.Fixpoint.Solver.Prettify (savePrettifiedQuery) where
+
+import           Data.Bifunctor (first)
+import           Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import           Data.List (intersperse)
+import           Language.Fixpoint.Misc (ensurePath)
+import           Language.Fixpoint.Solver.EnvironmentReduction
+  ( dropLikelyIrrelevantBindings
+  , axiomEnvSymbols
+  , inlineInSortedReft
+  , mergeDuplicatedBindings
+  , simplifyBooleanRefts
+  , undoANF
+  )
+import           Language.Fixpoint.Types.Config (Config, queryFile)
+import           Language.Fixpoint.Types.Constraints
+import           Language.Fixpoint.Types.Environments
+  (BindEnv, elemsIBindEnv, lookupBindEnv)
+import           Language.Fixpoint.Types.Names (Symbol)
+import           Language.Fixpoint.Types.PrettyPrint
+import           Language.Fixpoint.Types.Refinements
+  (SortedReft(..), conjuncts, reftBind, reftPred, sortedReftSymbols)
+import           Language.Fixpoint.Types.Substitutions (exprSymbolsSet)
+import qualified Language.Fixpoint.Utils.Files as Files
+import           System.FilePath (addExtension)
+import           Text.PrettyPrint.HughesPJ.Compat
+  (Doc, braces, hang, nest, render, sep, text, vcat, (<+>), ($+$))
+
+
+savePrettifiedQuery :: Fixpoint a => Config -> FInfo a -> IO ()
+savePrettifiedQuery cfg fi = do
+  let fq   = queryFile Files.Fq cfg `addExtension` "prettified"
+  putStrLn $ "Saving prettified Query: "   ++ fq ++ "\n"
+  ensurePath fq
+  writeFile fq $ render (prettyConstraints fi)
+
+prettyConstraints :: Fixpoint a => FInfo a -> Doc
+prettyConstraints fi =
+  vcat $ map (prettyConstraint aenvMap (bs fi)) $ HashMap.elems (cm fi)
+  where
+    aenvMap = axiomEnvSymbols (ae fi)
+
+prettyConstraint
+  :: Fixpoint a
+  => HashMap Symbol (HashSet Symbol)
+  -> BindEnv
+  -> SubC a
+  -> Doc
+prettyConstraint aenv bindEnv c =
+  let env = [ (s, ([bId], sr))
+            | bId <- elemsIBindEnv $ senv c
+            , let (s, sr) = lookupBindEnv bId bindEnv
+            ]
+      mergedEnv = mergeDuplicatedBindings env
+      undoANFEnv = HashMap.union (undoANF 5 mergedEnv) mergedEnv
+      boolSimplEnv = HashMap.union (simplifyBooleanRefts undoANFEnv) undoANFEnv
+
+      simplifiedLhs = inlineInSortedReft 100 boolSimplEnv (slhs c)
+      simplifiedRhs = inlineInSortedReft 100 boolSimplEnv (srhs c)
+      prunedPrettyEnv =
+        eraseUnusedBindings constraintSymbols $
+        dropLikelyIrrelevantBindings aenv constraintSymbols $
+        HashMap.map snd boolSimplEnv
+      constraintSymbols =
+        HashSet.union (sortedReftSymbols simplifiedLhs) (sortedReftSymbols simplifiedRhs)
+   in hang (text "\n\nconstraint:") 2 $
+          text "lhs" <+> toFix simplifiedLhs
+      $+$ text "rhs" <+> toFix simplifiedRhs
+      $+$ (pprId (sid c) <+> text "tag" <+> toFix (stag c))
+      $+$ toFixMeta (text "simpleConstraint" <+> pprId (sid c)) (toFix (sinfo c))
+      $+$ hang (text "environment:") 2
+            (vcat $ intersperse "" $ elidedMessage : map prettyBind prunedPrettyEnv)
+  where
+    prettyBind (ms, sr) = sep [maybe "_" toFix ms <+> ":", nest 2 $ prettySortedRef sr]
+    prettySortedRef sr = braces $ sep
+      [ toFix (reftBind (sr_reft sr)) <+> ":" <+> toFix (sr_sort sr) <+> "|"
+      , nest 2 $ toFix $ conjuncts $ reftPred $ sr_reft sr
+      ]
+
+    elidedMessage = "// elided some likely irrelevant bindings"
+
+pprId :: Show a => Maybe a -> Doc
+pprId (Just i)  = "id" <+> text (show i)
+pprId _         = ""
+
+toFixMeta :: Doc -> Doc -> Doc
+toFixMeta k v = text "// META" <+> k <+> text ":" <+> v
+
+-- | @eraseUnusedBindings ss env@ erases symbols that aren't refered from @ss@
+-- or refinement types in the environment.
+--
+-- Erasure is accomplished by replacing the symbol with @Nothing@ in the
+-- bindings.
+eraseUnusedBindings
+  :: HashSet Symbol -> HashMap Symbol SortedReft -> [(Maybe Symbol, SortedReft)]
+eraseUnusedBindings ss env = map (first reachable) $ HashMap.toList env
+  where
+    allSymbols = HashSet.union ss envSymbols
+    envSymbols =
+      HashSet.unions $
+      map (exprSymbolsSet . reftPred . sr_reft) $
+      HashMap.elems env
+
+    reachable s =
+      if s `HashSet.member` allSymbols then
+        Just s
+      else
+        Nothing

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -89,6 +89,7 @@ data Config = Config
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
+  , noEnvironmentReduction :: Bool     -- ^ Don't use environment reduction
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints 
   , extensionality   :: Bool           -- ^ Enable extensional interpretation of function equality
   , maxRWOrderingConstraints :: Maybe Int
@@ -183,6 +184,10 @@ defConfig = Config {
   , rewriteAxioms            = False &= help "allow axiom instantiation via rewriting"
   , oldPLE                   = False &= help "Use old version of PLE"
   , noIncrPle                = False &= help "Don't use incremental PLE"
+  , noEnvironmentReduction   =
+      False
+        &= name "no-environment-reduction"
+        &= help "Don't perform environment reduction"
   , checkCstr                = []    &= help "Only check these specific constraint-ids" 
   , extensionality           = False &= help "Allow extensional interpretation of extensionality"
   , maxRWOrderingConstraints = Nothing &= help "Maximum number of functions to consider in rewrite orderings"

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -33,7 +33,7 @@ module Language.Fixpoint.Types.Constraints (
   -- * Constraints
   , WfC (..), isGWfc, updateWfCExpr
   , SubC, SubcId
-  , mkSubC, subcId, sid, senv, slhs, srhs, stag, subC, wfC
+  , mkSubC, subcId, sid, senv, updateSEnv, slhs, srhs, stag, subC, wfC
   , SimpC (..)
   , Tag
   , TaggedC, clhs, crhs
@@ -226,6 +226,7 @@ strengthenSortedReft (RR s (Reft (v, r))) e = RR s (Reft (v, pAnd [r, e]))
 
 class TaggedC c a where
   senv  :: c a -> IBindEnv
+  updateSEnv  :: c a -> (IBindEnv -> IBindEnv) -> c a
   sid   :: c a -> Maybe Integer
   stag  :: c a -> Tag
   sinfo :: c a -> a
@@ -234,6 +235,7 @@ class TaggedC c a where
 
 instance TaggedC SimpC a where
   senv      = _cenv
+  updateSEnv c f = c { _cenv = f (_cenv c) }
   sid       = _cid
   stag      = _ctag
   sinfo     = _cinfo
@@ -242,6 +244,7 @@ instance TaggedC SimpC a where
 
 instance TaggedC SubC a where
   senv      = _senv
+  updateSEnv c f = c { _senv = f (_senv c) }
   sid       = _sid
   stag      = _stag
   sinfo     = _sinfo

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -79,6 +79,7 @@ module Language.Fixpoint.Types.Constraints (
   , mkEquation
   , Rewrite  (..)
   , AutoRewrite (..)
+  , dedupAutoRewrites
 
   -- * Misc  [should be elsewhere but here due to dependencies]
   , substVars
@@ -916,6 +917,9 @@ instance NFData Equation
 instance NFData SMTSolver
 instance NFData Eliminate
 
+dedupAutoRewrites :: M.HashMap SubcId [AutoRewrite] -> [AutoRewrite]
+dedupAutoRewrites = S.toList . S.unions . map S.fromList . M.elems
+
 instance Semigroup AxiomEnv where
   a1 <> a2        = AEnv aenvEqs' aenvSimpl' aenvExpand' aenvAutoRW'
     where
@@ -975,7 +979,7 @@ instance Fixpoint (M.HashMap SubcId [AutoRewrite]) where
     map fixRW rewrites ++
     rwsMapping
     where
-      rewrites     = L.nub $ concatMap snd (M.toList autoRW)
+      rewrites = dedupAutoRewrites autoRW
 
       fixRW rw@(AutoRewrite args lhs rhs) =
           text ("autorewrite " ++ show (hash rw))

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -85,7 +85,7 @@ import           Language.Fixpoint.Misc
 type BindId        = Int
 type BindMap a     = M.HashMap BindId a
 
-newtype IBindEnv   = FB (S.HashSet BindId) deriving (Eq, Data, Typeable, Generic)
+newtype IBindEnv   = FB (S.HashSet BindId) deriving (Eq, Data, Show, Typeable, Generic)
 
 instance PPrint IBindEnv where
   pprintTidy _ = pprint . L.sort . elemsIBindEnv

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -35,6 +35,7 @@ module Language.Fixpoint.Types.Environments (
   , fromListIBindEnv
   , memberIBindEnv
   , unionIBindEnv
+  , unionsIBindEnv
   , diffIBindEnv
   , intersectionIBindEnv
   , nullIBindEnv
@@ -249,6 +250,9 @@ filterIBindEnv f (FB m) = FB (S.filter f m)
 
 unionIBindEnv :: IBindEnv -> IBindEnv -> IBindEnv
 unionIBindEnv (FB m1) (FB m2) = FB $ m1 `S.union` m2
+
+unionsIBindEnv :: [IBindEnv] -> IBindEnv
+unionsIBindEnv = L.foldl' unionIBindEnv emptyIBindEnv
 
 intersectionIBindEnv :: IBindEnv -> IBindEnv -> IBindEnv
 intersectionIBindEnv (FB m1) (FB m2) = FB $ m1 `S.intersection` m2

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -43,6 +43,7 @@ module Language.Fixpoint.Types.Environments (
   -- * Global Binder Environments
   , BindEnv, beBinds
   , emptyBindEnv
+  , fromListBindEnv
   , insertBindEnv, lookupBindEnv
   , filterBindEnv, mapBindEnv, mapWithKeyMBindEnv, adjustBindEnv
   , bindEnvFromList, bindEnvToList, deleteBindEnv, elemsBindEnv
@@ -206,6 +207,9 @@ fromListIBindEnv = FB . S.fromList
 -- | Functions for Global Binder Environment
 insertBindEnv :: Symbol -> SortedReft -> BindEnv -> (BindId, BindEnv)
 insertBindEnv x r (BE n m) = (n, BE (n + 1) (M.insert n (x, r) m))
+
+fromListBindEnv :: [(BindId, (Symbol, SortedReft))] -> BindEnv
+fromListBindEnv xs = BE (length xs) (M.fromList xs)
 
 emptyBindEnv :: BindEnv
 emptyBindEnv = BE 0 M.empty

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -492,11 +492,13 @@ instance Fixpoint Expr where
      in case sp of
           PNot e -> e
           _ -> PNot sp
-  simplify (PImp p q) =
-    let sq = simplify q
-     in if sq == PTrue then PTrue
-        else if sq == PFalse then simplify (PNot p)
-        else PImp (simplify p) sq
+  -- XXX: Do not simplify PImp until PLE can handle it
+  -- https://github.com/ucsd-progsys/liquid-fixpoint/issues/475
+  -- simplify (PImp p q) =
+  --   let sq = simplify q
+  --    in if sq == PTrue then PTrue
+  --       else if sq == PFalse then simplify (PNot p)
+  --       else PImp (simplify p) sq
   simplify (PIff p q)    =
     let sp = simplify p
         sq = simplify q

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -487,6 +487,15 @@ instance Fixpoint Expr where
   simplify (POr  [])     = PFalse
   simplify (PAnd [p])    = simplify p
   simplify (POr  [p])    = simplify p
+  simplify (PIff p q)    =
+    let sp = simplify p
+        sq = simplify q
+     in if sp == sq then PTrue
+        else if sp == PTrue then sq
+        else if sq == PTrue then sp
+        else if sp == PFalse then PNot sq
+        else if sq == PFalse then PNot sp
+        else PIff sp sq
 
   simplify (PGrad k su i e)
     | isContraPred e      = PFalse

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -84,6 +84,7 @@ module Language.Fixpoint.Types.Refinements (
   , splitEApp
   , splitPAnd
   , reftConjuncts
+  , sortedReftSymbols
 
   -- * Transforming
   , mapPredReft
@@ -440,6 +441,12 @@ newtype Reft = Reft (Symbol, Expr)
 
 data SortedReft = RR { sr_sort :: !Sort, sr_reft :: !Reft }
                   deriving (Eq, Data, Typeable, Generic)
+
+sortedReftSymbols :: SortedReft -> HashSet Symbol
+sortedReftSymbols sr =
+  HashSet.union
+    (sortSymbols $ sr_sort sr)
+    (exprSymbolsSet $ reftPred $ sr_reft sr)
 
 elit :: Located Symbol -> Sort -> Expr
 elit l s = ECon $ L (symbolText $ val l) s

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -487,6 +487,16 @@ instance Fixpoint Expr where
   simplify (POr  [])     = PFalse
   simplify (PAnd [p])    = simplify p
   simplify (POr  [p])    = simplify p
+  simplify (PNot p) =
+    let sp = simplify p
+     in case sp of
+          PNot e -> e
+          _ -> PNot sp
+  simplify (PImp p q) =
+    let sq = simplify q
+     in if sq == PTrue then PTrue
+        else if sq == PFalse then simplify (PNot p)
+        else PImp (simplify p) sq
   simplify (PIff p q)    =
     let sp = simplify p
         sq = simplify q

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -80,6 +80,7 @@ module Language.Fixpoint.Types.Refinements (
   , conjuncts
   , eApps
   , eAppC
+  , exprKVars
   , exprSymbolsSet
   , splitEApp
   , splitPAnd

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DeriveFunctor              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE NoMonomorphismRestriction  #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE UndecidableInstances       #-}
@@ -59,6 +60,7 @@ module Language.Fixpoint.Types.Sorts (
   , bkFFunc
   , bkAbs
   , mkPoly
+  , sortSymbols
 
   , isNumeric, isReal, isString, isPolyInst
 
@@ -89,6 +91,8 @@ import           Data.Semigroup            (Semigroup (..))
 #endif
 
 import           Data.Hashable
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
 import           Data.List                 (foldl')
 import           Control.DeepSeq
 import           Data.Maybe                (fromMaybe)
@@ -262,6 +266,14 @@ data Sort = FInt
           | FTC   !FTycon
           | FApp  !Sort !Sort    -- ^ constructed type
             deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+sortSymbols :: Sort -> HashSet Symbol
+sortSymbols = \case
+  FObj s -> HashSet.singleton s
+  FFunc t0 t1 -> HashSet.union (sortSymbols t0) (sortSymbols t1)
+  FAbs _ t -> sortSymbols t
+  FApp t0 t1 -> HashSet.union (sortSymbols t0) (sortSymbols t1)
+  _ -> HashSet.empty
 
 data DataField = DField
   { dfName :: !LocSymbol          -- ^ Field Name

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -13,6 +13,7 @@ module Language.Fixpoint.Types.Substitutions (
   , subst1Except
   , targetSubstSyms
   , filterSubst
+  , exprSymbolsSet
   ) where
 
 import           Data.Maybe
@@ -313,8 +314,12 @@ ppRas = cat . punctuate comma . map toFix . flattenRefas
     -- go (PAll xts p)       = (fst <$> xts) ++ go p
     -- go _                  = []
 
+
 exprSymbols :: Expr -> [Symbol]
-exprSymbols = S.toList . go 
+exprSymbols = S.toList . exprSymbolsSet
+
+exprSymbolsSet :: Expr -> S.HashSet Symbol
+exprSymbolsSet = go
   where
     gos es                = S.unions (go <$> es)
     go (EVar x)           = S.singleton x

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -318,28 +318,5 @@ ppRas = cat . punctuate comma . map toFix . flattenRefas
 exprSymbols :: Expr -> [Symbol]
 exprSymbols = S.toList . exprSymbolsSet
 
-exprSymbolsSet :: Expr -> S.HashSet Symbol
-exprSymbolsSet = go
-  where
-    gos es                = S.unions (go <$> es)
-    go (EVar x)           = S.singleton x
-    go (EApp f e)         = gos [f, e] 
-    go (ELam (x,_) e)     = S.delete x (go e) 
-    go (ECoerc _ _ e)     = go e
-    go (ENeg e)           = go e
-    go (EBin _ e1 e2)     = gos [e1, e2] 
-    go (EIte p e1 e2)     = gos [p, e1, e2] 
-    go (ECst e _)         = go e
-    go (PAnd ps)          = gos ps
-    go (POr ps)           = gos ps
-    go (PNot p)           = go p
-    go (PIff p1 p2)       = gos [p1, p2] 
-    go (PImp p1 p2)       = gos [p1, p2]
-    go (PAtom _ e1 e2)    = gos [e1, e2] 
-    go (PKVar _ (Su su))  = S.fromList $ syms $ M.elems su
-    go (PAll xts p)       = go p `S.difference` S.fromList (fst <$> xts) 
-    go (PExist xts p)     = go p `S.difference` S.fromList (fst <$> xts) 
-    go _                  = S.empty 
-
 instance Expression (Symbol, SortedReft) where
   expr (x, RR _ (Reft (v, r))) = subst1 (expr r) (v, EVar x)

--- a/tests/proof/ple1.fq
+++ b/tests/proof/ple1.fq
@@ -11,7 +11,7 @@ expand [1 : True]
 bind 0 z : {v: beta | true }
 
 constraint:
-  env []
+  env [0]
   lhs {v : int | true }
   rhs {v : int | (foo z) = 22 }
   id 1 tag []


### PR DESCRIPTION
This PR addresses most of ucsd-progsys/liquidhaskell#1848

With `--savequery` liquid haskell now saves files .liquid/module_name.fq.prettified

The format is not valid .fq. Instead, it shows a list of constraints in the form:

```
constraint:
  lhs {VV##F##7 : Tuple | [(~ ((isAdmit Language.Haskell.Liquid.ProofCombinators.QED)))]}
  rhs {VV##F##7 : Tuple | [(ty##aB0 = (Type.TFun (Type.funArgTy ty##aB0) (Type.funResTy ty##aB0)))]}
  id 7 tag [6]
  // META constraint id 7 : Type.hs:(41,3)-(45,5)
  environment:
    // elided some likely irrelevant bindings
    
    ty##aB0 : {VV##0 : Type.Ty | [(Type.isFunTy VV##0)]}
    
  ...
```

The environment of each constraint is populated from the FInfo at the time the query is saved.
The prettified output differs from the .fq output in the following ways.

### 1. Bindings prefixed with `lq_anf` are sometimes inlined at their use sites

Given a binding like `a : { v | e1 }`, expressions of the form `... e0 = a ...` are changed to `... e1[a:=e0] ...`

`... e0 = (a : s) ...` is equally transformed to `... e1[a:=e0] ...` and the sort annotation is dropped.

Given a binding like `a : { v | v = e1 }`, expressions of the form `... a ...` are changed to `... e1 ...` if `v` does not appear free in `e1`.

### 2. Refinement types of boolean sort are simplified

Refinement types of the form `{v:bool | v && P v}` become `{v:Bool | v && P true}`.

Refinement types of the form `{v:bool | ~v && P v}` become `{v:bool | ~v && P false}`.

### 3. Bindings considered unrelated to the constraint are dropped

Say that we have an environment like
```
a : { v | v > b }, b : int, c : { v | v >= b && b >= d}, d : int, e: { v | P }
```
and a constraint
```
{ true } <: {a > 0}
```

We retain `a` because it is used in the constraint. 
We retain `b` because it is used by the binding of `a`. 
We retain `c` because it states facts about `b`.
We retain `d` because it is used in `c` which is also retained.

The only binding that we drop is `e` as long as `P` doesn't mention any retained binding.
Dropping `e` can still change the outcome of verification (suppose that `P` is `false`). However, we drop the binding anyway because this output is to be consumed by a human, not a computer. And humans will often inspect this output when `constraints` *fail* to verify, which means that the environment can't be inconsistent as necessary to invalidate this binding elimination.

Nonetheless, because of this transformation, we warn the user that some bindings are elided.

### 4. Unused binding names are erased

Bindings of the form `a : {v | P }` become `_ : { v | P }` if `a` is not used in any binding in the environment nor in the constraint.

### 5. Some extra simplifications of predicates

`P => true` simplifies to `P`
`P => false` simplifies to `~P`
`~~P` simplifies to `P`
`true <=> P` simplifies to `P`
`false <=> P` simplifies to `~P`
`P && P` simplifies to `P`