### PR TITLE
Fix non-termination of deANF

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -130,6 +130,7 @@ library
                   , filepath
                   , hashable
                   , intern
+                  , lens-family
                   , mtl
                   , parallel
                   , parser-combinators

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -11,6 +11,7 @@ module Language.Fixpoint.Solver.EnvironmentReduction
   ( reduceEnvironments
   , simplifyBindings
   , dropLikelyIrrelevantBindings
+  , inlineInExpr
   , inlineInSortedReft
   , mergeDuplicatedBindings
   , simplifyBooleanRefts

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -609,7 +609,13 @@ inlineInSortedReft
   -> SortedReft
   -> SortedReft
 inlineInSortedReft srLookup sr =
-    sr { sr_reft = mapPredReft (inlineInExpr srLookup) (sr_reft sr) }
+    let reft = sr_reft sr
+     in sr { sr_reft = mapPredReft (inlineInExpr (filterBind (reftBind reft) srLookup)) reft }
+  where
+    filterBind b srLookup sym = do
+      guard (sym /= b)
+      srLookup sym
+
 
 -- | Inlines bindings given by @srLookup@ in the given expression
 -- if they appear in equalities.

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -82,7 +82,7 @@ prettyConstraint bindEnv c =
             , let (s, sr) = lookupBindEnv bId bindEnv
             ]
       mergedEnv = mergeDuplicatedBindings env
-      undoANFEnv = HashMap.union (undoANF mergedEnv) mergedEnv
+      undoANFEnv = undoANF mergedEnv
       boolSimplEnv = HashMap.union (simplifyBooleanRefts undoANFEnv) undoANFEnv
 
       simplifiedLhs = inlineInSortedReft boolSimplEnv (slhs c)

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -20,7 +20,7 @@ import           Language.Fixpoint.Solver.EnvironmentReduction
   , inlineInSortedReft
   , mergeDuplicatedBindings
   , simplifyBooleanRefts
-  , undoANF
+  , undoANFAndVV
   )
 import           Language.Fixpoint.Types.Config (Config, queryFile)
 import           Language.Fixpoint.Types.Constraints
@@ -82,15 +82,16 @@ prettyConstraint bindEnv c =
             , let (s, sr) = lookupBindEnv bId bindEnv
             ]
       mergedEnv = mergeDuplicatedBindings env
-      undoANFEnv = undoANF mergedEnv
-      boolSimplEnv = HashMap.union (simplifyBooleanRefts undoANFEnv) undoANFEnv
+      undoANFEnv = undoANFAndVV mergedEnv
+      boolSimplEnv = HashMap.map snd $ simplifyBooleanRefts undoANFEnv
 
-      simplifiedLhs = inlineInSortedReft boolSimplEnv (slhs c)
-      simplifiedRhs = inlineInSortedReft boolSimplEnv (srhs c)
+      simplifiedLhs = inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (slhs c)
+      simplifiedRhs = inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (srhs c)
 
       prunedEnv =
-        dropLikelyIrrelevantBindings (constraintSymbols simplifiedLhs simplifiedRhs) $
-        HashMap.map snd boolSimplEnv
+        dropLikelyIrrelevantBindings
+          (constraintSymbols simplifiedLhs simplifiedRhs)
+          boolSimplEnv
       (renamedEnv, c') =
         shortenVarNames prunedEnv c { slhs = simplifiedLhs, srhs = simplifiedRhs }
       prettyEnv =

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -72,6 +72,14 @@ passesTerminationCheck aoc rwArgs c =
     RWTerminationCheckEnabled  -> isSat aoc c
     RWTerminationCheckDisabled -> return True
 
+-- | Yields the result of rewriting an expression with an autorewrite equation.
+--
+-- Yields nothing if:
+--
+--  * The result of the rewrite is identical to the original expression
+--  * Any of the arguments of the autorewrite has a refinement type which is
+--    not satisfied in the current context.
+--
 getRewrite ::
      OCAlgebra oc Expr IO
   -> RewriteArgs

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -38,7 +38,7 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icSimpl = SM.empty, -- :: !ConstMap
           icSubcId = Nothing, -- :: Maybe SubcId
           icFuel = emptyFuelCount, -- :: !FuelCount
-          icANFs = S.empty -- :: S.HashSet Pred
+          icANFs = []         -- :: [[(Symbol, SortedReft)]]
         }
 
     emptyFuelCount :: PLE.FuelCount


### PR DESCRIPTION
Replaces `deANF` with `undoANF` from the environment reduction implementation.

`deANF` repeated substitutions over an expression until reaching a fixpoint. Non-termination streamed from the fact that the substitutions would sometimes reintroduce the variables that they were substituting, causing infinite expansions. Some more details are explained in https://github.com/ucsd-progsys/liquidhaskell/issues/1912.

`undoANF`, instead, makes a single pass over the expression, relying on a circular program to expand all variables as necessary. The companion PR in liquidhaskell is https://github.com/ucsd-progsys/liquidhaskell/pull/1934

This PR makes a few refactorings on `undoANF` to make it easier to reuse.