### PR TITLE
Implement a flag to enable inlining of formulas

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -43,7 +43,8 @@ flag devel
 
 library
   autogen-modules:  Paths_liquid_fixpoint
-  exposed-modules:  Language.Fixpoint.Defunctionalize
+  exposed-modules:  Data.ShareMap
+                    Language.Fixpoint.Defunctionalize
                     Language.Fixpoint.Graph
                     Language.Fixpoint.Graph.Deps
                     Language.Fixpoint.Graph.Indexed
@@ -106,8 +107,7 @@ library
                     Language.Fixpoint.Utils.Statistics
                     Language.Fixpoint.Utils.Trie
                     Text.PrettyPrint.HughesPJ.Compat
-  other-modules:    Data.ShareMap
-                    Paths_liquid_fixpoint
+  other-modules:    Paths_liquid_fixpoint
   hs-source-dirs:   src
   build-depends:    base                 >= 4.9.1.0 && < 5
                   , ansi-terminal
@@ -187,15 +187,20 @@ test-suite test
   if flag(devel)
     ghc-options: -Werror
 
-test-suite testparser
+test-suite tasty
   type:             exitcode-stdio-1.0
-  main-is:          testParser.hs
-  hs-source-dirs:   tests
+  main-is:          Main.hs
+  other-modules:    ParserTests
+                    ShareMapReference
+                    ShareMapTests
+  hs-source-dirs:   tests/tasty
   build-depends:    base            >= 4.9.1.0 && < 5
+                  , hashable
                   , liquid-fixpoint
                   , tasty           >= 0.10
-                  , tasty-hunit
+                  , tasty-quickcheck
                   , tasty-hunit     >= 0.9
+                  , unordered-containers
   default-language: Haskell98
   ghc-options:      -threaded
 

--- a/src/Data/ShareMap.hs
+++ b/src/Data/ShareMap.hs
@@ -95,7 +95,7 @@ mergeKeysWith f k0 k1 sm | k0 /= k1 =
             { unsharedMap = HashMap.insertWith (flip f) k0' v1 (unsharedMap sm)
             , shareMap = -- Any values pointing to k1 are redirected to k0':
                 HashSet.foldl' (\m k -> insertReversibleMap k k0' m) (shareMap sm) $
