### PR TITLE
Improve debugging experience

### DIFF
--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -384,7 +384,7 @@ relatedKVarBinds bindEnv cs =
       let c = originalConstraint sc
           unSubst (Su su) = su
           substsToHashSet =
-            HashSet.fromList . HashMap.keys . HashMap.unions . map unSubst
+            HashSet.fromMap . HashMap.map (const ()) . HashMap.unions . map unSubst
        in foldl' (HashMap.unionWith HashSet.union) HashMap.empty $
           map (HashMap.map substsToHashSet) $
           (exprKVars (reftPred $ sr_reft $ srhs c) :) $

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -213,8 +213,21 @@ proposeRenamings = toSymMap . toPrefixSuffixMap
 --
 -- For instance,
 --
--- > toPrefixSuffixMap ["a##b##c"] ! "a" ! "b" == ["a##b##c"]
--- > toPrefixSuffixMap ["a##b"] ! "a" ! "" == ["a##b"]
+-- > toPrefixSuffixMap ["a##b##c"] ! "a" ! "c" == ["a##b##c"]
+-- > toPrefixSuffixMap ["a"] ! "a" ! "" == ["a"]
+--
+-- In general,
+--
+-- > forall ss.
+-- > Set.fromList ss == Set.fromList $ concat [ xs | m <- elems (toPrefixSuffixMap ss), xs <- elems m ]
+-- 
+-- > forall ss.
+-- > and [ all (pfx `isPrefixOfSym`) xs && all (sfx `isSuffixOfSym`) xs
+-- >     | (pfx, m) <- toList (toPrefixSuffixMap ss)
+-- >     , (sfx, xs) <- toList m
+-- >     ]
+--
+-- TODO: put the above in unit tests
 --
 toPrefixSuffixMap :: [Symbol] -> HashMap Symbol (HashMap Symbol [Symbol])
 toPrefixSuffixMap xs = HashMap.fromListWith (HashMap.unionWith (++))

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -14,6 +14,8 @@ import qualified Data.HashMap.Lazy as HashMap
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import           Data.List (intersperse)
+import           Data.Maybe (fromMaybe)
+import qualified Data.Text as Text
 import           Language.Fixpoint.Misc (ensurePath)
 import           Language.Fixpoint.Solver.EnvironmentReduction
   ( dropLikelyIrrelevantBindings
@@ -27,10 +29,29 @@ import           Language.Fixpoint.Types.Config (Config, queryFile)
 import           Language.Fixpoint.Types.Constraints
 import           Language.Fixpoint.Types.Environments
   (BindEnv, elemsIBindEnv, lookupBindEnv)
-import           Language.Fixpoint.Types.Names (Symbol)
+import           Language.Fixpoint.Types.Names
+  ( Symbol
+  , dropPrefixOfSym
+  , prefixOfSym
+  , suffixOfSym
+  , suffixSymbol
+  , symbol
+  , symbolText
+  )
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Refinements
-  (SortedReft(..), conjuncts, reftBind, reftPred, sortedReftSymbols)
+  ( Expr(..)
+  , Reft
+  , SortedReft(..)
+  , conjuncts
+  , reft
+  , reftBind
+  , reftPred
+  , sortedReftSymbols
+  , substf
+  , substSortInExpr
+  )
+import           Language.Fixpoint.Types.Sorts (Sort(..), substSort)
 import           Language.Fixpoint.Types.Substitutions (exprSymbolsSet)
 import qualified Language.Fixpoint.Utils.Files as Files
 import           System.FilePath (addExtension)
@@ -68,19 +89,20 @@ prettyConstraint aenv bindEnv c =
 
       simplifiedLhs = inlineInSortedReft 100 boolSimplEnv (slhs c)
       simplifiedRhs = inlineInSortedReft 100 boolSimplEnv (srhs c)
-      prunedPrettyEnv =
-        eraseUnusedBindings constraintSymbols $
-        dropLikelyIrrelevantBindings aenv constraintSymbols $
+
+      prunedEnv =
+        dropLikelyIrrelevantBindings aenv (constraintSymbols simplifiedLhs simplifiedRhs) $
         HashMap.map snd boolSimplEnv
-      constraintSymbols =
-        HashSet.union (sortedReftSymbols simplifiedLhs) (sortedReftSymbols simplifiedRhs)
+      (renamedEnv, c') =
+        shortenVarNames prunedEnv c { slhs = simplifiedLhs, srhs = simplifiedRhs }
+      prettyEnv = eraseUnusedBindings (constraintSymbols (slhs c') (srhs c')) renamedEnv
    in hang (text "\n\nconstraint:") 2 $
-          text "lhs" <+> toFix simplifiedLhs
-      $+$ text "rhs" <+> toFix simplifiedRhs
-      $+$ (pprId (sid c) <+> text "tag" <+> toFix (stag c))
-      $+$ toFixMeta (text "simpleConstraint" <+> pprId (sid c)) (toFix (sinfo c))
+          text "lhs" <+> toFix (slhs c')
+      $+$ text "rhs" <+> toFix (srhs c')
+      $+$ pprId (sid c) <+> text "tag" <+> toFix (stag c)
+      $+$ toFixMeta (text "constraint" <+> pprId (sid c)) (toFix (sinfo c))
       $+$ hang (text "environment:") 2
-            (vcat $ intersperse "" $ elidedMessage : map prettyBind prunedPrettyEnv)
+            (vcat $ intersperse "" $ elidedMessage : map prettyBind prettyEnv)
   where
     prettyBind (ms, sr) = sep [maybe "_" toFix ms <+> ":", nest 2 $ prettySortedRef sr]
     prettySortedRef sr = braces $ sep
@@ -89,6 +111,9 @@ prettyConstraint aenv bindEnv c =
       ]
 
     elidedMessage = "// elided some likely irrelevant bindings"
+
+    constraintSymbols sr0 sr1 =
+      HashSet.union (sortedReftSymbols sr0) (sortedReftSymbols sr1)
 
 pprId :: Show a => Maybe a -> Doc
 pprId (Just i)  = "id" <+> text (show i)
@@ -103,17 +128,111 @@ toFixMeta k v = text "// META" <+> k <+> text ":" <+> v
 -- Erasure is accomplished by replacing the symbol with @Nothing@ in the
 -- bindings.
 eraseUnusedBindings
-  :: HashSet Symbol -> HashMap Symbol SortedReft -> [(Maybe Symbol, SortedReft)]
-eraseUnusedBindings ss env = map (first reachable) $ HashMap.toList env
+  :: HashSet Symbol -> [(Symbol, SortedReft)] -> [(Maybe Symbol, SortedReft)]
+eraseUnusedBindings ss env = map (first reachable) env
   where
     allSymbols = HashSet.union ss envSymbols
     envSymbols =
       HashSet.unions $
-      map (exprSymbolsSet . reftPred . sr_reft) $
-      HashMap.elems env
+      map (exprSymbolsSet . reftPred . sr_reft . snd) env
 
     reachable s =
       if s `HashSet.member` allSymbols then
         Just s
       else
         Nothing
+
+-- | Shortens the names of refinements types in a given environment
+-- and constraint
+shortenVarNames
+  :: HashMap Symbol SortedReft
+  -> SubC a
+  -> ([(Symbol, SortedReft)], SubC a)
+shortenVarNames env c =
+  let bindsRenameMap = proposeRenamings $ HashMap.keys env
+      env' = map (renameBind bindsRenameMap) (HashMap.toList env)
+   in
+      (env', renameSubC bindsRenameMap c)
+  where
+    renameSubC :: HashMap Symbol Symbol -> SubC a -> SubC a
+    renameSubC symMap c =
+      mkSubC
+        (senv c)
+        (renameSortedReft symMap $ slhs c)
+        (renameSortedReft symMap $ srhs c)
+        (sid c)
+        (stag c)
+        (sinfo c)
+
+    renameBind
+      :: HashMap Symbol Symbol -> (Symbol, SortedReft) -> (Symbol, SortedReft)
+    renameBind symMap (s, sr) =
+      (at symMap s, renameSortedReft symMap sr)
+
+    renameSortedReft
+      :: HashMap Symbol Symbol -> SortedReft -> SortedReft
+    renameSortedReft symMap (RR t r) =
+      let sortSubst = FObj . (at symMap)
+       in RR (substSort sortSubst t) (renameReft symMap r)
+
+    renameReft :: HashMap Symbol Symbol -> Reft -> Reft
+    renameReft symMap r =
+      let m = HashMap.insert (reftBind r) (prefixOfSym $ reftBind r) symMap
+          sortSubst = FObj . (at symMap)
+       in reft (at m (reftBind r)) $
+            substSortInExpr sortSubst $
+            (substf (EVar . (at m)) $ reftPred r)
+
+    at :: HashMap Symbol Symbol -> Symbol -> Symbol
+    at m k = fromMaybe k $ HashMap.lookup k m
+
+-- | Given a list of symbols with no duplicates, it proposes shorter
+-- names to use for them.
+--
+-- All proposals preserve the prefix of the original name. A prefix is
+-- the longest substring containing the initial character and no separator
+-- ## ('symSepName').
+--
+-- Suffixes are preserved, except when symbols with a given prefix always
+-- use the same suffix.
+--
+proposeRenamings :: [Symbol] -> HashMap Symbol Symbol
+proposeRenamings = toSymMap . toPrefixSuffixMap
+
+-- | Indexes symbols by prefix and then by suffix. If the prefix
+-- equals the symbol, then the suffix is the empty symbol.
+--
+-- For instance,
+--
+-- > toPrefixSuffixMap ["a##b##c"] ! "a" ! "b" == ["a##b##c"]
+-- > toPrefixSuffixMap ["a##b"] ! "a" ! "" == ["a##b"]
+--
+toPrefixSuffixMap :: [Symbol] -> HashMap Symbol (HashMap Symbol [Symbol])
+toPrefixSuffixMap xs = HashMap.fromListWith (HashMap.unionWith (++))
+  [ (pfx, HashMap.singleton sfx [s])
+  | s <- xs
+  , let pfx = prefixOfSym s
+        sfx = suffixOfSym $ dropPrefixOfSym s
+  ]
+
+-- | Suggests renamings for every symbol in a given prefix/suffix map.
+toSymMap :: HashMap Symbol (HashMap Symbol [Symbol]) -> HashMap Symbol Symbol
+toSymMap prefixMap = HashMap.fromList
+  [ r
+  | (pfx, h) <- HashMap.toList prefixMap
+  , r <- renameWithSuffixes pfx (HashMap.toList h)
+  ]
+  where
+    renameWithSuffixes pfx = \case
+      [(_sfx, ss)] -> renameWithAppendages pfx ("", ss)
+      sfxs -> concatMap (renameWithAppendages pfx) sfxs
+
+    renameWithAppendages pfx (sfx, ss) = zip ss $ case ss of
+      [_s] -> [pfx `suffixIfNotNull` sfx]
+      ss -> zipWith (rename pfx sfx) [1..] ss
+
+    rename pfx sfx i _s =
+      pfx `suffixIfNotNull` sfx `suffixSymbol` symbol (show i)
+
+    suffixIfNotNull a b =
+      if Text.null (symbolText b) then a else a `suffixSymbol` b

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -19,7 +19,6 @@ import qualified Data.Text as Text
 import           Language.Fixpoint.Misc (ensurePath)
 import           Language.Fixpoint.Solver.EnvironmentReduction
   ( dropLikelyIrrelevantBindings
-  , axiomEnvSymbols
   , inlineInSortedReft
   , mergeDuplicatedBindings
   , simplifyBooleanRefts
@@ -69,20 +68,17 @@ savePrettifiedQuery cfg fi = do
 prettyConstraints :: Fixpoint a => FInfo a -> Doc
 prettyConstraints fi =
   vcat $
-  map (prettyConstraint aenvMap (bs fi)) $
+  map (prettyConstraint (bs fi)) $
   map snd $
   sortOn fst $
   HashMap.toList (cm fi)
-  where
-    aenvMap = axiomEnvSymbols (ae fi)
 
 prettyConstraint
   :: Fixpoint a
-  => HashMap Symbol (HashSet Symbol)
-  -> BindEnv
+  => BindEnv
   -> SubC a
   -> Doc
-prettyConstraint aenv bindEnv c =
+prettyConstraint bindEnv c =
   let env = [ (s, ([bId], sr))
             | bId <- elemsIBindEnv $ senv c
             , let (s, sr) = lookupBindEnv bId bindEnv
@@ -95,7 +91,7 @@ prettyConstraint aenv bindEnv c =
       simplifiedRhs = inlineInSortedReft 100 boolSimplEnv (srhs c)
 
       prunedEnv =
-        dropLikelyIrrelevantBindings aenv (constraintSymbols simplifiedLhs simplifiedRhs) $
+        dropLikelyIrrelevantBindings (constraintSymbols simplifiedLhs simplifiedRhs) $
         HashMap.map snd boolSimplEnv
       (renamedEnv, c') =
         shortenVarNames prunedEnv c { slhs = simplifiedLhs, srhs = simplifiedRhs }

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -9,11 +9,12 @@
 module Language.Fixpoint.Solver.Prettify (savePrettifiedQuery) where
 
 import           Data.Bifunctor (first)
+import           Data.Function (on)
 import           Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
-import           Data.List (intersperse)
+import           Data.List (intersperse, sortBy)
 import           Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 import           Language.Fixpoint.Misc (ensurePath)
@@ -95,7 +96,9 @@ prettyConstraint aenv bindEnv c =
         HashMap.map snd boolSimplEnv
       (renamedEnv, c') =
         shortenVarNames prunedEnv c { slhs = simplifiedLhs, srhs = simplifiedRhs }
-      prettyEnv = eraseUnusedBindings (constraintSymbols (slhs c') (srhs c')) renamedEnv
+      prettyEnv =
+        sortBy (flip compare `on` fst) $
+        eraseUnusedBindings (constraintSymbols (slhs c') (srhs c')) renamedEnv
    in hang (text "\n\nconstraint:") 2 $
           text "lhs" <+> toFix (slhs c')
       $+$ text "rhs" <+> toFix (srhs c')

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -45,11 +45,14 @@ module Language.Fixpoint.Types.Names (
   , isDummy
 
   -- * Destructors
+  , prefixOfSym
+  , suffixOfSym
   , stripPrefix
   , stripSuffix 
   , consSym
   , unconsSym
   , dropSym
+  , dropPrefixOfSym
   , headSym
   , lengthSym
 
@@ -396,6 +399,16 @@ lengthSym (symbolText -> t) = T.length t
 
 dropSym :: Int -> Symbol -> Symbol
 dropSym n (symbolText -> t) = symbol $ T.drop n t
+
+dropPrefixOfSym :: Symbol -> Symbol
+dropPrefixOfSym =
+  symbol .  T.drop (T.length symSepName) .  snd .  T.breakOn symSepName .  symbolText
+
+prefixOfSym :: Symbol -> Symbol
+prefixOfSym = symbol . fst . T.breakOn symSepName . symbolText
+
+suffixOfSym :: Symbol -> Symbol
+suffixOfSym = symbol . snd . T.breakOnEnd symSepName . symbolText
 
 stripPrefix :: Symbol -> Symbol -> Maybe Symbol
 stripPrefix p x = symbol <$> T.stripPrefix (symbolText p) (symbolText x)

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -478,10 +478,10 @@ debruijnIndex = go
 -- | Parsed refinement of @Symbol@ as @Expr@
 --   e.g. in '{v: _ | e }' v is the @Symbol@ and e the @Expr@
 newtype Reft = Reft (Symbol, Expr)
-               deriving (Eq, Data, Typeable, Generic)
+               deriving (Eq, Ord, Data, Typeable, Generic)
 
 data SortedReft = RR { sr_sort :: !Sort, sr_reft :: !Reft }
-                  deriving (Eq, Data, Typeable, Generic)
+                  deriving (Eq, Ord, Data, Typeable, Generic)
 
 sortedReftSymbols :: SortedReft -> HashSet Symbol
 sortedReftSymbols sr =

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -514,7 +514,7 @@ encodeSymConst (SL s) = litSymbol $ symbol s
 -- _decodeSymConst = fmap (SL . symbolText) . unLitSymbol
 
 instance Fixpoint SymConst where
-  toFix  = toFix . encodeSymConst
+  toFix (SL t) = text (show t)
 
 instance Fixpoint KVar where
   toFix (KV k) = text "$" <-> toFix k
@@ -539,7 +539,7 @@ instance Fixpoint Bop where
   toFix Mod    = text "mod"
 
 instance Fixpoint Expr where
-  toFix (ESym c)       = toFix $ encodeSymConst c
+  toFix (ESym c)       = toFix c
   toFix (ECon c)       = toFix c
   toFix (EVar s)       = toFix s
   toFix e@(EApp _ _)   = parens $ hcat $ punctuate " " $ toFix <$> (f:es) where (f, es) = splitEApp e

--- a/src/Language/Fixpoint/Types/Sorts.hs
+++ b/src/Language/Fixpoint/Types/Sorts.hs
@@ -61,6 +61,7 @@ module Language.Fixpoint.Types.Sorts (
   , bkAbs
   , mkPoly
   , sortSymbols
+  , substSort
 
   , isNumeric, isReal, isString, isPolyInst
 
@@ -274,6 +275,14 @@ sortSymbols = \case
   FAbs _ t -> sortSymbols t
   FApp t0 t1 -> HashSet.union (sortSymbols t0) (sortSymbols t1)
   _ -> HashSet.empty
+
+substSort :: (Symbol -> Sort) -> Sort -> Sort
+substSort f = \case
+  FObj s -> f s
+  FFunc t0 t1 -> FFunc (substSort f t0) (substSort f t1)
+  FApp t0 t1 -> FApp (substSort f t0) (substSort f t1)
+  FAbs i t -> FAbs i (substSort f t)
+  t -> t
 
 data DataField = DField
   { dfName :: !LocSymbol          -- ^ Field Name

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -140,7 +140,7 @@ instance Subable Expr where
   substf f (PImp p1 p2)    = PImp (substf f p1) (substf f p2)
   substf f (PIff p1 p2)    = PIff (substf f p1) (substf f p2)
   substf f (PAtom r e1 e2) = PAtom r (substf f e1) (substf f e2)
-  substf _ p@(PKVar _ _)   = p
+  substf f (PKVar k (Su su)) = PKVar k (Su $ M.map (substf f) su)
   substf _  (PAll _ _)     = errorstar "substf: FORALL"
   substf f (PGrad k su i e)= PGrad k su i (substf f e)
   substf _  p              = p


### PR DESCRIPTION
This is a bundle of features that I implemented to help me understand liquid-fixpoint. I can split it if necessary.

Here's the summary:
* Implemented shortening of variable names in the prettified output. This is explained in the comments of function `proposeRenamings`.
* Various bits in .fq files were printed in undeterministic order, which made hard comparing different .fq files. This PR sorts these bits.
* ESym expressions were printed in a format that couldn't be parsed. I fixed this, so .fq files are loadable when they use ESym.
* Now bindings are omitted in environments of the prettified output if they start with an uppercase letter. I think this is a filter that accurately discards bindings corresponding to top-level definitions (which are uninteresting most of the time).
* The prettified output now prefixes unused bindings with an underscore "_". Previously, the binding name was replaced with an underscore, and this made hard correlating the prettified output with other dumps.