### PR TITLE
Follow hlint suggestion, remove redundant $.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,15 +2,15 @@
 - ignore: {name: "Avoid lambda"} # 4 hints
 - ignore: {name: "Eta reduce"} # 30 hints
 - ignore: {name: "Evaluate"} # 1 hint
-- ignore: {name: "Fix pragma markup"} # 38 hints
+- ignore: {name: "Fix pragma markup"} # 36 hints
 - ignore: {name: "Functor law"} # 3 hints
-- ignore: {name: "Redundant <$>"} # 29 hints
+- ignore: {name: "Redundant <$>"} # 31 hints
 - ignore: {name: "Redundant bang pattern"} # 33 hints
 - ignore: {name: "Redundant flip"} # 1 hint
 - ignore: {name: "Redundant if"} # 1 hint
 - ignore: {name: "Use $>"} # 7 hints
 - ignore: {name: "Use ++"} # 1 hint
-- ignore: {name: "Use <$"} # 2 hints
+- ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 10 hints
 - ignore: {name: "Use camelCase"} # 2 hints
 - ignore: {name: "Use const"} # 1 hint
@@ -18,7 +18,7 @@
 - ignore: {name: "Use fold"} # 1 hint
 - ignore: {name: "Use gets"} # 9 hints
 - ignore: {name: "Use guards"} # 3 hints
-- ignore: {name: "Use infix"} # 3 hints
+- ignore: {name: "Use infix"} # 4 hints
 - ignore: {name: "Use map once"} # 1 hint
 - ignore: {name: "Use maybe"} # 7 hints
 - ignore: {name: "Use second"} # 1 hint


### PR DESCRIPTION
Picked off another hlint suggestion from #552. I'm intentionally keeping these small and focused so that they're easy to review.

I saw one failure with the **single-level anf vars** test that seemed to disappear when I backed out of the change to `tests/tasty/Arbitrary.hs` but I couldn't reproduce it when I reapplied the hlint suggestion.

```
> cabal test all
...
  undoANFSimplifyingWith id id
    id on empty env:                           OK
    id when env contains no lq_anf$* bindings: OK (0.10s)
      +++ OK, passed 500 tests.
    zero anf vars left afterwards, starting with:
      no anf vars:                             OK (0.05s)
        +++ OK, passed 500 tests.
      single-level anf vars:                   FAIL
...
        Use --quickcheck-replay=407282 --quickcheck-max-size=8 to reproduce.
        Use -p '/single-level anf vars/' to rerun this test only.
```