### PR TITLE
Test undoANF

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -204,6 +204,7 @@ test-suite tasty
                     SimplifyInterpreter
                     SimplifyPLE
                     SimplifyTests
+                    UndoANFTests
   hs-source-dirs:   tests/tasty
   build-depends:    base            >= 4.9.1.0 && < 5
                   , containers

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -18,6 +18,8 @@ module Language.Fixpoint.Solver.EnvironmentReduction
   , undoANF
   , undoANFAndVV
 
+  , mkSortedReftSimplifier
+
   -- for use in tests
   , undoANFSimplifyingWith
   ) where
@@ -585,7 +587,10 @@ substBindingsSimplifyingWith simplifier vLens p env =
      in env'
   where
     srLookup env' sym = view vLens <$> HashMap.lookup sym env'
-    sortedReftSimplifier (RR s r) = RR s (reft (reftBind r) (simplifier (reftPred r)))
+    sortedReftSimplifier = mkSortedReftSimplifier simplifier
+
+mkSortedReftSimplifier :: (Expr -> Expr) -> SortedReft -> SortedReft
+mkSortedReftSimplifier simplifier (RR s r) = RR s (reft (reftBind r) (simplifier (reftPred r)))
 
 substBindings
   :: Lens' v SortedReft
@@ -651,7 +656,7 @@ inlineInSortedReft srLookup sr =
 -- this function produces the expression @... e1 ...@ if @v@ does not
 -- appear free in @e1@.
 inlineInExpr :: (Symbol -> Maybe SortedReft) -> Expr -> Expr
-inlineInExpr srLookup = simplify . mapExprOnExpr inlineExpr
+inlineInExpr srLookup = mapExprOnExpr inlineExpr
   where
     inlineExpr (EVar sym)
       | Just sr <- srLookup sym

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -20,6 +20,7 @@ import           Language.Fixpoint.Solver.EnvironmentReduction
   , inlineInSortedReft
   , mergeDuplicatedBindings
   , simplifyBooleanRefts
+  , mkSortedReftSimplifier
   , undoANFAndVV
   )
 import           Language.Fixpoint.Types.Config (Config, queryFile)
@@ -85,8 +86,8 @@ prettyConstraint bindEnv c =
       undoANFEnv = undoANFAndVV mergedEnv
       boolSimplEnv = HashMap.map snd $ simplifyBooleanRefts undoANFEnv
 
-      simplifiedLhs = inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (slhs c)
-      simplifiedRhs = inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (srhs c)
+      simplifiedLhs = sortedReftSimplify $ inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (slhs c)
+      simplifiedRhs = sortedReftSimplify $ inlineInSortedReft (`HashMap.lookup` boolSimplEnv) (srhs c)
 
       prunedEnv =
         dropLikelyIrrelevantBindings
@@ -112,6 +113,8 @@ prettyConstraint bindEnv c =
       ]
 
     elidedMessage = "// elided some likely irrelevant bindings"
+
+    sortedReftSimplify = mkSortedReftSimplifier simplify
 
     constraintSymbols sr0 sr1 =
       HashSet.union (sortedReftSymbols sr0) (sortedReftSymbols sr1)

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -223,7 +223,7 @@ newtype Env = Env { unEnv :: M.HashMap Symbol SortedReft }
 newtype NoAnfEnv = NoAnfEnv { unNoAnfEnv :: Env }
   deriving (Eq, Show, Generic)
 instance Arbitrary NoAnfEnv where
-  arbitrary = NoAnfEnv <$> (arbitraryEnv gen 4)
+  arbitrary = sized (fmap NoAnfEnv . arbitraryEnv gen)
     where
       -- | Note that this relies on the property that the Arbitrary instance for
       -- Symbol cannot create lq_anf$ vars.
@@ -233,7 +233,7 @@ instance Arbitrary NoAnfEnv where
 newtype FlatAnfEnv = FlatAnfEnv { unFlatAnfEnv :: Env }
   deriving (Eq, Show, Generic)
 instance Arbitrary FlatAnfEnv where
-  arbitrary = FlatAnfEnv <$> (arbitraryEnv gen 2)
+  arbitrary = sized (fmap FlatAnfEnv . arbitraryEnv gen)
     where
       arbs n = vectorOf n ((,) <$> arbitrary <*> arbitrary)
       anfsGen n = fmap (\(a, b) -> (unAnfSymbol a, b)) <$> arbs n
@@ -269,7 +269,7 @@ arbitraryEnv gen = \k -> Env . M.fromList <$> (choose (0, k) >>= gen)
 newtype ChainedAnfEnv = ChainedAnfEnv { unChainedAnfEnv :: Env }
   deriving (Eq, Show, Generic)
 instance Arbitrary ChainedAnfEnv where
