### PR TITLE
Optimize serialization of bindings

### DIFF
--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -210,6 +210,7 @@ edgeGraph :: [CEdge] -> KVGraph
 edgeGraph es = KVGraph [(v, v, vs) | (v, vs) <- groupList es ]
 
 -- need to plumb list of ebinds
+{-# SCC kvEdges #-}
 kvEdges :: (F.TaggedC c a) => F.GInfo c a -> [CEdge]
 kvEdges fi = selfes ++ concatMap (subcEdges bs) cs ++ concatMap (ebindEdges ebs bs) cs
   where
@@ -248,6 +249,7 @@ subcEdges bs c =  [(KVar k, Cstr i ) | k  <- V.envKVars bs c]
 --------------------------------------------------------------------------------
 -- | Eliminated Dependencies
 --------------------------------------------------------------------------------
+{-# SCC elimDeps #-}
 elimDeps :: (F.TaggedC c a) => F.GInfo c a -> [CEdge] -> S.HashSet F.KVar -> S.HashSet F.Symbol -> CDeps
 elimDeps si es nonKutVs ebs = graphDeps si es'
   where
@@ -312,6 +314,7 @@ dCut    v = Deps (S.singleton v) S.empty
 --------------------------------------------------------------------------------
 -- | Compute Dependencies and Cuts ---------------------------------------------
 --------------------------------------------------------------------------------
+{-# SCC elimVars #-}
 elimVars :: (F.TaggedC c a) => Config -> F.GInfo c a -> ([CEdge], Elims F.KVar)
 --------------------------------------------------------------------------------
 elimVars cfg si = (es, ds)
@@ -333,6 +336,7 @@ cutVars cfg si
 forceKuts :: (Hashable a, Eq a) => S.HashSet a -> Elims a  -> Elims a
 forceKuts xs (Deps cs ns) = Deps (S.union cs xs) (S.difference ns xs)
 
+{-# SCC edgeDeps #-}
 edgeDeps :: (F.TaggedC c a) => Config -> F.GInfo c a -> [CEdge] -> Elims F.KVar
 edgeDeps cfg si  = forceKuts ks
                  . edgeDeps' cfg

--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -180,12 +180,12 @@ succs :: (F.TaggedC c a) => CMap (c a) -> KVRead -> CMap [F.SubcId]
 succs cm rdBy = sortNub . concatMap kvReads . kvWrites <$> cm
   where
     kvReads k = M.lookupDefault [] k rdBy
-    kvWrites  = V.kvars . F.crhs
+    kvWrites  = V.kvarsExpr . F.crhs
 
 --------------------------------------------------------------------------------
 kvWriteBy :: (F.TaggedC c a) => CMap (c a) -> F.SubcId -> [F.KVar]
 --------------------------------------------------------------------------------
-kvWriteBy cm = V.kvars . F.crhs . lookupCMap cm
+kvWriteBy cm = V.kvarsExpr . F.crhs . lookupCMap cm
 
 --------------------------------------------------------------------------------
 kvReadBy :: (F.TaggedC c a) => F.GInfo c a -> KVRead

--- a/src/Language/Fixpoint/Graph/Reducible.hs
+++ b/src/Language/Fixpoint/Graph/Reducible.hs
@@ -59,4 +59,4 @@ isBackEdge t (u,v) = v `elem` xs
 
 subcEdges' :: (F.TaggedC c a) => (F.KVar -> Node) -> F.BindEnv -> c a -> [(Node, Node)]
 subcEdges' kvI be c = [(kvI k1, kvI k2) | k1 <- V.envKVars be c
-                                        , k2 <- V.kvars $ F.crhs c]
+                                        , k2 <- V.kvarsExpr $ F.crhs c]

--- a/src/Language/Fixpoint/Graph/Types.hs
+++ b/src/Language/Fixpoint/Graph/Types.hs
@@ -132,6 +132,10 @@ txEdges es = concatMap iEs is
 -- | Dramatis Personae
 ---------------------------------------------------------------------------
 type KVRead  = M.HashMap F.KVar [F.SubcId]
+-- | (Constraint id, vertex key, edges to other constraints)
+--
+-- The vertex key is always equal to the constraint id. The redundancy
+-- is imposed by how @containers:Data.Graph@ requires graphs to be created.
 type DepEdge = (F.SubcId, F.SubcId, [F.SubcId])
 
 data Slice = Slice { slKVarCs :: [F.SubcId]     -- ^ F.SubcIds that transitively "reach" below
@@ -139,11 +143,21 @@ data Slice = Slice { slKVarCs :: [F.SubcId]     -- ^ F.SubcIds that transitively
                    , slEdges  :: [DepEdge] -- ^ Dependencies between slKVarCs
                    } deriving (Eq, Show)
 
-data CGraph = CGraph { gEdges :: [DepEdge]
-                     , gRanks :: !(F.CMap Int)
-                     , gSucc  :: !(F.CMap [F.SubcId])
-                     , gSccs  :: !Int
-                     }
+data CGraph = CGraph
+  { gEdges :: [DepEdge]
+    -- | Maps a constraint id to an index identifying the strongly connected
+    -- component to which it belongs.
+    -- The scc indices correspond with a topological ordering of the sccs.
+  , gRanks :: !(F.CMap Int)
+    -- | Tells for each constraint C, which constraints read any kvars that
+    -- C writes.
+    --
+    -- This is redundant with 'gEdges', so both fields need to express the
+    -- exact same dependencies.
+  , gSucc  :: !(F.CMap [F.SubcId])
+    -- | Amount of strongly connected components
+  , gSccs  :: !Int
+  }
 
 ---------------------------------------------------------------------------
 -- | CMap API -------------------------------------------------------------

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -182,10 +182,10 @@ mfromJust _ (Just x) = x
 mfromJust s Nothing  = errorstar $ "mfromJust: Nothing " ++ s
 
 inserts ::  (Eq k, Hashable k) => k -> v -> M.HashMap k [v] -> M.HashMap k [v]
-inserts k v m = M.insert k (v : M.lookupDefault [] k m) m
+inserts k v m = M.insertWith (const (v:)) k [v] m
 
 removes ::  (Eq k, Hashable k, Eq v) => k -> v -> M.HashMap k [v] -> M.HashMap k [v]
-removes k v m = M.insert k (L.delete v (M.lookupDefault [] k m)) m
+removes k v m = M.insertWith (const (L.delete v)) k [] m
 
 count :: (Eq k, Hashable k) => [k] -> [(k, Int)]
 count = M.toList . fmap sum . group . fmap (, 1)

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -19,6 +19,7 @@ import           Control.Monad                    (when, forM_, filterM)
 import qualified Data.HashMap.Strict              as M
 import qualified Data.List                        as L
 import qualified Data.HashSet                     as S
+import qualified Data.Set                         as Set
 import           Data.Tuple                       (swap)
 import           Data.Maybe
 import           Data.Array                       hiding (indices)
@@ -209,7 +210,7 @@ hashNub :: (Eq k, Hashable k) => [k] -> [k]
 hashNub = M.keys . M.fromList . fmap (, ())
 
 sortNub :: (Ord a) => [a] -> [a]
-sortNub = nubOrd . L.sort
+sortNub = Set.toList . Set.fromList
 
 sortNubBy :: (Eq a) => (a -> a -> Ordering) -> [a] -> [a]
 sortNubBy f = nubOrd . L.sortBy f

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -19,7 +19,6 @@ import           Control.Monad                    (when, forM_, filterM)
 import qualified Data.HashMap.Strict              as M
 import qualified Data.List                        as L
 import qualified Data.HashSet                     as S
-import qualified Data.Set                         as Set
 import           Data.Tuple                       (swap)
 import           Data.Maybe
 import           Data.Array                       hiding (indices)
@@ -210,7 +209,7 @@ hashNub :: (Eq k, Hashable k) => [k] -> [k]
 hashNub = M.keys . M.fromList . fmap (, ())
 
 sortNub :: (Ord a) => [a] -> [a]
-sortNub = Set.toList . Set.fromList
+sortNub = nubOrd . L.sort
 
 sortNubBy :: (Eq a) => (a -> a -> Ordering) -> [a] -> [a]
 sortNubBy f = nubOrd . L.sortBy f

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -59,6 +59,7 @@ module Language.Fixpoint.Smt.Interface (
     -- * Query API
     , smtDecl
     , smtDecls
+    , smtDefineFunc
     , smtAssert
     , smtFuncDecl
     , smtAssertAxiom
@@ -427,6 +428,15 @@ smtCheckSat me p
 smtAssert :: Context -> Expr -> IO ()
 smtAssert me p  = interact' me (Assert Nothing p)
 
+smtDefineFunc :: Context -> Symbol -> [(Symbol, F.Sort)] -> F.Sort -> Expr -> IO ()
+smtDefineFunc me name params rsort e =
+  let env = seData (ctxSymEnv me)
+   in interact' me $
+        DefineFunc
+          name
+          (map (sortSmtSort False env <$>) params)
+          (sortSmtSort False env rsort)
+          e
 
 -----------------------------------------------------------------
 -- Async calls to the smt

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -53,7 +53,8 @@ module Language.Fixpoint.Smt.Interface (
 
     -- * Execute Queries
     , command
-    , smtWrite
+    , smtExit
+    , smtSetMbqi
 
     -- * Query API
     , smtDecl
@@ -191,6 +192,11 @@ command me !cmd       = say cmd >> hear cmd
     hear (GetValue _) = smtRead me
     hear _            = return Ok
 
+smtExit :: Context -> IO ()
+smtExit me = asyncCommand me Exit
+
+smtSetMbqi :: Context -> IO ()
+smtSetMbqi me = asyncCommand me SetMbqi
 
 smtWrite :: Context -> Raw -> IO ()
 smtWrite me !s = smtWriteRaw me s

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -244,6 +244,8 @@ instance SMTLIB2 Command where
   smt2 _   (CheckSat)          = "(check-sat)"
   smt2 env (GetValue xs)       = key "key-value" (parens (smt2s env xs))
   smt2 env (CMany cmds)        = smt2many (smt2 env <$> cmds)
+  smt2 _   (Exit)              = "(exit)"
+  smt2 _   (SetMbqi)           = "(set-option :smt.mbqi true)"
 
 instance SMTLIB2 (Triggered Expr) where
   smt2 env (TR NoTrigger e)       = smt2 env e

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -233,6 +233,9 @@ instance SMTLIB2 Command where
   smt2 env (DeclData ds)       = key "declare-datatypes" (smt2data env ds)
   smt2 env (Declare x ts t)    = parenSeqs ["declare-fun", Builder.fromText x, parens (smt2many (smt2 env <$> ts)), smt2 env t]
   smt2 env c@(Define t)        = key "declare-sort" (smt2SortMono c env t)
+  smt2 env (DefineFunc name params rsort e) =
+    let bParams = [ parenSeqs [smt2 env s, smt2 env t] | (s, t) <- params]
+     in parenSeqs ["define-fun", smt2 env name, parenSeqs bParams, smt2 env rsort, smt2 env e]
   smt2 env (Assert Nothing p)  = {-# SCC "smt2-assert" #-} key "assert" (smt2 env p)
   smt2 env (Assert (Just i) p) = {-# SCC "smt2-assert" #-} key "assert" (parens ("!"<+> smt2 env p <+> ":named p-" <> bShow i))
   smt2 env (Distinct az)

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -53,6 +53,7 @@ data Command      = Push
                   | DeclData ![DataDecl]
                   | Declare  T.Text [SmtSort] !SmtSort
                   | Define   !Sort
+                  | DefineFunc Symbol [(Symbol, SmtSort)] !SmtSort Expr
                   | Assert   !(Maybe Int) !Expr
                   | AssertAx !(Triggered Expr)
                   | Distinct [Expr] -- {v:[Expr] | 2 <= len v}
@@ -73,6 +74,8 @@ ppCmd (DeclData d)     = text "Data" <+> pprint d
 ppCmd (Declare x [] t) = text "Declare" <+> text (T.unpack x) <+> text ":" <+> pprint t
 ppCmd (Declare x ts t) = text "Declare" <+> text (T.unpack x) <+> text ":" <+> parens (pprint ts) <+> pprint t
 ppCmd (Define {})   = text "Define ..."
+ppCmd (DefineFunc name params rsort e) =
+  text "DefineFunc" <+> pprint name <+> pprint params <+> pprint rsort <+> pprint e
 ppCmd (Assert _ e)  = text "Assert" <+> pprint e
 ppCmd (AssertAx _)  = text "AssertAxiom ..."
 ppCmd (Distinct {}) = text "Distinct ..."

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -47,6 +47,8 @@ import           System.Process
 -- | Commands issued to SMT engine
 data Command      = Push
                   | Pop
+                  | Exit
+                  | SetMbqi
                   | CheckSat
                   | DeclData ![DataDecl]
                   | Declare  T.Text [SmtSort] !SmtSort
@@ -62,6 +64,8 @@ instance PPrint Command where
   pprintTidy _ = ppCmd
 
 ppCmd :: Command -> Doc
+ppCmd Exit             = text "Exit"
+ppCmd SetMbqi          = text "SetMbqi"
 ppCmd Push             = text "Push"
 ppCmd Pop              = text "Pop"
 ppCmd CheckSat         = text "CheckSat"

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -13,7 +13,7 @@ import qualified Data.HashMap.Strict as M
 import           Language.Fixpoint.Types.Config    (Config)
 import qualified Language.Fixpoint.Types.Solutions as Sol
 import           Language.Fixpoint.Types
-import           Language.Fixpoint.Types.Visitor   (kvars, isConcC)
+import           Language.Fixpoint.Types.Visitor   (kvarsExpr, isConcC)
 import           Language.Fixpoint.Graph
 import           Language.Fixpoint.Misc            (safeLookup, group, errorstar)
 import           Language.Fixpoint.Solver.Sanitize
@@ -72,7 +72,7 @@ kIndex     :: SInfo a -> KIndex
 kIndex si  = group [(k, i) | (i, c) <- iCs, k <- rkvars c]
   where
     iCs    = M.toList (cm si)
-    rkvars = kvars . crhs
+    rkvars = kvarsExpr . crhs
 
 nonCutHyps :: SInfo a -> KIndex -> S.HashSet KVar -> [(KVar, Sol.Hyp)]
 nonCutHyps si kI nKs = [ (k, nonCutHyp kI si k) | k <- S.toList nKs ]

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -22,6 +22,7 @@ import           Language.Fixpoint.Solver.Sanitize
 -- | `solverInfo` constructs a `SolverInfo` comprising the Solution and various
 --   indices needed by the worklist-based refinement loop
 --------------------------------------------------------------------------------
+{-# SCC solverInfo #-}
 solverInfo :: Config -> SInfo a -> SolverInfo a b
 --------------------------------------------------------------------------------
 solverInfo cfg sI = SI sHyp sI' cD cKs

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -268,7 +268,7 @@ updCtx InstEnv {..} ctx delta cidMb
     cands     = (S.fromList (concatMap topApps es0)) `S.difference` (icSolved ctx)
     ctxEqs    = toSMT ieCfg ieSMT [] <$> concat 
                   [ initEqs 
-                  , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvars r) ] 
+                  , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvarsExpr $ reftPred $ sr_reft r) ]
                   ]
     (bs, es0) = (second unElabSortedReft <$> binds, unElab <$> es)
     es        = eRhs : (expr <$> binds) 
@@ -334,7 +334,7 @@ evaluate cfg ctx aenv facts es sid = do
   let cands    = mytracepp  ("evaluate-cands " ++ showpp sid) $ Misc.hashNub (concatMap topApps es)
   let s0       = EvalEnv 0 [] aenv (SMT.ctxSymEnv ctx) cfg
   let ctxEqs   = [ toSMT cfg ctx [] (EEq e1 e2) | (e1, e2)  <- eqs ]
-              ++ [ toSMT cfg ctx [] (expr xr)   | xr@(_, r) <- facts, null (Vis.kvars r) ] 
+              ++ [ toSMT cfg ctx [] (expr xr)   | xr@(_, r) <- facts, null (Vis.kvarsExpr $ reftPred $ sr_reft r) ]
   eqss        <- _evalLoop cfg ctx γ s0 ctxEqs cands 
   return       $ eqs ++ eqss
 
@@ -694,7 +694,7 @@ initEqualities ctx aenv es = concatMap (makeSimplifications (aenvSimpl aenv)) dc
 askSMT :: Config -> SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
 askSMT cfg ctx bs e
   | isTautoPred  e     = return True
-  | null (Vis.kvars e) = SMT.checkValidWithContext ctx [] PTrue e'
+  | null (Vis.kvarsExpr e) = SMT.checkValidWithContext ctx [] PTrue e'
   | otherwise          = return False
   where 
     e'                 = toSMT cfg ctx bs e 

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -167,6 +167,7 @@ filterValid sp p qs = do
   incVald (length qs')
   return qs'
 
+{-# SCC filterValid_ #-}
 filterValid_ :: F.SrcSpan -> F.Expr -> F.Cand a -> Context -> IO [a]
 filterValid_ sp p qs me = catMaybes <$> do
   smtAssertAsync me p

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -140,6 +140,7 @@ sendConcreteBindingsToSMT known act = do
         [ (i, F.subst1 p (v, F.EVar s))
         | (i, s, F.RR _ (F.Reft (v, p))) <- F.bindEnvToList be
         , F.isConc p
+        , not (isShortExpr p)
         , not (F.memberIBindEnv i known)
         ]
   st <- get
@@ -148,6 +149,10 @@ sendConcreteBindingsToSMT known act = do
       forM_ concretePreds $ \(i, e) ->
         smtDefineFunc me (F.bindSymbol (fromIntegral i)) [] F.boolSort e
       flip evalStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
+  where
+    isShortExpr F.PTrue = True
+    isShortExpr F.PTop = True
+    isShortExpr _ = False
 
 -- | `filterRequired [(x1, p1),...,(xn, pn)] q` returns a minimal list [xi] s.t.
 --   /\ [pi] => q

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -76,7 +76,7 @@ runSolverM :: Config -> SolverInfo b c -> SolveM a -> IO a
 runSolverM cfg sI act =
   bracket acquire release $ \ctx -> do
     res <- runStateT act' (s0 ctx)
-    smtWrite ctx "(exit)"
+    smtExit ctx
     return (fst res)
   where
     s0 ctx   = SS ctx be (stats0 fi)
@@ -216,8 +216,7 @@ filterValidOne_ p qs me = do
 
 smtEnablembqi :: SolveM ()
 smtEnablembqi
-  = withContext $ \me ->
-      smtWrite me "(set-option :smt.mbqi true)"
+  = withContext smtSetMbqi
 
 --------------------------------------------------------------------------------
 checkSat :: F.Expr -> SolveM  Bool

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -62,6 +62,7 @@ traceE (e,e')
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE 
 --------------------------------------------------------------------------------
+{-# SCC instantiate #-}
 instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
 instantiate cfg fi' subcIds = do
     let cs = M.filterWithKey

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -353,7 +353,7 @@ updCtx InstEnv {..} ctx delta cidMb
                   [ equalitiesPred initEqs 
                   , equalitiesPred sims 
                   , equalitiesPred (icEquals ctx)
-                  , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvars r) ] 
+                  , [ expr xr   | xr@(_, r) <- bs, null (Vis.kvarsExpr $ reftPred $ sr_reft r) ]
                   ])
     bs        = second unElabSortedReft <$> binds
     (rhs:es)  = unElab <$> (eRhs : (expr <$> binds))
@@ -803,7 +803,7 @@ askSMT :: Config -> SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
 askSMT cfg ctx bs e
 --   | isContraPred e     = return False 
   | isTautoPred  e     = return True
-  | null (Vis.kvars e) = SMT.checkValidWithContext ctx [] PTrue e'
+  | null (Vis.kvarsExpr e) = SMT.checkValidWithContext ctx [] PTrue e'
   | otherwise          = return False
   where 
     e'                 = toSMT "askSMT" cfg ctx bs e 

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -268,10 +268,16 @@ okInst env v t eq = isNothing tc
 -- | Predicate corresponding to LHS of constraint in current solution
 --------------------------------------------------------------------------------
 {-# SCC lhsPred #-}
-lhsPred :: (F.Loc a) => F.BindEnv -> Sol.Solution -> F.SimpC a -> F.Expr
-lhsPred be s c = F.notracepp _msg $ fst $ apply g s bs
+lhsPred
+  :: (F.Loc a)
+  => F.IBindEnv
+  -> F.BindEnv
+  -> Sol.Solution
+  -> F.SimpC a
+  -> F.Expr
+lhsPred bindingsInSmt be s c = F.notracepp _msg $ fst $ apply g s bs
   where
-    g          = CEnv ci be bs (F.srcSpan c)
+    g          = CEnv ci be bs (F.srcSpan c) bindingsInSmt
     bs         = F.senv c
     ci         = sid c
     _msg       = "LhsPred for id = " ++ show (sid c) ++ " with SOLUTION = " ++ F.showpp s
@@ -281,6 +287,10 @@ data CombinedEnv = CEnv
   , ceBEnv :: !F.BindEnv
   , ceIEnv :: !F.IBindEnv 
   , ceSpan :: !F.SrcSpan
+    -- | These are the bindings that the smt solver knows about and can be
+    -- referred as @EVar (bindSymbol <bindId>)@ instead of serializing them
+    -- again.
+  , ceBindingsInSmt :: !F.IBindEnv
   }
 
 instance F.Loc CombinedEnv where 
@@ -292,7 +302,10 @@ type ExprInfo    = (F.Expr, KInfo)
 apply :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.IBindEnv -> ExprInfo
 apply g s bs      = (F.conj (pks:ps), kI)   -- see [NOTE: pAnd-SLOW]
   where
-    (pks, kI)     = applyKVars g s ks  
+    -- Clear the "known" bindings for applyKVars, since it depends on
+    -- using the fully expanded representation of the predicates to bind their
+    -- variables with quantifiers.
+    (pks, kI)     = applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
     (ps,  ks, _)  = envConcKVars g s bs
 
 
@@ -304,8 +317,10 @@ envConcKVars g s bs = (concat pss, concat kss, L.nubBy (\x y -> F.ksuKVar x == F
     is              = F.elemsIBindEnv bs
 
 lookupBindEnvExt :: CombinedEnv -> Sol.Sol a Sol.QBind -> F.BindId -> (F.Symbol, F.SortedReft)
-lookupBindEnvExt g s i 
-  | Just p <- ebSol g s i = (x, sr { F.sr_reft = F.Reft (x, p) }) 
+lookupBindEnvExt g s i
+  | Just p <- ebSol g {ceBindingsInSmt = F.emptyIBindEnv} s i = (x, sr { F.sr_reft = F.Reft (x, p) })
+  | F.memberIBindEnv i (ceBindingsInSmt g) =
+      (x, sr { F.sr_reft = F.Reft (x, F.EVar (F.bindSymbol (fromIntegral i)))})
   | otherwise             = (x, sr)
    where 
       (x, sr)              = F.lookupBindEnv i (ceBEnv g) 
@@ -352,7 +367,7 @@ applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
 
 nonCutsResult :: F.BindEnv -> Sol.Sol a Sol.QBind -> M.HashMap F.KVar F.Expr
 nonCutsResult be s =
-  let g = CEnv Nothing be F.emptyIBindEnv F.dummySpan
+  let g = CEnv Nothing be F.emptyIBindEnv F.dummySpan F.emptyIBindEnv
    in M.mapWithKey (mkNonCutsExpr g) $ Sol.sHyp s
   where
     mkNonCutsExpr g k cs = F.pOr $ map (bareCubePred g s k) cs

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -555,7 +555,7 @@ symSorts :: CombinedEnv -> F.IBindEnv -> [(F.Symbol, F.Sort)]
 symSorts g bs = second F.sr_sort <$> F.envCs (ceBEnv g) bs
 
 _noKvars :: F.Expr -> Bool
-_noKvars = null . V.kvars
+_noKvars = null . V.kvarsExpr
 
 --------------------------------------------------------------------------------
 -- | Information about size of formula corresponding to an "eliminated" KVar.

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -80,6 +80,7 @@ siKvars :: F.SInfo a -> S.HashSet F.KVar
 siKvars = S.fromList . M.keys . F.ws
 
 
+{-# SCC doPLE #-}
 doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM ()
 doPLE cfg fi0 subcIds = do
   fi <- liftIO $ instantiate cfg fi0 (Just subcIds)
@@ -91,6 +92,7 @@ doPLE cfg fi0 subcIds = do
         sI  = solverInfo cfg fi
 
 --------------------------------------------------------------------------------
+{-# SCC solve_ #-}
 solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
        => Config
        -> F.SInfo a
@@ -132,6 +134,7 @@ tidyPred :: F.Expr -> F.Expr
 tidyPred = F.substf (F.eVar . F.tidySymbol)
 
 --------------------------------------------------------------------------------
+{-# SCC refine #-}
 refine :: (F.Loc a) => Sol.Solution -> W.Worklist a -> SolveM Sol.Solution
 --------------------------------------------------------------------------------
 refine s w
@@ -184,6 +187,7 @@ predKs _              = []
 --------------------------------------------------------------------------------
 -- | Convert Solution into Result ----------------------------------------------
 --------------------------------------------------------------------------------
+{-# SCC result #-}
 result :: (F.Fixpoint a, F.Loc a, NFData a) => Config -> W.Worklist a -> Sol.Solution
        -> SolveM (F.Result (Integer, a))
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/TrivialSort.hs
+++ b/src/Language/Fixpoint/Solver/TrivialSort.hs
@@ -92,7 +92,7 @@ updTIBinds be ti = foldl' (flip (updTI Lhs)) ti ts
 --------------------------------------------------------------------
 updTI :: Polarity -> SortedReft -> TrivInfo -> TrivInfo
 --------------------------------------------------------------------
-updTI p (RR t r) = addKVs t (kvars r) . addNTS p r t
+updTI p (RR t r) = addKVs t (kvarsExpr $ reftPred r) . addNTS p r t
 
 addNTS :: Polarity -> Reft -> Sort -> TrivInfo -> TrivInfo
 addNTS p r t ti

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -422,7 +422,10 @@ stripSuffix p x = symbol <$> T.stripSuffix (symbolText p) (symbolText x)
 -- | Use this **EXCLUSIVELY** when you want to add stuff in front of a Symbol
 --------------------------------------------------------------------------------
 suffixSymbol :: Symbol -> Symbol -> Symbol
-suffixSymbol  x y = x `mappendSym` symSepName `mappendSym` y
+suffixSymbol  x y = symbol $ suffixSymbolText (symbolText x) (symbolText y)
+
+suffixSymbolText :: T.Text -> T.Text -> T.Text
+suffixSymbolText  x y = x <> symSepName <> y
 
 vv                  :: Maybe Integer -> Symbol
 -- vv (Just i)         = symbol $ symbolSafeText vvName `T.snoc` symSepName `mappend` T.pack (show i)
@@ -459,7 +462,7 @@ unLitSymbol :: Symbol -> Maybe Symbol
 unLitSymbol = stripPrefix litPrefix
 
 intSymbol :: (Show a) => Symbol -> a -> Symbol
-intSymbol x i = x `suffixSymbol` symbol (show i)
+intSymbol x i = symbol $ symbolText x `suffixSymbolText` T.pack (show i)
 
 appendSymbolText :: Symbol -> T.Text -> T.Text
 appendSymbolText s t = encode (symbolText s <> symSepName <> t)

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -76,6 +76,7 @@ module Language.Fixpoint.Types.Names (
 
   -- * Wrapping Symbols
   , litSymbol
+  , bindSymbol
   , testSymbol
   , renameSymbol
   , kArgSymbol
@@ -482,12 +483,19 @@ existSymbol prefix = intSymbol (existPrefix `mappendSym` prefix)
 gradIntSymbol :: Integer -> Symbol
 gradIntSymbol = intSymbol gradPrefix
 
-tempPrefix, anfPrefix, renamePrefix, litPrefix, gradPrefix :: Symbol
+-- | Used to define functions corresponding to binding predicates
+--
+-- The integer is the BindId.
+bindSymbol :: Integer -> Symbol
+bindSymbol = intSymbol bindPrefix
+
+tempPrefix, anfPrefix, renamePrefix, litPrefix, gradPrefix, bindPrefix :: Symbol
 tempPrefix   = "lq_tmp$"
 anfPrefix    = "lq_anf$"
 renamePrefix = "lq_rnm$"
 litPrefix    = "lit$"
 gradPrefix   = "grad$"
+bindPrefix   = "b$"
 
 testPrefix  :: Symbol
 testPrefix   = "is$"

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -326,6 +326,7 @@ eapps                 = fold eappVis () []
     eapp' _ e@(EApp _ _) = [e]
     eapp' _ _            = []
 
+{-# SCC kvars #-}
 kvars :: Visitable t => t -> [KVar]
 kvars                 = fold kvVis () []
   where

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -39,7 +39,7 @@ module Language.Fixpoint.Types.Visitor (
   , applyCoSub
 
   -- * Predicates on Constraints
-  , isConcC , isKvarC
+  , isConcC , isConc, isKvarC
 
   -- * Sorts
   , foldSort


### PR DESCRIPTION
This PR does a few clean ups and an optimization for serialization.

Before this PR, bindings of constraints were serialized for each constraint. If two constraints shared some bindings, these bindings would be serialized twice. This overhead turned out to be substantial for the Step.hs module of stitch-lh.

This PR reduces the overhead by defining functions for the bindings via smtlib2 as explained in #494. The benchmarks of LH do not improve much, but verification of Step.hs.bfq in LF goes from 17 seconds to 11 seconds. The overhead of serialization, initially at 40%, goes to 4%, and PLE takes most of the verification time now.

At the moment, bindings are serialized before the fixpoint calculation and after PLE. Two further improvements to do in subsequent PRs would be:
* Have PLE use the serialized bindings. Right now it ignores them.
* Have PLE not modify existing bindings as a result, but instead add new bindings with the new equations.