### PR TITLE
Cleanups and optimizations for PLE

### DIFF
--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -478,9 +478,8 @@ getAutoRws γ ctx =
 
 evalOne :: Knowledge -> EvalEnv -> ICtx -> Int -> Expr -> IO (EvAccum, FuelCount)
 evalOne γ env ctx i e | i > 0 || null (getAutoRws γ ctx) = do
-    ((e', _), st) <- runStateT (eval γ ctx NoRW e) (env { evFuel = icFuel ctx })
-    let evAcc' = if mytracepp ("evalOne: " ++ showpp e) e' == e then evAccum st else S.insert (e, e') (evAccum st)
-    return (evAcc', evFuel st)
+    st <- execStateT (eval γ ctx NoRW e) (env { evFuel = icFuel ctx })
+    return (evAccum st, evFuel st)
 evalOne γ env ctx _ e = do
   env' <- execStateT (evalREST γ ctx rp) (env { evFuel = icFuel ctx })
   return (evAccum env', evFuel env')

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -447,7 +447,8 @@ type EvAccum = S.HashSet (Expr, Expr)
 --------------------------------------------------------------------------------
 data EvalEnv = EvalEnv
   { evEnv      :: !SymEnv
-  , evAccum    :: EvAccum
+  , evAccum    :: EvAccum -- ^ A cache of equalities between expressions that are
+                          -- known to hold.
   , evFuel     :: FuelCount
 
   -- REST parameters

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -37,7 +37,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icSolved = S.empty, -- :: S.HashSet Expr
           icSimpl = SM.empty, -- :: !ConstMap
           icSubcId = Nothing, -- :: Maybe SubcId
-          icFuel = emptyFuelCount, -- :: !FuelCount
           icANFs = []         -- :: [[(Symbol, SortedReft)]]
         }
 


### PR DESCRIPTION
Cuts the time by half for a couple of benchmarks. It reduces the time it takes to verify stitch-lh by a couple of seconds.

I've tested that tests aren't broken in lh when run with `--no-interpreter`.