### PR TITLE
Implement the flag --no-interpreter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,8 @@ jobs:
           name: Test
           command: |
             mkdir -p /tmp/junit
-            stack --no-terminal test -j2 liquid-fixpoint:test --flag liquid-fixpoint:devel --test-arguments="--xml=/tmp/junit/main-test-results.xml":
+            stack --no-terminal test -j2 liquid-fixpoint:test --flag liquid-fixpoint:devel --test-arguments="--xml=/tmp/junit/main-test-results.xml"
+            stack --no-terminal test -j2 liquid-fixpoint:test --flag liquid-fixpoint:devel --ta "--fixpoint-opts --no-interpreter" --test-arguments="--xml=/tmp/junit/main-test-results-no-interpreter.xml"
             stack --no-terminal haddock --flag liquid-fixpoint:devel --test --no-run-tests --no-haddock-deps --haddock-arguments="--no-print-missing-docs"
             # mkdir -p $CIRCLE_TEST_REPORTS/tasty
             # cp -r tests/logs/cur $CIRCLE_TEST_REPORTS/tasty/log

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -179,8 +179,10 @@ test-suite test
                   , directory
                   , filepath
                   , mtl           >= 2.2.2
+                  , optparse-applicative
                   , process
                   , stm           >= 2.4
+                  , tagged
                   , tasty         >= 0.10
                   , tasty-ant-xml
                   , tasty-hunit

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -125,7 +125,7 @@ solve_ cfg fi s0 ks wkl = do
     return (s3, res0)
 
   (fi1, s4, res1) <- case resStatus res0 of  {- first run the interpreter -}
-    Unsafe _ bads | not (noLazyPLE cfg) && rewriteAxioms cfg && useInterpreter cfg -> do
+    Unsafe _ bads | not (noLazyPLE cfg) && rewriteAxioms cfg && not (noInterpreter cfg) -> do
       fi1 <- doInterpret cfg fi (map fst $ mytrace ("before the Interpreter " ++ show (length bads) ++ " constraints remain") bads)
       (s4, res1) <-  sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s4    <- {- SCC "sol-refine" #-} refine bindingsInSmt s3 wkl

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -92,7 +92,7 @@ data Config = Config
   , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
   , noslice          :: Bool           -- ^ Disable non-concrete KVar slicing
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
-  , useInterpreter   :: Bool           -- ^ Use the interpreter to assist PLE
+  , noInterpreter    :: Bool           -- ^ Do not use the interpreter to assist PLE
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
   , noEnvironmentReduction :: Bool     -- ^ Don't use environment reduction
@@ -213,7 +213,10 @@ defConfig = Config {
   , nonLinCuts               = False &= help "Treat non-linear kvars as cuts"
   , noslice                  = False &= help "Disable non-concrete KVar slicing"
   , rewriteAxioms            = False &= help "allow axiom instantiation via rewriting"
-  , useInterpreter           = True &= help "Use the interpreter to assist PLE"
+  , noInterpreter            =
+      False
+        &= name "no-interpreter"
+        &= help "Do not use the interpreter to assist PLE"
   , oldPLE                   = False &= help "Use old version of PLE"
   , noIncrPle                = False &= help "Don't use incremental PLE"
   , noEnvironmentReduction   =

--- a/tests/horn/neg/ple_sum_fuel.5.smt2
+++ b/tests/horn/neg/ple_sum_fuel.5.smt2
@@ -1,7 +1,7 @@
 (fixpoint "--rewrite")
 (fixpoint "--save")
 (fixpoint "--fuel=5")
-(fixpoint "--useinterpreter=False")
+(fixpoint "--no-interpreter")
 
 (constant sum  (func(0, [int, int])))
 

--- a/tests/horn/pos/ple_sum_fuel.5.smt2
+++ b/tests/horn/pos/ple_sum_fuel.5.smt2
@@ -1,7 +1,7 @@
 (fixpoint "--rewrite")
 (fixpoint "--save")
 (fixpoint "--fuel=6")
-(fixpoint "--useinterpreter=False")
+(fixpoint "--no-interpreter")
 
 (constant sum  (func(0, [int, int])))
 


### PR DESCRIPTION
Otherwise, one has to use `--useInterpreter=False` which is a bit clunky and isn't documented in the help message.