### PR TITLE
Follow hlint suggestion to use camelCase.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -7,6 +7,5 @@
 - ignore: {name: "Use $>"} # 7 hints
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 10 hints
-- ignore: {name: "Use camelCase"} # 2 hints
 - ignore: {name: "Use const"} # 1 hint
 - ignore: {name: "Use infix"} # 4 hints

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -38,7 +38,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.ShareMap (ShareMap)
 import qualified Data.ShareMap as ShareMap
 import qualified Data.Text as Text
-import           Language.Fixpoint.SortCheck (exprSort_maybe)
+import           Language.Fixpoint.SortCheck (exprSortMaybe)
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.Constraints
 import           Language.Fixpoint.Types.Environments
@@ -683,7 +683,7 @@ inlineInExpr srLookup = mapExprOnExpr inlineExpr
 
     isEq r = r == Eq || r == Ueq
 
-    wrapWithCoercion br to e = case exprSort_maybe e of
+    wrapWithCoercion br to e = case exprSortMaybe e of
       Just from -> if from /= to then ECoerc from to e else e
       Nothing -> if br == Ueq then ECst e to else e
 

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -31,7 +31,7 @@ module Language.Fixpoint.SortCheck  (
   , sortExpr
   , checkSortExpr
   , exprSort
-  , exprSort_maybe
+  , exprSortMaybe
 
   -- * Unify
   , unifyFast
@@ -860,12 +860,12 @@ applySorts = {- tracepp "applySorts" . -} (defs ++) . Vis.fold vis () []
 -- | Expressions sort  ---------------------------------------------------------
 --------------------------------------------------------------------------------
 exprSort :: String -> Expr -> Sort
-exprSort msg e = fromMaybe (panic err') (exprSort_maybe e)
+exprSort msg e = fromMaybe (panic err') (exprSortMaybe e)
   where
     err'        = printf "exprSort [%s] on unexpected expression %s" msg (show e)
 
-exprSort_maybe :: Expr -> Maybe Sort
-exprSort_maybe = go
+exprSortMaybe :: Expr -> Maybe Sort
+exprSortMaybe = go
   where
     go (ECst _ s) = Just s
     go (ELam (_, sx) e) = FFunc sx <$> go e
@@ -1088,8 +1088,8 @@ unifyExpr _ _
 
 unifyExprApp :: Env -> Expr -> Expr -> Maybe TVSubst
 unifyExprApp f e1 e2 = do
-  t1 <- getArg $ exprSort_maybe e1
-  t2 <- exprSort_maybe e2
+  t1 <- getArg $ exprSortMaybe e1
+  t2 <- exprSortMaybe e2
   unify f (Just $ EApp e1 e2) t1 t2
   where
     getArg (Just (FFunc t1 _)) = Just t1


### PR DESCRIPTION
The `_maybe` suffix is common in the ghc codebase but not in `liquid-fixpoint`. Only one name triggers the `use camelCase` hlint suggestion, `exprSort_maybe`. Another one for #552?