### PR TITLE
Write shrinker for undoANF tests; print problems on unify; fix undoANF Arbitrary instance

### DIFF
--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -1131,7 +1131,7 @@ unifySorts :: Sort -> Sort -> Maybe TVSubst
 --------------------------------------------------------------------------------
 unifySorts   = unifyFast False emptyEnv
   where
-    emptyEnv x = die $ err dummySpan $ "SortChecl: lookup in Empty Env: " <> pprint x
+    emptyEnv x = die $ err dummySpan $ "SortCheck: lookup in Empty Env: " <> pprint x
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -1131,7 +1131,7 @@ unifySorts :: Sort -> Sort -> Maybe TVSubst
 --------------------------------------------------------------------------------
 unifySorts   = unifyFast False emptyEnv
   where
-    emptyEnv = const $ die $ err dummySpan "SortChecl: lookup in Empty Env "
+    emptyEnv x = die $ err dummySpan $ "SortChecl: lookup in Empty Env: " <> pprint x
 
 
 --------------------------------------------------------------------------------

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -42,6 +42,10 @@ prop_pprint_parse_inv_expr expr = expr == rr (showpp expr)
 
 -}
 
+-- NOTE: Arbitrary instances in this file with an _explicit_ implementation of
+-- `shrink _ = mempty` are known to not have useful shrinker. Instances without
+-- an _explicit_ implementation have simply not been given a shrinker yet.
+
 instance Arbitrary Expr where
   arbitrary = sized arbitraryExpr
   shrink x = filter valid $ genericShrink x

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -176,7 +176,7 @@ arbitrarySort = arbitrarySortPossiblyInvolving Nothing
 arbitrarySortPossiblyInvolving :: [Int] -> Int -> Gen Sort
 arbitrarySortPossiblyInvolving [] n = frequency
   [ (4, arbitrarySortNoAbs n)
-  , (1, newAbs n) ]
+  , (1, newAbs [] n) ]
 arbitrarySortPossiblyInvolving vars n = do
   let fvar = oneof $ pure . FVar <$> vars
   frequency

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -166,7 +166,7 @@ instance Arbitrary Sort where
 -- The sort is \"well-formed\" in the sense that all `FVar`s have an enclosing
 -- `FAbs` bringing them into scope.
 arbitrarySort :: Int -> Gen Sort
-arbitrarySort = arbitrarySortPossiblyInvolving Nothing
+arbitrarySort = arbitrarySortPossiblyInvolving []
 
 -- | Create an arbitrary sort, possibly involving the variables represented by
 -- the list of Ints. Can possibly create a `FAbs` that will also possibly

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -42,9 +42,8 @@ prop_pprint_parse_inv_expr expr = expr == rr (showpp expr)
 
 -}
 
--- NOTE: Arbitrary instances in this file with an _explicit_ implementation of
--- `shrink _ = mempty` are known to not have useful shrinker. Instances without
--- an _explicit_ implementation have simply not been given a shrinker yet.
+-- NOTE: `shrink _ = mempty` is identical to the default (implicit) shrink implementation.
+-- We prefer to make it explicit.
 
 instance Arbitrary Expr where
   arbitrary = sized arbitraryExpr


### PR DESCRIPTION
Fixes #557.

Three main changes: 

1. The error message in `SortCheck.hs` now prints the variable name on whom lookup failed.
2. Added shrinkers for the `Arbitrary` instances in `Arbitrary.hs`
3. Fixed the bug in the above issue: there were two problems, one was FVars outside of the scope of an FAbs, and the other was the generation of any FObj in a unification position would fail unification.  We now carefully only generate FVars when they are enclosed by a matching FAbs, and FObjs are not generated at all.