### PR TITLE
Bottleneck pruning in AmericanFlag

### DIFF
--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -77,7 +77,7 @@ import           Language.Fixpoint.Types.Refinements
   , subst1
   )
 import           Language.Fixpoint.Types.Sorts (boolSort, sortSymbols)
-import           Language.Fixpoint.Types.Visitor (mapExpr)
+import           Language.Fixpoint.Types.Visitor (mapExprOnExpr)
 
 -- | Strips from all the constraint environments the bindings that are
 -- irrelevant for their respective constraints.
@@ -615,7 +615,7 @@ inlineInSortedReftChanged env (m, sr) =
 -- binding is allowed to have. If the binding exceeds this threshold, it
 -- is not inlined.
 inlineInExpr :: HashMap Symbol (m, SortedReft) -> Expr -> Expr
-inlineInExpr env = simplify . mapExpr inlineExpr
+inlineInExpr env = simplify . mapExprOnExpr inlineExpr
   where
     inlineExpr (EVar sym)
       | anfPrefix `isPrefixOfSym` sym

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -33,6 +33,7 @@ import           Language.Fixpoint.Graph.Deps             (isTarget)
 import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import qualified Language.Fixpoint.Solver.PLE as PLE      (instantiate)
 import           Control.Monad.State
+import           Data.Bifunctor (second)
 import qualified Data.Text            as T
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet         as S
@@ -269,7 +270,7 @@ updCtx InstEnv {..} ctx delta cidMb
                   [ initEqs 
                   , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvars r) ] 
                   ]
-    (bs, es0) = (unElab <$> binds, unElab <$> es)
+    (bs, es0) = (second unElabSortedReft <$> binds, unElab <$> es)
     es        = eRhs : (expr <$> binds) 
     eRhs      = maybe PTrue crhs subMb
     binds     = [ lookupBindEnv i ieBEnv | i <- delta ] 
@@ -313,7 +314,7 @@ isPleCstr :: AxiomEnv -> SubcId -> SimpC a -> Bool
 isPleCstr aenv sid c = isTarget c && M.lookupDefault False sid (aenvExpand aenv) 
 
 cstrExprs :: BindEnv -> SimpC a -> ([(Symbol, SortedReft)], [Expr])
-cstrExprs bds sub = (unElab <$> binds, unElab <$> es)
+cstrExprs bds sub = (second unElabSortedReft <$> binds, unElab <$> es)
   where
     es            = (crhs sub) : (expr <$> binds)
     binds         = envCs bds (senv sub)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -37,6 +37,7 @@ import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import           Language.Fixpoint.Solver.Rewrite
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
+import           Data.Bifunctor (second)
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet         as S
 import qualified Data.List            as L
@@ -353,7 +354,7 @@ updCtx InstEnv {..} ctx delta cidMb
                   , equalitiesPred (icEquals ctx)
                   , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvars r) ] 
                   ])
-    bs        = unElab <$> binds
+    bs        = second unElabSortedReft <$> binds
     (rhs:es)  = unElab <$> (eRhs : (expr <$> binds))
     eRhs      = maybe PTrue crhs subMb
     binds     = [ lookupBindEnv i ieBEnv | i <- delta ] 
@@ -848,7 +849,7 @@ class Simplifiable a where
 
 
 instance Simplifiable Expr where
-  simplify γ ictx e = mytracepp ("simplification of " ++ showpp e) $ fix (Vis.mapExpr tx) e 
+  simplify γ ictx e = mytracepp ("simplification of " ++ showpp e) $ fix (Vis.mapExprOnExpr tx) e
     where 
       fix f e = if e == e' then e else fix f e' where e' = f e 
       tx e 

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -340,12 +340,12 @@ exElim env ienv xi p = F.notracepp msg (F.pExist yts p)
                             , yi `F.memberIBindEnv` ienv                  ]
 
 applyKVars :: CombinedEnv -> Sol.Sol a Sol.QBind -> [F.KVSub] -> ExprInfo
-applyKVars g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
+applyKVars g s = mrExprInfos (applyKVar g s) F.conj mconcat
 
 applyKVar :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> ExprInfo
 applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
   Left cs   -> hypPred g s ksu cs
