### PR TITLE
Fix comment about what filterValid does

### DIFF
--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -183,7 +183,7 @@ filterRequired = error "TBD:filterRequired"
 -}
 
 --------------------------------------------------------------------------------
--- | `filterValid p [(x1, q1),...,(xn, qn)]` returns the list `[ xi | p => qi]`
+-- | `filterValid p [(q1, x1),...,(qn, xn)]` returns the list `[ xi | p => qi]`
 --------------------------------------------------------------------------------
 {-# SCC filterValid #-}
 filterValid :: F.SrcSpan -> F.Expr -> F.Cand a -> SolveM [a]


### PR DESCRIPTION
The comment above filterValid, talks about the pairs (x1,q1) which
constitute Cand.  This order is flipped from what it actually is,
causing a slight confusion for readers trying to understand the code.