### PR TITLE
Add profile flag and profile ple/interpreter/solver

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -109,6 +109,7 @@ library
                     Language.Fixpoint.Utils.Progress
                     Language.Fixpoint.Utils.Statistics
                     Language.Fixpoint.Utils.Trie
+                    Language.Fixpoint.Utils.Profile
                     Text.PrettyPrint.HughesPJ.Compat
   other-modules:    Paths_liquid_fixpoint
   hs-source-dirs:   src
@@ -144,6 +145,7 @@ library
                   , unordered-containers
                   , aeson
                   , rest-rewrite >= 0.1.1
+                  , time
   default-language: Haskell98
   ghc-options:      -W -fno-warn-missing-methods -fwarn-missing-signatures
 

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -77,6 +77,7 @@ data Config = Config
   , smtTimeout  :: Maybe Int           -- ^ smt timeout in msec
   , elimStats   :: Bool                -- ^ print eliminate stats
   , solverStats :: Bool                -- ^ print solver stats
+  , profile     :: Bool                -- ^ print profiling info
   , metadata    :: Bool                -- ^ print meta-data associated with constraints
   , stats       :: Bool                -- ^ compute constraint statistics
   , parts       :: Bool                -- ^ partition FInfo into separate fq files
@@ -196,6 +197,7 @@ defConfig = Config {
   , elimStats                = False   &= help "(alpha) Print eliminate stats"
   , solverStats              = False   &= help "Print solver stats"
   , save                     = False   &= help "Save Query as .fq and .bfq files"
+  , profile                  = False   &= help "Profile the execution of fixpoint"
   , metadata                 = False   &= help "Print meta-data associated with constraints"
   , stats                    = False   &= help "Compute constraint statistics"
   , etaElim                  = False   &= help "eta elimination in function definition"

--- a/src/Language/Fixpoint/Utils/Profile.hs
+++ b/src/Language/Fixpoint/Utils/Profile.hs
@@ -1,0 +1,13 @@
+module Language.Fixpoint.Utils.Profile where
+
+import Data.Time.Clock
+import Control.Monad
+import Control.Monad.IO.Class
+
+profileIO :: MonadIO m => Bool -> String -> m a -> m a
+profileIO shouldProfile header m = do
+  beforeTime <- liftIO getCurrentTime
+  ret <- m
+  afterTime <- liftIO $ getCurrentTime
+  when shouldProfile $ liftIO $ putStrLn $ header <> show (afterTime `diffUTCTime` beforeTime)
+  return ret


### PR DESCRIPTION
Related to #539.

Adds a `--profile` flag, which when provided will output some basic profiling information, such as how much time was spent in the IO of the PLE, PLE interpreter, and overall in the solver.