### PR TITLE
Remove duplicate deps, syb and tasty-hunit.

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -139,7 +139,6 @@ library
                   , process
                   , stm
                   , syb
-                  , syb
                   , text
                   , transformers
                   , unordered-containers
@@ -185,7 +184,6 @@ test-suite test
                   , tagged
                   , tasty         >= 0.10
                   , tasty-ant-xml
-                  , tasty-hunit
                   , tasty-hunit   >= 0.9
                   , tasty-rerun   >= 1.1.12
                   , transformers  >= 0.5


### PR DESCRIPTION
Removes the two duplicate dependencies in the `.cabal` file.