-  Right eqs -> (F.pAnd $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
+  Right eqs -> (F.conj $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
   where
     msg     = "applyKVar: " ++ show (ceCid g)
 
@@ -430,7 +430,7 @@ cubePredExc :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> Sol.Cube -> F.IB
 
 cubePredExc g s ksu c bs' = (cubeP, extendKInfo kI (Sol.cuTag c))
   where
-    cubeP           = (xts, psu, elabExist sp s yts' (p' &.& psu') )
+    cubeP           = (xts, psu, elabExist sp s yts' (F.conj [p', psu']) )
     sp              = F.srcSpan g
     yts'            = symSorts g bs'
     g'              = addCEnv  g bs

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -340,12 +340,12 @@ exElim env ienv xi p = F.notracepp msg (F.pExist yts p)
                             , yi `F.memberIBindEnv` ienv                  ]
 
 applyKVars :: CombinedEnv -> Sol.Sol a Sol.QBind -> [F.KVSub] -> ExprInfo
-applyKVars g s = mrExprInfos (applyKVar g s) F.conj mconcat
+applyKVars g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
 
 applyKVar :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> ExprInfo
 applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
   Left cs   -> hypPred g s ksu cs
-  Right eqs -> (F.conj $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
+  Right eqs -> (F.pAnd $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
   where
     msg     = "applyKVar: " ++ show (ceCid g)
 
@@ -430,7 +430,7 @@ cubePredExc :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> Sol.Cube -> F.IB
 
 cubePredExc g s ksu c bs' = (cubeP, extendKInfo kI (Sol.cuTag c))
   where
-    cubeP           = (xts, psu, elabExist sp s yts' (F.conj [p', psu']) )
+    cubeP           = (xts, psu, elabExist sp s yts' (p' &.& psu') )
     sp              = F.srcSpan g
     yts'            = symSorts g bs'
     g'              = addCEnv  g bs

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -118,7 +118,7 @@ instK ho env v t qc = Sol.qb . unique $
   ]
 
 unique :: [Sol.EQual] -> [Sol.EQual]
-unique = L.nubBy ((. Sol.eqPred) . (==) . Sol.eqPred)
+unique qs = M.elems $ M.fromList [ (Sol.eqPred q, q) | q <- qs ]
 
 instKSig :: Bool
          -> F.SEnv F.Sort

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -340,12 +340,12 @@ exElim env ienv xi p = F.notracepp msg (F.pExist yts p)
                             , yi `F.memberIBindEnv` ienv                  ]
 
 applyKVars :: CombinedEnv -> Sol.Sol a Sol.QBind -> [F.KVSub] -> ExprInfo
-applyKVars g s = mrExprInfos (applyKVar g s) F.pAnd mconcat
+applyKVars g s = mrExprInfos (applyKVar g s) F.pAndNoDedup mconcat
 
 applyKVar :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> ExprInfo
 applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
   Left cs   -> hypPred g s ksu cs
-  Right eqs -> (F.pAnd $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
+  Right eqs -> (F.pAndNoDedup $ fst <$> Sol.qbPreds msg s (F.ksuSubst ksu) eqs, mempty) -- TODO: don't initialize kvars that have a hyp solution
   where
     msg     = "applyKVar: " ++ show (ceCid g)
 
@@ -430,7 +430,7 @@ cubePredExc :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.KVSub -> Sol.Cube -> F.IB
 
 cubePredExc g s ksu c bs' = (cubeP, extendKInfo kI (Sol.cuTag c))
   where
-    cubeP           = (xts, psu, elabExist sp s yts' (p' &.& psu') )
+    cubeP           = (xts, psu, elabExist sp s yts' (F.pAndNoDedup [p', psu']) )
     sp              = F.srcSpan g
     yts'            = symSorts g bs'
     g'              = addCEnv  g bs

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -129,7 +129,6 @@ import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.Binary as B
-import qualified Data.HashSet as S
 
 -- import           Text.Printf               (printf)
 
@@ -170,9 +169,9 @@ instance B.Binary SrcSpan
 instance B.Binary GradInfo
 instance B.Binary Brel
 instance B.Binary KVar
-instance (Hashable a, Eq a, B.Binary a) => B.Binary (S.HashSet a) where
-  put = B.put . S.toList
-  get = S.fromList <$> B.get
+instance (Hashable a, Eq a, B.Binary a) => B.Binary (HashSet a) where
+  put = B.put . HashSet.toList
+  get = HashSet.fromList <$> B.get
 instance (Hashable k, Eq k, B.Binary k, B.Binary v) => B.Binary (M.HashMap k v) where
   put = B.put . M.toList
   get = M.fromList <$> B.get

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -39,7 +39,7 @@ module Language.Fixpoint.Types.Refinements (
   -- * Constructing Terms
   , eVar, elit
   , eProp
-  , conj, pAnd, pOr, pIte
+  , conj, pAnd, pOr, pIte, pAndNoDedup
   , (&.&), (|.|)
   , pExist
   , mkEApp
@@ -568,52 +568,58 @@ instance Fixpoint Expr where
   toFix (ECoerc a t e)   = parens (text "coerce" <+> toFix a <+> text "~" <+> toFix t <+> text "in" <+> toFix e)
   toFix (ELam (x,s) e)   = text "lam" <+> toFix x <+> ":" <+> toFix s <+> "." <+> toFix e
 
-  simplify (POr  [])     = PFalse
-  simplify (POr  [p])    = simplify p
-  simplify (PNot p) =
-    let sp = simplify p
-     in case sp of
-          PNot e -> e
-          _ -> PNot sp
-  -- XXX: Do not simplify PImp until PLE can handle it
-  -- https://github.com/ucsd-progsys/liquid-fixpoint/issues/475
-  -- simplify (PImp p q) =
-  --   let sq = simplify q
-  --    in if sq == PTrue then PTrue
-  --       else if sq == PFalse then simplify (PNot p)
-  --       else PImp (simplify p) sq
-  simplify (PIff p q)    =
-    let sp = simplify p
-        sq = simplify q
-     in if sp == sq then PTrue
-        else if sp == PTrue then sq
-        else if sq == PTrue then sp
-        else if sp == PFalse then PNot sq
-        else if sq == PFalse then PNot sp
-        else PIff sp sq
-
-  simplify (PGrad k su i e)
-    | isContraPred e      = PFalse
-    | otherwise           = PGrad k su i (simplify e)
-
-  simplify (PAnd ps)
-    | any isContraPred ps = PFalse
-                         -- Note: Performance of some tests is very sensitive to this code. See #480 
-    | otherwise           = simplPAnd . dedup . flattenRefas . filter (not . isTautoPred) $ map simplify ps
+  simplify = simplifyExpr dedup
     where
       dedup = Set.toList . Set.fromList
-      simplPAnd [] = PTrue
-      simplPAnd [p] = p
-      simplPAnd xs = PAnd xs
 
-  simplify (POr  ps)
-    | any isTautoPred ps = PTrue
-    | otherwise          = POr  $ filter (not . isContraPred) $ map simplify ps
+simplifyExpr :: ([Expr] -> [Expr]) -> Expr -> Expr
+simplifyExpr dedup = go
+  where
+    go (POr  [])     = PFalse
+    go (POr  [p])    = go p
+    go (PNot p) =
+      let sp = go p
+       in case sp of
+            PNot e -> e
+            _ -> PNot sp
+    -- XXX: Do not simplify PImp until PLE can handle it
+    -- https://github.com/ucsd-progsys/liquid-fixpoint/issues/475
+    -- go (PImp p q) =
+    --   let sq = go q
+    --    in if sq == PTrue then PTrue
+    --       else if sq == PFalse then go (PNot p)
+    --       else PImp (go p) sq
+    go (PIff p q)    =
+      let sp = go p
+          sq = go q
+       in if sp == sq then PTrue
+          else if sp == PTrue then sq
+          else if sq == PTrue then sp
+          else if sp == PFalse then PNot sq
+          else if sq == PFalse then PNot sp
+          else PIff sp sq
 
-  simplify p
-    | isContraPred p     = PFalse
-    | isTautoPred  p     = PTrue
-    | otherwise          = p
+    go (PGrad k su i e)
+      | isContraPred e      = PFalse
+      | otherwise           = PGrad k su i (go e)
+
+    go (PAnd ps)
+      | any isContraPred ps = PFalse
+                           -- Note: Performance of some tests is very sensitive to this code. See #480
+      | otherwise           = simplPAnd . dedup . flattenRefas . filter (not . isTautoPred) $ map go ps
+      where
+        simplPAnd [] = PTrue
+        simplPAnd [p] = p
+        simplPAnd xs = PAnd xs
+
+    go (POr  ps)
+      | any isTautoPred ps = PTrue
+      | otherwise          = POr  $ filter (not . isContraPred) $ map go ps
+
+    go p
+      | isContraPred p     = PFalse
+      | isTautoPred  p     = PTrue
+      | otherwise          = p
 
 isContraPred   :: Expr -> Bool
 isContraPred z = eqC z || (z `elem` contras)
@@ -873,6 +879,9 @@ conj ps  = PAnd ps
 
 pAnd, pOr     :: ListNE Pred -> Pred
 pAnd          = simplify . PAnd
+
+pAndNoDedup :: ListNE Pred -> Pred
+pAndNoDedup = simplifyExpr id . PAnd
 
 pOr           = simplify . POr
 


### PR DESCRIPTION
Here go some optimizations driven by profiling liquid-fixpoint when fed with AmericanFlag.hs.bfq

These optimizations clean up the flamegraph in #482. The remaining bottlenecks seem to be in smt interactions via pipe, serialization, and HashMap/Set lookups.