### PR TITLE
Fix inlining of anf bindings

### DIFF
--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -85,11 +85,11 @@ prettyConstraint bindEnv c =
             , let (s, sr) = lookupBindEnv bId bindEnv
             ]
       mergedEnv = mergeDuplicatedBindings env
-      undoANFEnv = HashMap.union (undoANF 5 mergedEnv) mergedEnv
+      undoANFEnv = HashMap.union (undoANF mergedEnv) mergedEnv
       boolSimplEnv = HashMap.union (simplifyBooleanRefts undoANFEnv) undoANFEnv
 
-      simplifiedLhs = inlineInSortedReft 100 boolSimplEnv (slhs c)
-      simplifiedRhs = inlineInSortedReft 100 boolSimplEnv (srhs c)
+      simplifiedLhs = inlineInSortedReft boolSimplEnv (slhs c)
+      simplifiedRhs = inlineInSortedReft boolSimplEnv (srhs c)
 
       prunedEnv =
         dropLikelyIrrelevantBindings (constraintSymbols simplifiedLhs simplifiedRhs) $

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -90,7 +90,7 @@ data Config = Config
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
   , noEnvironmentReduction :: Bool     -- ^ Don't use environment reduction
-  , inlineANFBindings :: Maybe Int     -- ^ Inline ANF bindings with up-to the given amount of conjuncts.
+  , inlineANFBindings :: Bool          -- ^ Inline ANF bindings.
                                        -- Sometimes improves performance and sometimes worsens it.
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints 
   , extensionality   :: Bool           -- ^ Enable extensional interpretation of function equality
@@ -191,10 +191,10 @@ defConfig = Config {
         &= name "no-environment-reduction"
         &= help "Don't perform environment reduction"
   , inlineANFBindings        =
-      Nothing
+      False
         &= name "inline-anf-bindings"
         &= help (unwords
-          [ "Inline ANF bindings with up-to the given amount of conjuncts."
+          [ "Inline ANF bindings."
           , "Sometimes improves performance and sometimes worsens it."
           , "Disabled by --no-environment-reduction"
           ])


### PR DESCRIPTION
This fixes the handling of equalities that need coercions. Before, we would get failures about mismatched sorts after inlining.

The following bindings
```
bind 286 lq_anf$##d3Pl : {v : Str | [(v = "Data.ByteString.Lazy: invariant violation:")]}
bind 287 lq_anf$##d3Pm : {v : [Char] | [(len v = (strLen lq_anf$##d3Pl)); (len v >= 0); (v ~~ lq_anf$##d3Pl)]}
bind 290 lq_anf$##d3Pp : {v : [Char] | [(v = ((len lq_anf$##d3Pm) + (len lq_anf$##d3Po))); (v >= 0)]}
```
are inlined first to
```
bind 287 lq_anf$##d3Pm : {v : [Char] |
  [(len v = (strLen "Data.ByteString.Lazy: invariant violation:"));
  (len v >= 0); 
  (v ~~ "Data.ByteString.Lazy: invariant violation:" : Str)]}
bind 290 lq_anf$##d3Pp : {v : [Char] | [(v = ((len lq_anf$##d3Pm) + (len lq_anf$##d3Po))); (v >= 0)]}
```
and then to
```
bind 290 lq_anf$##d3Pp : {v : [Char] |
  [(v = ((len (coerce Str ~ [Char] in "Data.ByteString.Lazy: invariant violation:") + (len lq_anf$##d3Po)));
  (v >= 0)]}
```

Closes #483

It also reduces the amount of expressions being inlined in the hope of stopping tests from failing with inlining, but T1548.hs still blows up.