### PR TITLE
human-friendly equations from PLE

### DIFF
--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE UndecidableInstances      #-}
 {-# LANGUAGE PatternGuards             #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 {-# OPTIONS_GHC -Wno-orphans           #-}
 {-# OPTIONS_GHC -Wno-name-shadowing    #-}
@@ -301,7 +302,7 @@ type VarAs = SymEnv -> Symbol -> Sort -> Builder
 --------------------------------------------------------------------------------
 smt2App :: VarAs -> SymEnv -> Expr -> [Builder] -> Maybe Builder
 --------------------------------------------------------------------------------
-smt2App _ _ (ECst (EVar f) _) [d]
+smt2App _ _ (dropECst -> EVar f) [d]
   | f == setEmpty = Just (bb emp)
   | f == setEmp   = Just (key2 "=" (bb emp) d)
   | f == setSng   = Just (key (bb sng) d) -- Just (key2 (bb add) (bb emp) d)
@@ -313,7 +314,7 @@ smt2App k env f (d:ds)
 smt2App _ _ _ _    = Nothing
 
 smt2AppArg :: VarAs -> SymEnv -> Expr -> Maybe Builder
-smt2AppArg k env (ECst (EVar f) t)
+smt2AppArg k env (ECst (dropECst -> EVar f) t)
   | Just fThy <- symEnvTheory f env
   = Just $ if isPolyCtor fThy t
             then k env f (ffuncOut t)

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -332,7 +332,7 @@ ffuncOut t = maybe t (last . snd) (bkFFunc t)
 --------------------------------------------------------------------------------
 isSmt2App :: SEnv TheorySymbol -> Expr -> Maybe Int
 --------------------------------------------------------------------------------
-isSmt2App g  (EVar f)
+isSmt2App g  (dropECst -> EVar f)
   | f == setEmpty = Just 1
   | f == setEmp   = Just 1
   | f == setSng   = Just 1

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -26,7 +26,7 @@ askSMT cfg ctx bs e
 toSMT :: String -> Config -> Context -> [(Symbol, Sort)] -> Expr -> Pred
 toSMT msg cfg ctx bs e =
     defuncAny cfg senv .
-        elaborate "makeKnowledge" (elabEnv bs) .
+        elaborate (dummyLoc msg) (elabEnv bs) .
             mytracepp ("toSMT from " ++ msg ++ showpp e) $
                 e
   where

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternGuards #-}
@@ -75,6 +74,7 @@ import           Language.Fixpoint.Types.Refinements
   , Subst(..)
   , pattern PTrue
   , pattern PFalse
+  , dropECst
   , expr
   , exprKVars
   , exprSymbolsSet
@@ -686,11 +686,6 @@ inlineInExpr srLookup = mapExprOnExpr inlineExpr
     wrapWithCoercion br to e = case exprSortMaybe e of
       Just from -> if from /= to then ECoerc from to e else e
       Nothing -> if br == Ueq then ECst e to else e
-
-dropECst :: Expr -> Expr
-dropECst = \case
-  ECst e _t -> dropECst e
-  e -> e
 
 -- | Transforms bindings of the form @{v:bool | v && P v}@ into
 -- @{v:Bool | v && P true}@, and bindings of the form @{v:bool | ~v && P v}@

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -535,6 +535,9 @@ eval γ ctx et e0 =
     go (PIff e1 e2)     = binOp PIff e1 e2
     go (PAnd es)        = efAll PAnd (go  <$$> es)
     go (POr es)         = efAll POr (go <$$> es)
+    go e | EVar _ <- dropECst e = do
+      (me', fe) <- evalApp γ ctx e [] et
+      return (Mb.fromMaybe e me', fe)
     go (ECst e t)       = do (e', fe) <- eval γ ctx et e
                              return (ECst e' t, fe)
     go e                = return (e, noExpand)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -903,8 +903,7 @@ mkCoSub env eTs xTs = M.fromList [ (x, unite ys) | (x, ys) <- Misc.groupList xys
     unite ts    = Mb.fromMaybe (uError ts) (unifyTo1 senv ts)
     senv        = mkSearchEnv env
     uError ts   = panic ("mkCoSub: cannot build CoSub for " ++ showpp xys ++ " cannot unify " ++ showpp ts)
-    xys         = Misc.sortNub $ concat $ zipWith matchSorts _xTs _eTs
-    (_xTs,_eTs) = (xTs, eTs)
+    xys         = Misc.sortNub $ concat $ zipWith matchSorts xTs eTs
 
 matchSorts :: Sort -> Sort -> [(Symbol, Sort)]
 matchSorts s1 s2 = go s1 s2

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -25,7 +25,7 @@ module Language.Fixpoint.Solver.PLE
   , FuelCount(..)
   , ICtx(..)
   , Knowledge(..)
-  , Simplifiable(..)
+  , simplify
   )
   where
 
@@ -1104,12 +1104,8 @@ type LDataCon = Symbol              -- Data Constructors
 isConstant :: S.HashSet LDataCon -> Expr -> Bool
 isConstant dcs e = S.null (S.difference (exprSymbolsSet e) dcs)
 
-class Simplifiable a where
-  simplify :: Knowledge -> ICtx -> a -> a
-
-
-instance Simplifiable Expr where
-  simplify γ ictx e = mytracepp ("simplification of " ++ showpp e) $ fix (Vis.mapExprOnExpr tx) e
+simplify :: Knowledge -> ICtx -> Expr -> Expr
+simplify γ ictx e = mytracepp ("simplification of " ++ showpp e) $ fix (Vis.mapExprOnExpr tx) e
     where
       fix f e = if e == e' then e else fix f e' where e' = f e
       tx e

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -392,7 +392,7 @@ updCtx env@InstEnv{..} ctx delta cidMb
                   ])
     bs        = second unElabSortedReft <$> binds
     rhs       = unElab eRhs
-    es        = unElab <$> (expr <$> binds)
+    es        = expr <$> bs
     eRhs      = maybe PTrue crhs subMb
     binds     = [ lookupBindEnv i ieBEnv | i <- delta ]
     subMb     = getCstr ieCstrs <$> cidMb

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -892,6 +892,11 @@ substEqCoerce env eq es = Vis.applyCoSub coSub $ eqBody eq
     eTs   = sortExpr sp env <$> es
     coSub = mkCoSub env eTs ts
 
+-- | @mkCoSub senv eTs xTs = su@ creates a substitution @su@ such that
+-- @subst su xTs == eTs@.
+--
+-- The variables in the domain of the substitution are those that appear
+-- as @FObj symbol@ in @xTs@.
 mkCoSub :: SEnv Sort -> [Sort] -> [Sort] -> Vis.CoSub
 mkCoSub env eTs xTs = M.fromList [ (x, unite ys) | (x, ys) <- Misc.groupList xys ]
   where

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -106,7 +106,7 @@ savePLEEqualities cfg fi res = when (save cfg) $ do
       (cid, L.sort [ e | i <- elemsIBindEnv (senv c), Just e <- [M.lookup i res] ])
     renderConstraintRewrite (cid, eqs) =
       "constraint id" <+> text (show cid ++ ":")
-      $+$ nest 2 (toFix (pAnd eqs))
+      $+$ nest 2 (vcat $ L.intersperse "" $ map (toFix . unElab) $ concatMap conjuncts eqs)
       $+$ ""
 
 -------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -79,7 +79,9 @@ instantiate cfg fi' subcIds = do
                (cm fi)
     let t  = mkCTrie (M.toList cs)                                          -- 1. BUILD the Trie
     res   <- withRESTSolver $ \solver -> withProgress (1 + M.size cs) $
-               withCtx cfg file sEnv (pleTrie t . instEnv cfg fi cs solver) -- 2. TRAVERSE Trie to compute InstRes
+               withCtx cfg file sEnv $ \ctx -> do
+                  env <- instEnv cfg fi cs solver ctx
+                  pleTrie t env                                             -- 2. TRAVERSE Trie to compute InstRes
     savePLEEqualities cfg fi res
     return $ resSInfo cfg sEnv fi res                                       -- 3. STRENGTHEN SInfo using InstRes
   where
@@ -111,31 +113,37 @@ savePLEEqualities cfg fi res = when (save cfg) $ do
 
 -------------------------------------------------------------------------------
 -- | Step 1a: @instEnv@ sets up the incremental-PLE environment
-instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SMT.Context -> InstEnv a
-instEnv cfg fi cs restSolver ctx =
+instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SMT.Context -> IO (InstEnv a)
+instEnv cfg fi cs restSolver ctx = do
+    refRESTCache <- newIORef mempty
+    refRESTSatCache <- newIORef mempty
     let
         restOC = FC.restOC cfg
-        et :: Maybe (ExploredTerms RuntimeTerm OCType IO)
-        et = case restSolver of
-               Just solver ->
-                 let oc = ordConstraints restOC solver
-                  in Just $ ExploredTerms.empty
-                       EF
-                         { ExploredTerms.union = OC.union oc
-                         , ExploredTerms.subsumes = OC.notStrongerThan oc
-                         }
-                       ExploreWhenNeeded
-               Nothing -> Nothing
+        oc0 = ordConstraints restOC $ Mb.fromJust restSolver
+        oc :: OCAlgebra OCType RuntimeTerm IO
+        oc = oc0
+             { OC.isSat = cachedIsSat refRESTSatCache oc0
+             , OC.notStrongerThan = cachedNotStrongerThan refRESTCache oc0
+             }
+        et :: ExploredTerms RuntimeTerm OCType IO
+        et = ExploredTerms.empty
+               EF
+                 { ExploredTerms.union = OC.union oc
+                 , ExploredTerms.subsumes = OC.notStrongerThan oc
+                 , exRefine = OC.refine oc
+                 }
+                 ExploreWhenNeeded
         s0 = EvalEnv
               { evEnv = SMT.ctxSymEnv ctx
               , evNewEqualities = mempty
               , evSMTCache = mempty
               , evFuel = defFuelCount cfg
-              , explored = et
+              , explored = Just et
               , restSolver = restSolver
               , restOCA = restOC
+              , evOCAlgebra = oc
               }
-     in InstEnv
+    return $ InstEnv
        { ieCfg = cfg
        , ieSMT = ctx
        , ieBEnv = bs fi
@@ -144,6 +152,26 @@ instEnv cfg fi cs restSolver ctx =
        , ieKnowl = knowledge cfg ctx fi
        , ieEvEnv = s0
        }
+  where
+    cachedNotStrongerThan refRESTCache oc a b = do
+      m <- readIORef refRESTCache
+      case M.lookup (a, b) m of
+        Nothing -> do
+          nst <- OC.notStrongerThan oc a b
+          writeIORef refRESTCache (M.insert (a, b) nst m)
+          return nst
+        Just nst ->
+          return nst
+
+    cachedIsSat refRESTSatCache oc a = do
+      m <- readIORef refRESTSatCache
+      case M.lookup a m of
+        Nothing -> do
+          sat <- OC.isSat oc a
+          writeIORef refRESTSatCache (M.insert a sat m)
+          return sat
+        Just sat ->
+          return sat
 
 ----------------------------------------------------------------------------------------------
 -- | Step 1b: @mkCTrie@ builds the @Trie@ of constraints indexed by their environments
@@ -400,6 +428,7 @@ data EvalEnv = EvalEnv
   , explored   :: Maybe (ExploredTerms RuntimeTerm OCType IO)
   , restSolver :: Maybe SolverHandle
   , restOCA    :: RESTOrdering
+  , evOCAlgebra :: OCAlgebra OCType RuntimeTerm IO
   }
 
 data FuelCount = FC
@@ -426,7 +455,7 @@ evalOne γ ctx i e
 evalOne γ ctx _ e = do
     env <- get
     let oc :: OCAlgebra OCType RuntimeTerm IO
-        oc = ordConstraints (restOCA env) (Mb.fromJust $ restSolver env)
+        oc = evOCAlgebra env
         rp = RP (contramap Rewrite.convert oc) [(e, PLE)] constraints
         constraints = OC.top oc
         emptyET = ExploredTerms.empty (EF (OC.union oc) (OC.notStrongerThan oc) (OC.refine oc)) ExploreWhenNeeded

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -646,12 +646,13 @@ evalRESTWithCache cacheRef γ ctx acc rp =
      else
       return acc
   where
-    shouldExploreTerm exploredTerms e =
+    shouldExploreTerm exploredTerms e | Vis.isConc e =
       case rwTerminationOpts rwArgs of
         RWTerminationCheckDisabled ->
           return $ not $ ExploredTerms.visited (Rewrite.convert e) exploredTerms
         RWTerminationCheckEnabled  ->
           ExploredTerms.shouldExplore (Rewrite.convert e) (c rp) exploredTerms
+    shouldExploreTerm _ _ = return False
 
     allowed (_, rwE, _) | rwE `elem` pathExprs = return False
     allowed (_, _, c)   = termCheck c

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -42,6 +42,7 @@ import           Language.REST.SMT (SMTExpr)
 import           Language.REST.WQOConstraints.ADT (ConstraintsADT, adtOC)
 import qualified Language.REST.RuntimeTerm as RT
 
+-- | @(e, f)@ asserts that @e@ is a subexpression of @f e@
 type SubExpr = (Expr, Expr -> Expr)
 
 data TermOrigin = PLE | RW deriving (Show, Eq)

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -126,21 +126,22 @@ getRewrite ::
   -> oc
   -> SubExpr
   -> AutoRewrite
-  -> MaybeT IO (Expr, oc)
+  -> MaybeT IO ((Expr, Expr), Expr, oc)
 getRewrite aoc rwArgs c (subE, toE) (AutoRewrite args lhs rhs) =
   do
     su <- MaybeT $ return $ unify freeVars lhs subE
     let subE' = subst su rhs
     guard $ subE /= subE'
     let expr' = toE subE'
+        eqn = (subst su lhs, subE')
     mapM_ (checkSubst su) exprs
     return $ case rwTerminationOpts rwArgs of
       RWTerminationCheckEnabled ->
         let
           c' = refine aoc c subE subE'
         in
-          (expr', c')
-      RWTerminationCheckDisabled -> (expr', c)
+          (eqn, expr', c')
+      RWTerminationCheckDisabled -> (eqn, expr', c)
   where
     check :: Expr -> MaybeT IO ()
     check e = do

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -105,6 +105,7 @@ convert (ECon c)       = RT.App (Op $ "$econ" `TX.append` (TX.pack . show) c) []
 convert (ESym (SL tx)) = RT.App (Op tx) []
 convert (ECst t _)     = convert t
 convert (PIff e0 e1)   = convert (PAtom Eq e0 e1)
+convert (PImp e0 e1)   = convert (POr [PNot e0, e1])
 convert e              = error (show e)
 
 passesTerminationCheck :: OCAlgebra oc a IO -> RewriteArgs -> oc -> IO Bool

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -219,6 +219,13 @@ unifyAll freeVars (template:xs) (seen:ys) =
     return $ Su (M.union s1 s2)
 unifyAll _ _ _ = undefined
 
+-- | @unify vs template e = Just su@ yields a substitution @su@
+-- such that subst su template == e
+--
+-- Moreover, @su@ is constraint to only substitute variables in @vs@.
+--
+-- Yields @Nothing@ if no substitution exists.
+--
 unify :: [Symbol] -> Expr -> Expr -> Maybe Subst
 unify _ template seenExpr | template == seenExpr = Just (Su M.empty)
 unify freeVars template seenExpr = case (template, seenExpr) of

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -104,6 +104,7 @@ convert (EBin o l r)   = RT.App (Op $ "$ebin" `TX.append` (TX.pack . show) o) [c
 convert (ECon c)       = RT.App (Op $ "$econ" `TX.append` (TX.pack . show) c) []
 convert (ESym (SL tx)) = RT.App (Op tx) []
 convert (ECst t _)     = convert t
+convert (PIff e0 e1)   = convert (PAtom Eq e0 e1)
 convert e              = error (show e)
 
 passesTerminationCheck :: OCAlgebra oc a IO -> RewriteArgs -> oc -> IO Bool

--- a/src/Language/Fixpoint/Solver/Simplify.hs
+++ b/src/Language/Fixpoint/Solver/Simplify.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE PartialTypeSignatures     #-}
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ViewPatterns              #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing    #-}
 
@@ -55,7 +56,7 @@ applyBooleanFolding brel e1 e2 =
 -- where possible.
 applyConstantFolding :: Bop -> Expr -> Expr -> Expr
 applyConstantFolding bop e1 e2 =
-  case (e1, e2) of
+  case (dropECst e1, dropECst e2) of
     (ECon (R left), ECon (R right)) ->
       Mb.fromMaybe e (cfR bop left right)
     (ECon (R left), ECon (I right)) ->
@@ -65,16 +66,16 @@ applyConstantFolding bop e1 e2 =
     (ECon (I left), ECon (I right)) ->
       Mb.fromMaybe e (cfI bop left right)
     (EBin Mod  _   _              , _)  -> e
-    (EBin bop1 e11 (ECon (R left)), ECon (R right))
+    (EBin bop1 e11 (dropECst -> ECon (R left)), ECon (R right))
       | bop == bop1 -> maybe e (EBin bop e11) (cfR (rop bop) left right)
       | otherwise   -> e
-    (EBin bop1 e11 (ECon (R left)), ECon (I right))
+    (EBin bop1 e11 (dropECst -> ECon (R left)), ECon (I right))
       | bop == bop1 -> maybe e (EBin bop e11) (cfR (rop bop) left (fromIntegral right))
       | otherwise   -> e
-    (EBin bop1 e11 (ECon (I left)), ECon (R right))
+    (EBin bop1 e11 (dropECst -> ECon (I left)), ECon (R right))
       | bop == bop1 -> maybe e (EBin bop e11) (cfR (rop bop) (fromIntegral left) right)
       | otherwise   -> e
-    (EBin bop1 e11 (ECon (I left)), ECon (I right))
+    (EBin bop1 e11 (dropECst -> ECon (I left)), ECon (I right))
       | bop == bop1 -> maybe e (EBin bop e11) (cfI (rop bop) left right)
       | otherwise   -> e
     _ -> e

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -652,7 +652,8 @@ elabAppSort f e1 e2 s1 s2 = do
 -- | defuncEApp monomorphizes function applications.
 --------------------------------------------------------------------------------
 defuncEApp :: SymEnv -> Expr -> [(Expr, Sort)] -> Expr
-defuncEApp env e es = L.foldl' makeApplication e' es'
+defuncEApp _env e [] = e
+defuncEApp env e es = eCst (L.foldl' makeApplication e' es') (snd $ last es)
   where
     (e', es')       = takeArgs (seTheory env) e es
 

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -658,7 +658,7 @@ defuncEApp env e es = L.foldl' makeApplication e' es'
 
 takeArgs :: SEnv TheorySymbol -> Expr -> [(Expr, a)] -> (Expr, [(Expr, a)])
 takeArgs env e es =
-  case Thy.isSmt2App env (Vis.stripCasts e) of
+  case Thy.isSmt2App env e of
     Just n  -> let (es1, es2) = splitAt n es
                in (eApps e (fst <$> es1), es2)
     Nothing -> (e, es)

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -219,14 +219,14 @@ elabExpr msg env e = case elabExprE msg env e of
 
 elabExprE :: Located String -> SymEnv -> Expr -> Either Error Expr
 elabExprE msg env e =
-  case runCM0 (srcSpan msg) (elab (env, f) e) of
+  case runCM0 (srcSpan msg) (elab (env, envLookup) e) of
     Left (ChError f') ->
       let e' = f' ()
        in Left $ err (srcSpan e') (d (val e'))
     Right s  -> Right (fst s)
   where
     sEnv = seSort env
-    f    = (`lookupSEnvWithDistance` sEnv)
+    envLookup = (`lookupSEnvWithDistance` sEnv)
     d m  = vcat [ "elaborate" <+> text (val msg) <+> "failed on:"
                 , nest 4 (pprint e)
                 , "with error"

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -718,7 +718,7 @@ unApplySortedReft :: SortedReft -> SortedReft
 unApplySortedReft sr = sr { sr_reft = mapPredReft unApply (sr_reft sr) }
 
 unApply :: Expr -> Expr
-unApply = Vis.trans (Vis.defaultVisitor { Vis.txExpr = const go }) () ()
+unApply = Vis.mapExprOnExpr go
   where
     go (ECst (EApp (EApp f e1) e2) _)
       | Just _ <- unApplyAt f = EApp e1 e2

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -50,7 +50,14 @@ module Language.Fixpoint.SortCheck  (
   -- * Sort-Directed Transformations
   , Elaborate (..)
   , applySorts
-  , unElab, unElabSortedReft, unApplyAt
+  , elabApply
+  , elabExpr
+  , elabNumeric
+  , unApply
+  , unElab
+  , unElabSortedReft
+  , unApplySortedReft
+  , unApplyAt
   , toInt
 
   -- * Predicates on Sorts
@@ -701,6 +708,9 @@ unElab = Vis.stripCasts . unApply
 
 unElabSortedReft :: SortedReft -> SortedReft
 unElabSortedReft sr = sr { sr_reft = mapPredReft unElab (sr_reft sr) }
+
+unApplySortedReft :: SortedReft -> SortedReft
+unApplySortedReft sr = sr { sr_reft = mapPredReft unApply (sr_reft sr) }
 
 unApply :: Expr -> Expr
 unApply = Vis.trans (Vis.defaultVisitor { Vis.txExpr = const go }) () ()

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -984,6 +984,7 @@ instance Fixpoint (M.HashMap SubcId [AutoRewrite]) where
       fixRW rw@(AutoRewrite args lhs rhs) =
           text ("autorewrite " ++ show (hash rw))
           <+> hsep (map toFix args)
+          <+> text "="
           <+> text "{"
           <+> toFix lhs
           <+> text "="

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -80,6 +80,7 @@ module Language.Fixpoint.Types.Refinements (
   , dropECst
   , eApps
   , eAppC
+  , eCst
   , exprKVars
   , exprSymbolsSet
   , splitEApp
@@ -443,7 +444,11 @@ splitPAnd (PAnd es) = concatMap splitPAnd es
 splitPAnd e         = [e]
 
 eAppC :: Sort -> Expr -> Expr -> Expr
-eAppC s e1 e2 = ECst (EApp e1 e2) s
+eAppC s e1 e2 = eCst (EApp e1 e2) s
+
+-- | Eliminates redundant casts
+eCst :: Expr -> Sort -> Expr
+eCst e t = ECst (dropECst e) t
 
 --------------------------------------------------------------------------------
 debruijnIndex :: Expr -> Int

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 {-# OPTIONS_GHC -Wno-orphans            #-}
 
@@ -84,6 +85,7 @@ module Language.Fixpoint.Types.Refinements (
   , exprKVars
   , exprSymbolsSet
   , splitEApp
+  , splitEAppThroughECst
   , splitPAnd
   , reftConjuncts
   , sortedReftSymbols
@@ -432,6 +434,12 @@ splitEApp :: Expr -> (Expr, [Expr])
 splitEApp = go []
   where
     go acc (EApp f e) = go (e:acc) f
+    go acc e          = (e, acc)
+
+splitEAppThroughECst :: Expr -> (Expr, [Expr])
+splitEAppThroughECst = go []
+  where
+    go acc (dropECst -> (EApp f e)) = go (e:acc) f
     go acc e          = (e, acc)
 
 dropECst :: Expr -> Expr

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -77,6 +77,7 @@ module Language.Fixpoint.Types.Refinements (
   -- * Destructing
   , flattenRefas
   , conjuncts
+  , dropECst
   , eApps
   , eAppC
   , exprKVars
@@ -431,6 +432,11 @@ splitEApp = go []
   where
     go acc (EApp f e) = go (e:acc) f
     go acc e          = (e, acc)
+
+dropECst :: Expr -> Expr
+dropECst e = case e of
+  ECst e' _ -> dropECst e'
+  _ -> e
 
 splitPAnd :: Expr -> [Expr]
 splitPAnd (PAnd es) = concatMap splitPAnd es

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -399,7 +399,7 @@ stripCasts = mapExprOnExpr go
 type CoSub = M.HashMap Symbol Sort
 
 applyCoSub :: CoSub -> Expr -> Expr
-applyCoSub coSub      = mapExpr fE
+applyCoSub coSub = mapExprOnExpr fE
   where
     fE (ECoerc s t e) = ECoerc  (txS s) (txS t) e
     fE (ELam (x,t) e) = ELam (x, txS t)         e

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -403,8 +403,9 @@ applyCoSub coSub      = mapExpr fE
   where
     fE (ECoerc s t e) = ECoerc  (txS s) (txS t) e
     fE (ELam (x,t) e) = ELam (x, txS t)         e
+    fE (ECst e t)     = ECst e (txS t)
     fE e              = e
-    txS               = mapSort fS
+    txS               = mapSortOnlyOnce fS
     fS (FObj a)       = {- FObj -} txV a
     fS t              = t
     txV a             = M.lookupDefault (FObj a) a coSub
@@ -420,6 +421,24 @@ foldSort f = step
     go b (FApp t1 t2)  = L.foldl' step b [t1, t2]
     go b (FAbs _ t)    = go b t
     go b _             = b
+
+-- | Like 'mapSort' but it doesn't substitute on the result
+-- of the function.
+--
+-- > mapSortOnlyOnce [(a,b), (b,c)] a = b
+--
+-- whereas
+--
+-- > mapSort [(a,b), (b,c)] a = c
+--
+mapSortOnlyOnce :: (Sort -> Sort) -> Sort -> Sort
+mapSortOnlyOnce f = step
+  where
+    step !x           = f $ go x
+    go (FFunc t1 t2) = FFunc (step t1) (step t2)
+    go (FApp t1 t2)  = FApp  (step t1) (step t2)
+    go (FAbs i t)    = FAbs i (step t)
+    go !t             = t
 
 mapSort :: (Sort -> Sort) -> Sort -> Sort
 mapSort f = step

--- a/tests/horn/neg/ple_sum_fuel.3.smt2
+++ b/tests/horn/neg/ple_sum_fuel.3.smt2
@@ -8,8 +8,8 @@
 (define sum(n : int) : int = { if (n <= 0) then (0) else (n + sum (n-1)) })
 
 (constraint 
-   (forall ((x int) ((5 <= x) && (0 <= (sum (x-5))))) 
-       ((15 <= (sum x)))
+   (forall ((x int) ((7 <= x) && (0 <= (sum (x-7)))))
+       ((28 <= (sum x)))
    )
 )
 

--- a/tests/horn/pos/ple_list01_adt.smt2
+++ b/tests/horn/pos/ple_list01_adt.smt2
@@ -8,7 +8,7 @@
 
 (constant len (func(1, [(Vec @(0)), int])))
 
-(define len(l: [a]) : int = {
+(define len(l: Vec a) : int = {
   if (is$VNil l) then 0 else (1 + len(tail l))
 })
 

--- a/tests/proof/GADTs.fq
+++ b/tests/proof/GADTs.fq
@@ -15,7 +15,12 @@ define add (x:int, y:int): int = {
 define proj (lq1 : (Field a),  lq2 : a): a = {
   if (is$FInt lq1) 
     then (coerce (int  ~ a) (add (coerce (a ~ int) lq2) 1)) 
-    else (coerce (bool ~ a) (not ((coerce (a ~ bool) lq2))))
+    else (coerce (bool ~ a)
+            // TODO: fix the parser so we can write
+            // (~ (coerce (a ~ bool) lq2))
+            (if coerce (a ~ bool) lq2 == true
+              then false
+              else true))
 } 
 
 match is$FInt FInt = (true)

--- a/tests/proof/IndPal00.fq
+++ b/tests/proof/IndPal00.fq
@@ -11,11 +11,11 @@ data IndPalindrome.PalP 1 = [
 
 match tail Cons lq_tmp$x##536 lq_tmp$x##537  =  (lq_tmp$x##537)
 match head Cons lq_tmp$x##536 lq_tmp$x##537  =  (lq_tmp$x##536)
-match isCons Cons lq_tmp$x##536 lq_tmp$x##537  =  (true)
-match isNil Cons lq_tmp$x##536 lq_tmp$x##537  =  (false)
+match is$Cons Cons lq_tmp$x##536 lq_tmp$x##537  =  (true)
+match is$Nil Cons lq_tmp$x##536 lq_tmp$x##537  =  (false)
 match len Cons lq_tmp$x##536 lq_tmp$x##537  =  ((1 + (len lq_tmp$x##537)))
-match isCons Nil  =  (false)
-match isNil Nil  =  (true)
+match is$Cons Nil  =  (false)
+match is$Nil Nil  =  (true)
 match len Nil  =  (0)
 match getPal IndPalindrome.Pal lq_tmp$x##540x  =  (lq_tmp$x##540x)
 match is$IndPalindrome.Pal IndPalindrome.Pal lq_tmp$x##540xx  =  (true)
@@ -32,7 +32,7 @@ match prop IndPalindrome.Pals lq_tmp$x##495 lq_tmp$x##496  =  ((IndPalindrome.Pa
 expand [23 : True]
 
 
-bind 137 l : {VV##890 : [a##a2pJ] | [((len VV##890) > 0); ((isCons VV##890) <=> true); ((isNil VV##890) <=> false)]}
+bind 137 l : {VV##890 : [a##a2pJ] | [((len VV##890) > 0); ((is$Cons VV##890) <=> true); ((is$Nil VV##890) <=> false)]}
 bind 138 d : {p : (IndPalindrome.Pal a##a2pJ) | [((prop p) = (IndPalindrome.Pal l)); 
                                                  ((is$IndPalindrome.Pals p) <=> false);
                                                  ((is$IndPalindrome.Pal0 p) <=> true);
@@ -46,7 +46,7 @@ constraint:
   env [137;
        138]
   lhs {VV##F##23 : [Char] | [true ]}
-  rhs {VV##F##23 : [Char] | [IndPalindrome.Pal0 = d && isCons l && (l == Nil) && false]}
+  rhs {VV##F##23 : [Char] | [IndPalindrome.Pal0 = d && is$Cons l && (l == Nil) && false]}
   id 23 tag [4]
 
 
@@ -69,7 +69,7 @@ constant GHC.Types.C# : (func(0 , [Char; Char]))
 constant GHC.List.drop : (func(1 , [int; [@(0)]; [@(0)]]))
 constant getPal : (func(1 , [(IndPalindrome.PalP @(0));
                                                                              [@(0)]]))
-constant isNil : (func(1 , [[@(0)]; bool]))
+constant is$Nil : (func(1 , [[@(0)]; bool]))
 constant Data.Foldable.length : (func(2 , [(@(1) @(0)); int]))
 constant x_Tuple33 : (func(3 , [(Tuple @(0) @(1) @(2)); @(2)]))
 constant is$36$GHC.Tuple.$40$$44$$41$ : (func(2 , [(Tuple @(0) @(1));
@@ -175,7 +175,7 @@ constant GHC.Integer.Type.Jn# : (func(0 , [GHC.Prim.ByteArray#;
 constant GHC.Classes.compare : (func(1 , [@(0);
                                           @(0);
                                           GHC.Types.Ordering]))
-constant isCons : (func(1 , [[@(0)]; bool]))
+constant is$Cons : (func(1 , [[@(0)]; bool]))
 constant papp2 : (func(4 , [(Pred @(0) @(1)); @(2); @(3); bool]))
 constant GHC.Stack.Types.EmptyCallStack : (GHC.Stack.Types.CallStack)
 constant GHC.Types.krep$36$$42$Arr$42$ : (GHC.Types.KindRep)

--- a/tests/proof/IndPal000.fq
+++ b/tests/proof/IndPal000.fq
@@ -1,14 +1,14 @@
 fixpoint "--rewrite"
 
 
-match isCons Cons x xs = (true)
-match isNil  Cons x xs = (false)
-match isCons Nil       = (false)
-match isNil  Nil       = (true)
+match is$Cons Cons x xs = (true)
+match is$Nil  Cons x xs = (false)
+match is$Cons Nil       = (false)
+match is$Nil  Nil       = (true)
 
 constant Cons : (func(1 , [@(0); [@(0)]; [@(0)]]))
-constant isCons : (func(1 , [[@(0)]; bool]))
-constant isNil : (func(1 , [[@(0)]; bool]))
+constant is$Cons : (func(1 , [[@(0)]; bool]))
+constant is$Nil : (func(1 , [[@(0)]; bool]))
 constant Nil : (func(1 , [[@(0)]]))
 
 expand [1 : True]
@@ -16,7 +16,7 @@ expand [1 : True]
 bind 1 l : {xs : [int] | true }
 constraint:
   env [1]
-  lhs {v:int | [isCons l && (l == Nil) ]}
+  lhs {v:int | [is$Cons l && (l == Nil) ]}
   rhs {v:int | [false]}
   id 1 tag []
 

--- a/tests/proof/list01.fq
+++ b/tests/proof/list01.fq
@@ -5,13 +5,6 @@ data Vec 1 = [
   | VCons { head : @(0), tail : Vec @(0)}
 ]
 
-define filter (lq1 : func(0 , [a##a29r;bool]),  lq2 : [a##a29r]) : [a##a29r] = {
-  if (isNil lq2) then Nil else (
-      if (lq1 (head lq2)) 
-        then (Cons (head lq2) (filter lq1 (tail lq2))) 
-        else (filter lq1 (tail lq2)))
-}
-
 constant len: (func(1, [(Vec @(0)); int]))
 
 match len VNil       = 0

--- a/tests/proof/list01_adt.fq
+++ b/tests/proof/list01_adt.fq
@@ -7,7 +7,7 @@ data Vec 1 = [
 
 constant len: (func(1, [(Vec @(0)); int]))
 
-define len(l: [a]) : int = {
+define len(l: Vec a) : int = {
   if (is$VNil l) then 0 else (1 + len(tail l))
 }
 

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -15,13 +15,16 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
       -- @PLE.simplify@ does not actually use all these fields, so we can get
       -- away with leaving some of them @undefined@.
       KN
-        { knSims = M.empty, -- :: Map Symbol ([Rewrite], IsUserDataSMeasure)
+        { knSims = M.empty, -- :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
+          knSimsByMeasureName = M.empty, -- :: Map Symbol ([Rewrite], IsUserDataSMeasure)
+          knNonUserDataMeasures = M.empty, -- :: Map Symbol [Rewrite]
           knAms = M.empty, -- :: Map Symbol Equation
           knContext = undefined, -- :: SMT.Context
           knPreds = undefined, -- :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
           knLams = [], -- :: ![(Symbol, Sort)]
           knSummary = [], -- :: ![(Symbol, Int)]
           knDCs = S.empty, -- :: !(S.HashSet Symbol)
+          knDataCtors = SM.empty, -- :: !(M.HashMap Symbol DataCtor)
           knSels = [], -- :: !SelectorMap
           knConsts = [], -- :: !ConstDCMap
           knAutoRWs = SM.empty, -- :: M.HashMap SubcId [AutoRewrite]

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -37,7 +37,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
         { icAssms = S.empty, -- S.HashSet Pred
           icCands = S.empty, -- :: S.HashSet Expr
           icEquals = S.empty, -- :: EvAccum
-          icSolved = S.empty, -- :: S.HashSet Expr
           icSimpl = SM.empty, -- :: !ConstMap
           icSubcId = Nothing, -- :: Maybe SubcId
           icANFs = []         -- :: [[(Symbol, SortedReft)]]

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -15,7 +15,7 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
       -- @PLE.simplify@ does not actually use all these fields, so we can get
       -- away with leaving some of them @undefined@.
       KN
-        { knSims = M.empty, -- :: Map Symbol [Rewrite]
+        { knSims = M.empty, -- :: Map Symbol ([Rewrite], IsUserDataSMeasure)
           knAms = M.empty, -- :: Map Symbol Equation
           knContext = undefined, -- :: SMT.Context
           knPreds = undefined, -- :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -16,8 +16,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
       -- away with leaving some of them @undefined@.
       KN
         { knSims = M.empty, -- :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
-          knSimsByMeasureName = M.empty, -- :: Map Symbol ([Rewrite], IsUserDataSMeasure)
-          knNonUserDataMeasures = M.empty, -- :: Map Symbol [Rewrite]
           knAms = M.empty, -- :: Map Symbol Equation
           knContext = undefined, -- :: SMT.Context
           knPreds = undefined, -- :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool


### PR DESCRIPTION
Fixes #500

The equations produced by PLE are smaller and fewer. No benchmark worsens, some benchmarks improve, and the regular PLE catches up with the interpreted PLE speed ups.

Major changes in this PR:

* Remove the surrounding context of unfoldings. This is point (4) in the description of #500. Unexpected: Had to figure out how to deal with lambda expressions so I preserve the bindings.
* Unfold equations only if any of the guards can really be reduced. This reduces equations drastically, since no nested if-then-else appear, only the results of reducing them. But it requires to refine proofs sometimes to do a case on inputs.
* Separated selectors and constructor tests from the other measures, as the smt solver already knows about them. They are used for rewriting candidate expressions, but otherwise produce no unfolding equations themselves.
* Have PLE and REST work with elaborated terms, where explicit casts appear to instantiate type variables. This allows to tell the smt solver what instantiation of  polymorphic variables is needed by a proof.
* Originally this PR unfolded measures as if they were reflected functions when the measure appears applied to an expression which isn't a constructor application. But we discovered that this worsened a benchmark. See https://github.com/ucsd-progsys/liquidhaskell/issues/2005.
* Iterate over the same candidates over an over, instead of producing new candidates on every iteration. This simplifies the PLE loop, which doesn't need to manage a dynamic list of candidates.
* Treat variables as special cases of application. This condenses the code responsible for unfoldings in fewer places, and removes initialization logic related to measures and reflected functions without arguments.
