### PR TITLE
Rerun and paste output from smt2 cmds, #395.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,26 +145,26 @@ You can use the `.smt2` interface from the command-line as follows:
 Use `--stdin` to read files from `stdin`
 
 ```
-$ more tests/horn/pos/test01.smt | fixpoint --stdin
+$ more tests/horn/pos/test01.smt2 | fixpoint --stdin
 
-Liquid-Fixpoint Copyright 2013-15 Regents of the University of California.
+Liquid-Fixpoint Copyright 2013-21 Regents of the University of California.
 All Rights Reserved.
 
-Working 175% [==================================================================================================================]
-Safe ( 3  constraints checked)
+Working 166% [===============================================================]
+Safe ( 2  constraints checked)
 ```
 
 Use `-q` to disable all output (banner, progress bar etc.)
 
 ```
-$ more tests/horn/pos/test01.smt | fixpoint -q --stdin
+$ more tests/horn/pos/test01.smt2 | fixpoint -q --stdin
 ```
 
 Use `--json` to get the output as a JSON object (rendered to `stdout`)
 
 ```
 $ more tests/horn/pos/abs02-re.smt2 | stack exec -- fixpoint -q --json --stdin
-"{\"result\":\"safe\"}"
+{"contents":{"numIter":3,"numCstr":3,"numChck":3,"numBrkt":3,"numVald":3},"tag":"Safe"}
 ```
 
 


### PR DESCRIPTION
The command line for the SMTLIB2 interface still exists. I reran and updated the samples (shortening one output so the code snippet did not render with a horizontal scroll bar.).