-  arbitrary = ChainedAnfEnv <$> (arbitraryEnv gen 4)
+  arbitrary = sized (fmap ChainedAnfEnv . arbitraryEnv gen)
     where
       gen = finalAnfGen (chainedAnfGen anfSymNGen) finalChainedGen
       finalChainedGen :: [(Symbol, SortedReft)] -> Gen (Symbol, SortedReft)

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -295,7 +295,7 @@ chainedAnfGen symGen n = do
   syms <- fmap unAnfSymbol <$> (for [1..n+1] symGen)
   finalSym <- arbitrary
   let symPairs :: [(Symbol, Symbol)]
-      symPairs = pairs syms ++ [(last syms, finalSym)]
+      symPairs = pairs (syms ++ [finalSym])
   for symPairs $ \(sym, prevSym) -> do
     otherSym <- arbitrary
     sort <- arbitrary

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -227,7 +227,7 @@ instance Arbitrary NoAnfEnv where
     where
       -- | Note that this relies on the property that the Arbitrary instance for
       -- Symbol cannot create lq_anf$ vars.
-      gen _ = (\a b -> [(a, b)]) <$> arbitrary <*> arbitrary
+      gen n = vectorOf n ((,) <$> arbitrary <*> arbitrary)
 
 -- | Env with anf vars that do not reference further anf vars.
 newtype FlatAnfEnv = FlatAnfEnv { unFlatAnfEnv :: Env }

--- a/tests/tasty/Main.hs
+++ b/tests/tasty/Main.hs
@@ -6,6 +6,7 @@ import qualified ParserTests
 import qualified ShareMapTests
 import qualified SimplifyTests
 import qualified InterpretTests
+import qualified UndoANFTests
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -15,4 +16,5 @@ main = defaultMain $ testGroup "Tests"
   , ShareMapTests.tests
   , SimplifyTests.tests
   , InterpretTests.tests
+  , UndoANFTests.tests
   ]

--- a/tests/tasty/UndoANFTests.hs
+++ b/tests/tasty/UndoANFTests.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+
+module UndoANFTests where
+
+import Language.Fixpoint.Types (SortedReft(..), Sort, Reft(..), Symbol, Expr(..),
+                                reft, isPrefixOfSym, anfPrefix)
+import Language.Fixpoint.Solver.EnvironmentReduction (undoANFSimplifyingWith)
+import qualified Language.Fixpoint.Types.Visitor as Visitor
+import Arbitrary
+import qualified Data.HashMap.Strict as M
+import Test.Tasty (TestTree, testGroup, localOption)
+import Test.Tasty.HUnit ((@?=))
+import qualified Test.Tasty.HUnit as H
+import Test.Tasty.QuickCheck ((===))
+import qualified Test.Tasty.QuickCheck as Q
+
+
+tests :: TestTree
+tests =
+  withOptions $
+    testGroup
+      "undoANFSimplifyingWith id id"
+      [ H.testCase "id on empty env" $
+          simpleUndoANF M.empty @?= M.empty
+      , Q.testProperty "id when env contains no lq_anf$* bindings" $
+          prop_no_change simpleUndoANFNoAnfEnv
+      , testGroup
+          "zero anf vars left afterwards, starting with:"
+          [ Q.testProperty "no anf vars" $
+              prop_no_anfs unNoAnfEnv simpleUndoANFNoAnfEnv
+          , Q.testProperty "single-level anf vars" $
+              prop_no_anfs unFlatAnfEnv simpleUndoANFFlatAnfEnv
+          , Q.testProperty "chained anf vars" $
+              prop_no_anfs unChainedAnfEnv simpleUndoANFChainedAnfEnv
+          ]
+      ]
+  where
+    withOptions = localOption (Q.QuickCheckMaxSize 4) . localOption (Q.QuickCheckTests 500)
+
+prop_no_change :: (Q.Arbitrary e, Eq e, Show e) => (e -> e) -> e -> Q.Property
+prop_no_change f e = Q.within 1000000 $ f e === e
+
+prop_no_anfs :: (Q.Arbitrary e, Eq e, Show e) => (e -> Env) -> (e -> e) -> e -> Q.Property
+prop_no_anfs toEnv f e = Q.within 1000000 . checkNoAnfs . toEnv . f $ e
+  where
+    checkNoAnfs (Env m) =
+      let symbolsAndSortedRefts = M.toList m
+          isAnfVar = isPrefixOfSym anfPrefix
+          toAnfVarSymbols (_, sr) = sortedReftAnfVarSymbols sr
+          anfVarSymbolVisitor :: Visitor.Visitor [Symbol] ()
+          anfVarSymbolVisitor =
+            (Visitor.defaultVisitor :: Visitor.Visitor [Symbol] ()) { Visitor.accExpr = \_ -> \case
+                                       EVar v | isAnfVar v -> [v]
+                                       _ -> []
+                                   }
+          sortedReftAnfVarSymbols = Visitor.fold anfVarSymbolVisitor () mempty
+      in
+        (concatMap toAnfVarSymbols symbolsAndSortedRefts) === []
+
+-- | We perform tests with only trivial lenses (i.e. id)
+simpleUndoANF :: M.HashMap Symbol SortedReft -> M.HashMap Symbol SortedReft
+simpleUndoANF = undoANFSimplifyingWith id id
+
+-- | simpleUndoANF conjugated with various newtypes
+simpleUndoANFEnv :: Env -> Env
+simpleUndoANFEnv = Env . simpleUndoANF . unEnv
+
+simpleUndoANFNoAnfEnv :: NoAnfEnv -> NoAnfEnv
+simpleUndoANFNoAnfEnv = NoAnfEnv . simpleUndoANFEnv . unNoAnfEnv
+
+simpleUndoANFFlatAnfEnv :: FlatAnfEnv -> FlatAnfEnv
+simpleUndoANFFlatAnfEnv = FlatAnfEnv . simpleUndoANFEnv . unFlatAnfEnv
+
+simpleUndoANFChainedAnfEnv :: ChainedAnfEnv -> ChainedAnfEnv
+simpleUndoANFChainedAnfEnv = ChainedAnfEnv . simpleUndoANFEnv . unChainedAnfEnv

