### PR TITLE
Factor out askSMT and toSMT

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -65,6 +65,7 @@ library
                     Language.Fixpoint.Smt.Theories
                     Language.Fixpoint.Smt.Types
                     Language.Fixpoint.Solver
+                    Language.Fixpoint.Solver.Common
                     Language.Fixpoint.Solver.Eliminate
                     Language.Fixpoint.Solver.EnvironmentReduction
                     Language.Fixpoint.Solver.GradualSolution

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Language.Fixpoint.Solver.Common (askSMT, toSMT) where
+
+import Language.Fixpoint.Types.Config
+import Language.Fixpoint.Smt.Interface
+import Language.Fixpoint.Types
+import qualified Language.Fixpoint.Types.Visitor as Vis
+import Language.Fixpoint.Defunctionalize (defuncAny)
+import Language.Fixpoint.SortCheck (elaborate)
+
+mytracepp :: (PPrint a) => String -> a -> a
+mytracepp = notracepp
+
+askSMT :: Config -> Context -> [(Symbol, Sort)] -> Expr -> IO Bool
+askSMT cfg ctx bs e
+--   | isContraPred e      = return False
+  | isTautoPred  e         = return True
+  | null (Vis.kvarsExpr e) = checkValidWithContext ctx [] PTrue e'
+  | otherwise              = return False
+  where
+    e' = toSMT "askSMT" cfg ctx bs e
+
+toSMT :: String -> Config -> Context -> [(Symbol, Sort)] -> Expr -> Pred
+toSMT msg cfg ctx bs e =
+    defuncAny cfg senv .
+        elaborate "makeKnowledge" (elabEnv bs) .
+            mytracepp ("toSMT from " ++ msg ++ showpp e) $
+                e
+  where
+    elabEnv = insertsSymEnv senv
+    senv    = ctxSymEnv ctx

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -2,10 +2,10 @@
 
 module Language.Fixpoint.Solver.Common (askSMT, toSMT) where
 
-import Language.Fixpoint.Types.Config
-import Language.Fixpoint.Smt.Interface
+import Language.Fixpoint.Types.Config (Config)
+import Language.Fixpoint.Smt.Interface (Context(..), checkValidWithContext)
 import Language.Fixpoint.Types
-import qualified Language.Fixpoint.Types.Visitor as Vis
+import Language.Fixpoint.Types.Visitor (kvarsExpr)
 import Language.Fixpoint.Defunctionalize (defuncAny)
 import Language.Fixpoint.SortCheck (elaborate)
 
@@ -14,10 +14,10 @@ mytracepp = notracepp
 
 askSMT :: Config -> Context -> [(Symbol, Sort)] -> Expr -> IO Bool
 askSMT cfg ctx bs e
---   | isContraPred e      = return False
-  | isTautoPred  e         = return True
-  | null (Vis.kvarsExpr e) = checkValidWithContext ctx [] PTrue e'
-  | otherwise              = return False
+--   | isContraPred e  = return False
+  | isTautoPred  e     = return True
+  | null (kvarsExpr e) = checkValidWithContext ctx [] PTrue e'
+  | otherwise          = return False
   where
     e' = toSMT "askSMT" cfg ctx bs e
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -30,6 +30,7 @@ import qualified Language.Fixpoint.Utils.Trie    as T
 import           Language.Fixpoint.Utils.Progress
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Graph.Deps             (isTarget)
+import           Language.Fixpoint.Solver.Common          (askSMT, toSMT)
 import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import           Language.Fixpoint.Solver.Rewrite
 
@@ -1001,23 +1002,6 @@ knowledge cfg ctx si = KN
       = (smName rw,) . (smDC rw,) <$> L.elemIndex x (smArgs rw)
       | otherwise
       = Nothing
-
-askSMT :: Config -> SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
-askSMT cfg ctx bs e
---   | isContraPred e     = return False
-  | isTautoPred  e     = return True
-  | null (Vis.kvarsExpr e) = SMT.checkValidWithContext ctx [] PTrue e'
-  | otherwise          = return False
-  where
-    e'                 = toSMT "askSMT" cfg ctx bs e
-
-toSMT :: String ->  Config -> SMT.Context -> [(Symbol, Sort)] -> Expr -> Pred
-toSMT msg cfg ctx bs e = defuncAny cfg senv . elaborate "makeKnowledge" (elabEnv bs) . mytracepp ("toSMT from " ++ msg ++ showpp e)
-                          $ e
-  where
-    elabEnv      = insertsSymEnv senv
-    senv         = SMT.ctxSymEnv ctx
-
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------


### PR DESCRIPTION
There were two copies of `askSMT` and `toSMT` in `Instantiate.hs` and `PLE.hs`. I moved the implementations to `Common.hs`.

This is a simple code hygiene change. It may be that there are plans for the implementations of `askSMT` and `toSMT` in `Instantiate.hs` and `PLE.hs` to evolve separately. In that case we can either merge this and fork the implementations again once they do need to evolve separately, or this PR can be rejected.