-                reverseLookup k1 $ shareMap sm
+                reverseLookup k1' $ shareMap sm
             }
         Nothing ->
           sm { shareMap = insertReversibleMap k0 k1' (shareMap sm) }

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -224,7 +224,7 @@ simplifyFInfo !cfg !fi0 = do
 
 reduceFInfo :: Fixpoint a => Config -> FInfo a -> IO (FInfo a)
 reduceFInfo cfg fi = do
-  let simplifiedFi = {- SCC "simplifyFInfo" #-} simplifyBindings fi
+  let simplifiedFi = {- SCC "simplifyFInfo" #-} simplifyBindings cfg fi
       reducedFi = {- SCC "reduceEnvironments" #-} reduceEnvironments simplifiedFi
   when (save cfg) $
     savePrettifiedQuery cfg reducedFi

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -435,6 +435,9 @@ reachableSymbols ss0 outgoingEdges = go HashSet.empty ss0
 --
 -- It runs 'mergeDuplicatedBindings' and 'simplifyBooleanRefts'
 -- on the environment of each constraint.
+--
+-- If 'inlineANFBindings cfg' is on, also runs 'undoANF' to inline
+-- @lq_anf@ bindings.
 simplifyBindings :: Config -> FInfo a -> FInfo a
 simplifyBindings cfg fi =
   let (bs', cm', oldToNew) = simplifyConstraints (bs fi) (cm fi)
@@ -555,6 +558,11 @@ mergeDuplicatedBindings xs =
 -- Only bindings with prefix lq_anf... might be inlined.
 --
 -- Doesn't inline bindings having more than @maxConjuncts@ conjuncts.
+--
+-- This function is used to produced the prettified output, and the user
+-- can request to use it in the verification pipeline with
+-- @--inline-anf-bindings@. However, using it in the verification
+-- pipeline causes some tests in liquidhaskell to blow up.
 undoANF :: Int -> HashMap Symbol (m, SortedReft) -> HashMap Symbol (m, SortedReft)
 undoANF maxConjuncts env =
     -- Circular program here. This should terminate as long as the

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -90,6 +90,8 @@ data Config = Config
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
   , noEnvironmentReduction :: Bool     -- ^ Don't use environment reduction
+  , inlineANFBindings :: Maybe Int     -- ^ Inline ANF bindings with up-to the given amount of conjuncts.
+                                       -- Sometimes improves performance and sometimes worsens it.
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints 
   , extensionality   :: Bool           -- ^ Enable extensional interpretation of function equality
   , maxRWOrderingConstraints :: Maybe Int
@@ -188,6 +190,14 @@ defConfig = Config {
       False
         &= name "no-environment-reduction"
         &= help "Don't perform environment reduction"
+  , inlineANFBindings        =
+      Nothing
+        &= name "inline-anf-bindings"
+        &= help (unwords
+          [ "Inline ANF bindings with up-to the given amount of conjuncts."
+          , "Sometimes improves performance and sometimes worsens it."
+          , "Disabled by --no-environment-reduction"
+          ])
   , checkCstr                = []    &= help "Only check these specific constraint-ids" 
   , extensionality           = False &= help "Allow extensional interpretation of extensionality"
   , maxRWOrderingConstraints = Nothing &= help "Maximum number of functions to consider in rewrite orderings"

--- a/tests/tasty/Main.hs
+++ b/tests/tasty/Main.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import qualified ParserTests
+import qualified ShareMapTests
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = defaultMain $ testGroup "Tests"
+  [ ParserTests.tests
+  , ShareMapTests.tests
+  ]

--- a/tests/tasty/ParserTests.hs
+++ b/tests/tasty/ParserTests.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Main where
+module ParserTests (tests) where
 
 import Language.Fixpoint.Types (showFix)
 import Language.Fixpoint.Parse
@@ -8,12 +8,9 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Data.List (intercalate)
 
-main :: IO ()
-main = defaultMain $ parserTests
-
-parserTests :: TestTree
-parserTests =
-  testGroup "Tests"
+tests :: TestTree
+tests =
+  testGroup "ParserTests"
     [ testSortP
     , testFunAppP
     , testExpr0P

--- a/tests/tasty/ShareMapReference.hs
+++ b/tests/tasty/ShareMapReference.hs
@@ -10,8 +10,15 @@ import           Data.List (find)
 
 -- | See "Data.ShareMap" for documentation.
 data ShareMap k v = ShareMap
-  { toHashMap :: HashMap k v
-  , keyPartitions :: [HashSet k]
+  { -- | Contains all the values in the ShareMap.
+    toHashMap :: HashMap k v
+  , -- | Contains all the keys in the ShareMap.
+    --
+    -- All sets in @keyPartitions@ are disjoint.
+    -- Every key in in @keyPartitions@ is present in @toHashMap@.
+    -- If @k1@ and @k2@ belong to the same set @s@ in @keyPartitions@
+    -- then @toHashMap ! k1 == toHashMap ! k2@.
+    keyPartitions :: [HashSet k]
   }
   deriving Show
 

--- a/tests/tasty/ShareMapReference.hs
+++ b/tests/tasty/ShareMapReference.hs
@@ -1,0 +1,78 @@
+-- | A reference implementation for Data.ShareMap
+module ShareMapReference where
+
+import           Data.Hashable (Hashable)
+import           Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import           Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import           Data.List (find)
+
+-- | See "Data.ShareMap" for documentation.
+data ShareMap k v = ShareMap
+  { toHashMap :: HashMap k v
+  , keyPartitions :: [HashSet k]
+  }
+  deriving Show
+
+empty :: ShareMap k v
+empty = ShareMap HashMap.empty []
+
+insertWith
+  :: (Hashable k, Eq k)
+  => (v -> v -> v)
+  -> k
+  -> v
+  -> ShareMap k v
+  -> ShareMap k v
+insertWith f k v sm =
+  let h = toHashMap sm
+      ks = keyPartitions sm
+   in case find (HashSet.member k) ks of
+     Nothing ->
+       sm
+         { toHashMap = HashMap.insertWith f k v h
+         , keyPartitions = HashSet.singleton k : ks
+         }
+     Just keys ->
+       sm
+         { toHashMap =
+             HashSet.foldl' (\h' k' -> HashMap.insertWith f k' v h') h keys
+         }
+
+mergeKeysWith
+  :: (Hashable k, Eq k)
+  => (v -> v -> v)
+  -> k
+  -> k
+  -> ShareMap k v
+  -> ShareMap k v
+mergeKeysWith f k0 k1 sm | k0 /= k1 =
+  let h = toHashMap sm
+      ks = keyPartitions sm
+   in case break (HashSet.member k0) ks of
+     (_before0, []) -> case break (HashSet.member k1) ks of
+       (_before1, []) -> sm
+       (before1, keys1 : after1) ->
+         sm
+           { toHashMap = HashMap.insertWith f k0 (h HashMap.! k1) h
+           , keyPartitions =
+               HashSet.insert k0 keys1 : before1 ++ after1
+           }
+     (before0, keys0 : after0)
+       | HashSet.member k1 keys0 -> sm
+       | otherwise ->
+         let v0 = h HashMap.! k0
+             v1 = maybe v0 (f v0) $ HashMap.lookup k1 h
+             keys'
+               | otherwise = case break (HashSet.member k1) (before0 ++ after0) of
+                 (before1, []) ->
+                    HashSet.insert k1 keys0 : before1
+                 (before1, keys1 : after1)->
+                    HashSet.union keys0 keys1 : before1 ++ after1
+          in sm
+              { toHashMap =
+                  HashSet.foldl' (\h' k' -> HashMap.insert k' v1 h') h (head keys')
+              , keyPartitions = keys'
+              }
+mergeKeysWith _ _ _ sm = sm

--- a/tests/tasty/ShareMapTests.hs
+++ b/tests/tasty/ShareMapTests.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module ShareMapTests where
+
+import Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+import Data.List (foldl', nub)
+import qualified Data.ShareMap as ShareMap
+import qualified ShareMapReference as Reference
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.Tasty.HUnit
+
+-- | Compare Data.ShareMap against a reference implementation
+tests :: TestTree
+tests =
+  localOption (QuickCheckMaxSize 50) $
+  localOption (QuickCheckTests 500) $
+  testGroup "Data.ShareMap"
+    [ testProperty "behaves as ShareMapReference" $ \xs ->
+        let m1 :: HashMap Int [Int]
+            m1 = Reference.toHashMap $
+                  interpretSteps
+                    (Reference.insertWith (++))
+                    (Reference.mergeKeysWith (++))
+                    Reference.empty
+                    xs
+            m2 = ShareMap.toHashMap $
+                  interpretSteps
+                    (ShareMap.insertWith (++))
+                    (ShareMap.mergeKeysWith (++))
+                    ShareMap.empty
+                    xs
+         in m1 === m2
+    ]
+
+-- | The steps to use to generate a ShareMap
+data ShareMapStep k v
+  = Insert k v
+  | MergeKeys k k
+  deriving Show
+
+-- | Run a sequence of steps to produce some sharemap
+interpretSteps
+  :: (k -> v -> a -> a)
+  -> (k -> k -> a -> a)
+  -> a
+  -> [ShareMapStep k v]
+  -> a
+interpretSteps f g = foldl' $ \a x -> case x of
+  Insert k v -> f k v a
+  MergeKeys k1 k2 -> g k1 k2 a
+
+instance Arbitrary (ShareMapStep Int [Int]) where
+  arbitrary = do
+    n <- getSize
+    let sz = 8
+    resize (min n sz) $ frequency
+      [ ( 1
+        , Insert
+            <$> choose (1, sz)
+            <*> (nub <$> listOf (choose (1, sz)))
+        )
+      , ( 1
+        , MergeKeys
+            <$> choose (1, sz)
+            <*> choose (1, sz)
+        )
+      ]
+  shrink s = case s of
+    Insert k v -> Insert k <$> shrink v
+    _ -> []


### PR DESCRIPTION
Follow up from #473 

Inlining ANF bindings can either speed up or slow down your verification. `Fusion.T.hs` is a benchmark in LH that improves and `FoldrUniversal.hs` is a benchmark that worsens.