--- a/tests/tasty/UndoANFTests.hs
+++ b/tests/tasty/UndoANFTests.hs
@@ -9,7 +9,7 @@ import Language.Fixpoint.Solver.EnvironmentReduction (undoANFSimplifyingWith)
 import qualified Language.Fixpoint.Types.Visitor as Visitor
 import Arbitrary
 import qualified Data.HashMap.Strict as M
-import Test.Tasty (TestTree, testGroup, localOption)
+import Test.Tasty (TestTree, testGroup, adjustOption, localOption)
 import Test.Tasty.HUnit ((@?=))
 import qualified Test.Tasty.HUnit as H
 import Test.Tasty.QuickCheck ((===))
@@ -36,7 +36,8 @@ tests =
           ]
       ]
   where
-    withOptions = localOption (Q.QuickCheckMaxSize 8) . localOption (Q.QuickCheckTests 500)
+    withOptions = localOption (Q.QuickCheckMaxSize 8) -- localOption because default value is larger than 8.
+                  . adjustOption (max (Q.QuickCheckTests 500)) -- adjustOption . max because we may want larger on the command line.
 
 -- | 5 seconds (in microseconds).
 timeout :: Int

--- a/tests/tasty/UndoANFTests.hs
+++ b/tests/tasty/UndoANFTests.hs
@@ -36,7 +36,7 @@ tests =
           ]
       ]
   where
-    withOptions = localOption (Q.QuickCheckMaxSize 8) -- localOption because default value is larger than 8.
+    withOptions = adjustOption (min (Q.QuickCheckMaxSize 8))   -- adjustOption . min because we don't want to default to the enormous value.
                   . adjustOption (max (Q.QuickCheckTests 500)) -- adjustOption . max because we may want larger on the command line.
 
 -- | 5 seconds (in microseconds).


### PR DESCRIPTION
This PR adds tests for `undoANF`.

There are currently 5 tests added: a simple unit test on the empty env, and 4 PBTs using `QuickCheck`.  The properties tests for are:
1. `undoANF` leaves an env without `lq_anf$` vars unchanged, except possibly for simplification
2. `undoANF` removes all references to `lq_anf$` vars from the `Expr`s of the `Reft`s of the `SortedReft`s.

For number 2., we check this in three starting classes of environments: ones with no `lq_anf$`s, ones with only a single level of `lq_anf$` references, and ones with multiple levels of `lq_anf$` references.

Because `simplify` is called in `undoANF`, I have parameterized a bunch of functions on a simplifier.  The reason for this is that `simplify` can reorder the conjuncts, making 1. difficult to test.  Instead, we test `undoANF` without a simplifier (and with a trivial lens) by testing `undoANFSimplifyingWith id id`.

The way this was done (preserving the old functions entirely and introducing new ones) ensures that there is (hopefully!) no change of behavior in the library from the addition of the parameterized functions.  The one exception to this is `undoANFOnlyModified`, because a bug was discovered in it whereby it would return more than just the unmodified bindings due to above mentioned reorderings from `simplify`.

Care was taken to ensure that tests cannot accidentally loop forever by adding a timeout of 1s (tests run in ~0.07s on my machine...), and by carefully creating symbols in a way that should be impossible to form loops.