### PR TITLE
Allow to load back fq dumps into fixpoint

### DIFF
--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -1005,10 +1005,12 @@ data Rewrite  = SMeasure
 
 instance Fixpoint AxiomEnv where
   toFix axe = vcat ((toFix <$> aenvEqs axe) ++ (toFix <$> aenvSimpl axe))
-              $+$ text "expand" <+> toFix (pairdoc <$> M.toList(aenvExpand axe))
+              $+$ renderExpand (pairdoc <$> M.toList (aenvExpand axe))
               $+$ toFix (aenvAutoRW axe)
     where
       pairdoc (x,y) = text $ show x ++ " : " ++ show y
+      renderExpand [] = empty
+      renderExpand xs = text "expand" <+> toFix xs
 
 instance Fixpoint Doc where
   toFix = id

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -947,9 +947,9 @@ instance Hashable AutoRewrite
 
 instance Fixpoint (M.HashMap SubcId [AutoRewrite]) where
   toFix autoRW =
-    vcat (map fixRW rewrites)
-    $+$ text "rewrite "
-    <+> toFix rwsMapping
+    vcat $
+    map fixRW rewrites ++
+    rwsMapping
     where
       rewrites     = L.nub $ concatMap snd (M.toList autoRW)
 
@@ -965,7 +965,7 @@ instance Fixpoint (M.HashMap SubcId [AutoRewrite]) where
       rwsMapping = do
         (cid, rws) <- M.toList autoRW
         rw         <-  rws
-        return $ text $ show cid ++ " : " ++ show (hash rw)
+        return $ "rewrite" <+> brackets (text $ show cid ++ " : " ++ show (hash rw))
 
 
 
@@ -990,13 +990,13 @@ instance Fixpoint Doc where
   toFix = id
 
 instance Fixpoint Equation where
-  toFix (Equ f xs e _ _) = "define" <+> toFix f <+> ppArgs xs <+> text "=" <+> parens (toFix e)
+  toFix (Equ f xs e s _) = "define" <+> toFix f <+> ppArgs xs <+> ":" <+> toFix s <+> text "=" <+> braces (parens (toFix e))
 
 instance Fixpoint Rewrite where
   toFix (SMeasure f d xs e)
     = text "match"
    <+> toFix f
-   <+> parens (toFix d <+> hsep (toFix <$> xs))
+   <+> toFix d <+> hsep (toFix <$> xs)
    <+> text " = "
    <+> parens (toFix e)
 

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -45,7 +45,7 @@ module Language.Fixpoint.Types.Environments (
   , emptyBindEnv
   , insertBindEnv, lookupBindEnv
   , filterBindEnv, mapBindEnv, mapWithKeyMBindEnv, adjustBindEnv
-  , bindEnvFromList, bindEnvToList, elemsBindEnv
+  , bindEnvFromList, bindEnvToList, deleteBindEnv, elemsBindEnv
   , EBindEnv, splitByQuantifiers
 
   -- * Information needed to lookup and update Solutions
@@ -257,6 +257,9 @@ diffIBindEnv (FB m1) (FB m2) = FB $ m1 `S.difference` m2
 
 adjustBindEnv :: ((Symbol, SortedReft) -> (Symbol, SortedReft)) -> BindId -> BindEnv -> BindEnv
 adjustBindEnv f i (BE n m) = BE n $ M.adjust f i m
+
+deleteBindEnv :: BindId -> BindEnv -> BindEnv
+deleteBindEnv i (BE n m) = BE n $ M.delete i m
 
 instance Functor SEnv where
   fmap = mapSEnv


### PR DESCRIPTION
There were some syntax discrepancies in the fq files produced by liquid-fixpoint, which prevented it from using these files as input.

* `match` clauses had parenthesis around the data constructor argument,
* `define` bodies weren't surrounded with braces,
* and `define` sorts weren't terminated with the sort of the body.

Moreover, liquid-fixpoint is only capable of parsing FInfos, while much of the processing happens on SInfos. This PR also implements a conversion of SInfos to FInfos.