### PR TITLE
Optimize simplification of PAnd and remove duplicated conjuncts

### DIFF
--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -494,6 +494,7 @@ instance Fixpoint Expr where
 
   simplify (PAnd ps)
     | any isContraPred ps = PFalse
+                         -- Note: Performance of some tests is very sensitive to this code. See #480 
     | otherwise           = PAnd $ dedup . flattenRefas . filter (not . isTautoPred) $ map simplify ps
     where
       dedup = Set.toList . Set.fromList

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -102,7 +102,8 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
-import           Data.List                 (foldl', partition, nub)
+import           Data.List                 (foldl', partition)
+import qualified Data.Set                  as Set
 import           Data.String
 import           Data.Text                 (Text)
 import qualified Data.Text                 as T
@@ -244,7 +245,7 @@ instance Hashable Reft
 -- | Substitutions -------------------------------------------------------------
 --------------------------------------------------------------------------------
 newtype Subst = Su (M.HashMap Symbol Expr)
-                deriving (Eq, Data, Typeable, Generic)
+                deriving (Eq, Data, Ord, Typeable, Generic)
 
 instance Show Subst where
   show = showFix
@@ -310,7 +311,7 @@ data Expr = ESym !SymConst
           | PExist ![(Symbol, Sort)] !Expr
           | PGrad  !KVar !Subst !GradInfo !Expr
           | ECoerc !Sort !Sort !Expr  
-          deriving (Eq, Show, Data, Typeable, Generic)
+          deriving (Eq, Show, Ord, Data, Typeable, Generic)
 
 type Pred = Expr
 
@@ -343,7 +344,7 @@ pattern ERDiv e1 e2 = EBin RDiv   e1 e2
 
 
 data GradInfo = GradInfo {gsrc :: SrcSpan, gused :: Maybe SrcSpan}
-          deriving (Eq, Show, Data, Typeable, Generic)
+          deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
 srcGradInfo :: SourcePos -> GradInfo
 srcGradInfo src = GradInfo (SS src src) Nothing
@@ -493,7 +494,9 @@ instance Fixpoint Expr where
 
   simplify (PAnd ps)
     | any isContraPred ps = PFalse
-    | otherwise           = PAnd $ filter (not . isTautoPred) $ map simplify ps
+    | otherwise           = PAnd $ dedup . flattenRefas . filter (not . isTautoPred) $ map simplify ps
+    where
+      dedup = Set.toList . Set.fromList
 
   simplify (POr  ps)
     | any isTautoPred ps = PTrue
@@ -761,13 +764,8 @@ conj ps  = PAnd ps
 --   some basic things but is faster.
 
 pAnd, pOr     :: ListNE Pred -> Pred
-pAnd          = simplify . PAnd . nub . flatten
-  where
-    flatten ps = foldl' go [] $ reverse ps
-  
-    go acc (PAnd ps) = flatten ps ++ acc
-    go acc p         = p : acc
-  
+pAnd          = simplify . PAnd
+
 pOr           = simplify . POr
 
 (&.&) :: Pred -> Pred -> Pred
@@ -861,10 +859,11 @@ trueReft  = Reft (vv_, PTrue)
 falseReft = Reft (vv_, PFalse)
 
 flattenRefas :: [Expr] -> [Expr]
-flattenRefas        = concatMap flatP
+flattenRefas        = flatP []
   where
-    flatP (PAnd ps) = concatMap flatP ps
-    flatP p         = [p]
+    flatP acc (PAnd ps:xs) = flatP (flatP acc xs) ps
+    flatP acc (p:xs)       = p : flatP acc xs
+    flatP acc []           = acc
 
 conjuncts :: Expr -> [Expr]
 conjuncts (PAnd ps) = concatMap conjuncts ps


### PR DESCRIPTION
It is handy removing duplicate conjuncts for #473, but using `nub` would be too slow. I replaced it with `Set.toList . Set.fromList`.

Also, concatenation in `flattenRefas` was done in the quadratic way in some inputs. This PR changes it to linear.

No test time worsens much (maximum 300 ms), and some benchmarks show substantial improvements (half the time to run). 

test | develop | this commit | difference
-- | -- | -- | --
Tests/Benchmarks/text/Data/Text/Internal.hs | 11.6144 | 6.1947 | -5.4197
Tests/Benchmarks/vect-algs/Data/Vector/Algorithms/Merge.hs | 15.5744 | 9.7944 | -5.78
Tests/Macro/unit-neg/StateConstraints0.hs | 27.0741 | 18.7044 | -8.3697
Tests/Benchmarks/text/Data/Text/Encoding.hs | 70.4149 | 61.8344 | -8.5805
Tests/Benchmarks/bytestring/Data/ByteString/Char8.hs | 22.6642 | 12.8245 | -9.8397
Tests/Benchmarks/bytestring/Data/ByteString/Fusion.T.hs | 54.1343 | 42.6044 | -11.5299
Tests/Benchmarks/bytestring/Data/ByteString/Lazy.hs | 50.1643 | 37.4042 | -12.7601
Tests/Benchmarks/vect-algs/Data/Vector/Algorithms/AmericanFlag.hs | 28.6342 | 14.2144 | -14.4198
Tests/Benchmarks/text/Data/Text/Lazy/Encoding.hs | 67.2748 | 46.5344 | -20.7404
Tests/Benchmarks/text/Data/Text/Search.hs | 40.1441 | 17.2444 | -22.8997
