### PR TITLE
Enable cabal build with rest dependency.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,5 @@
+packages: .
+source-repository-package
+    type: git
+    location: https://github.com/zgrannan/rest
+    tag: 9637b77823ef3ceb909510cad2508e828767f6fb


### PR DESCRIPTION
Enables building with cabal. Without the added `cabal.project`, a `cabal build` fails with:

```
> cabal build all --enable-tests
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - rest-rewrite-0.2.0 (lib) (requires build)
 - store-0.7.14 (lib) (requires build)
 - liquid-fixpoint-0.8.10.7.1 (lib) (first run)
 - liquid-fixpoint-0.8.10.7.1 (test:tasty) (first run)
 - liquid-fixpoint-0.8.10.7.1 (exe:fixpoint) (first run)
 - liquid-fixpoint-0.8.10.7.1 (test:test) (first run)
...
[17 of 31] Compiling Language.REST.Types
  ( src/Language/REST/Types.hs, dist/build/Language/REST/Types.o, dist/build/Language/REST/Types.dyn_o )

src/Language/REST/Types.hs:72:10: error:
    Duplicate instance declarations:
      instance Hashable a => Hashable (OS.Set a)
        -- Defined at src/Language/REST/Types.hs:72:10
      instance Hashable v => Hashable (OS.Set v)
        -- Defined in ‘hashable-1.3.5.0:Data.Hashable.Class’
   |
72 | instance Hashable a => Hashable (OS.Set a) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Language/REST/Types.hs:75:10: error:
    Duplicate instance declarations:
      instance (Hashable a, Hashable b) => Hashable (M.Map a b)
        -- Defined at src/Language/REST/Types.hs:75:10
      instance (Hashable k, Hashable v) => Hashable (M.Map k v)
        -- Defined in ‘hashable-1.3.5.0:Data.Hashable.Class’
   |
75 | instance (Hashable a, Hashable b) => Hashable (M.Map a b) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: cabal: Failed to build rest-rewrite-0.2.0 (which is required by
test:tasty from liquid-fixpoint-0.8.10.7.1 and test:test from
liquid-fixpoint-0.8.10.7.1). See the build log above for details.
```

This is the equivalent of what we already do for stack.

```yaml
extra-deps:
- hashable-1.3.5.0
- git: https://github.com/zgrannan/rest
  commit: 9637b77823ef3ceb909510cad2508e828767f6fb
```