### PR TITLE
Check the tree like invariant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ version: 2.0
 
 jobs:
   build:
-    docker:
-      - image: fpco/stack-build:lts-16.8
+    machine:
+      image: ubuntu-2004:202107-02
     steps:
+      - run: sudo apt-get update && sudo apt-get install -y curl git ssh unzip wget libtinfo-dev gcc make
       - add_ssh_keys
       - run: 
           name: Install z3 
@@ -13,24 +14,25 @@ jobs:
             wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip
             unzip z3-4.8.7-x64-ubuntu-16.04.zip
             rm -f z3-4.8.7-x64-ubuntu-16.04.zip
-            cp z3-4.8.7-x64-ubuntu-16.04/bin/libz3.a /usr/local/lib
-            cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
-            cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
+            sudo cp z3-4.8.7-x64-ubuntu-16.04/bin/libz3.a /usr/local/lib
+            sudo cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
+            sudo cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
             rm -rf z3-4.8.7-x64-ubuntu-16.04
             z3 --version
 
       - checkout
       - restore_cache:
           keys:
-            - stack-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
-            - stack-{{ checksum "stack.yaml" }}
+            - stack-cache-v1-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
+            - stack-cache-v1-{{ checksum "stack.yaml" }}
       - run:
           name: Dependencies
           command: |
+            wget -qO- https://get.haskellstack.org/ | sudo sh
             stack --no-terminal setup
             stack --no-terminal build -j2 liquid-fixpoint --only-dependencies --test --no-run-tests
       - save_cache:
-          key: stack-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
+          key: stack-cache-v1-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
           paths:
             - ~/.stack
             - ./.stack-work
@@ -43,10 +45,9 @@ jobs:
           command: |
             mkdir -p /tmp/junit
             stack --no-terminal test -j2 liquid-fixpoint:test --flag liquid-fixpoint:devel --test-arguments="--xml=/tmp/junit/main-test-results.xml":
-            stack --no-terminal haddock --flag liquid-fixpoint:devel
-            stack --no-terminal sdist
+            stack --no-terminal haddock --flag liquid-fixpoint:devel --test --no-run-tests --no-haddock-deps --haddock-arguments="--no-print-missing-docs"
             # mkdir -p $CIRCLE_TEST_REPORTS/tasty
             # cp -r tests/logs/cur $CIRCLE_TEST_REPORTS/tasty/log
       - run:
           name: Dist
-          command: stack sdist
+          command: stack --no-terminal sdist

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -144,11 +144,13 @@ sendConcreteBindingsToSMT known act = do
         , not (F.memberIBindEnv i known)
         ]
   st <- get
-  withContext $ \me -> do
+  (a, st') <- withContext $ \me -> do
     smtBracket me "" $ do
       forM_ concretePreds $ \(i, e) ->
         smtDefineFunc me (F.bindSymbol (fromIntegral i)) [] F.boolSort e
-      flip evalStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
+      flip runStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
+  put st'
+  return a
   where
     isShortExpr F.PTrue = True
     isShortExpr F.PTop = True

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -327,7 +327,7 @@ updCtxRes res iMb ctx = (ctx, res')
 
 
 updRes :: InstRes -> Maybe BindId -> Expr -> InstRes
-updRes res (Just i) e = M.insert i e res 
+updRes res (Just i) e = M.insertWith (error "tree-like invariant broken in ple. See https://github.com/ucsd-progsys/liquid-fixpoint/issues/496") i e res
 updRes res  Nothing _ = res 
 
 ---------------------------------------------------------------------------------------------- 

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -850,7 +850,7 @@ outVV (m, fi) i c = (m', fi')
 
 type BindM = M.HashMap Integer BindId
 
-sinfoToFInfo :: Fixpoint a => SInfo a -> FInfo a
+sinfoToFInfo :: SInfo a -> FInfo a
 sinfoToFInfo fi = fi
   { bs = envWithoutLhss
   , cm = simpcToSubc (bs fi) <$> cm fi


### PR DESCRIPTION
Gives feedback to the user when the tree-like invariant doesn't hold.
This is a temporary remedy until we fix #496.