### PR TITLE
Pickup the latest version of rest-rewrite.

### DIFF
--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,16 +12,12 @@ packages:
   original:
     hackage: hashable-1.3.5.0
 - completed:
-    name: rest-rewrite
-    version: 0.2.1
-    git: https://github.com/zgrannan/rest
+    hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
     pantry-tree:
-      size: 4369
-      sha256: b31fd014bcc8be8b0567463a59aefa5f67e9fe0ce4e41c56bbbba4618a80120a
-    commit: 9637b77823ef3ceb909510cad2508e828767f6fb
+      size: 3943
+      sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
   original:
-    git: https://github.com/zgrannan/rest
-    commit: 9637b77823ef3ceb909510cad2508e828767f6fb
+    hackage: rest-rewrite-0.3.0
 snapshots:
 - completed:
     size: 590102


### PR DESCRIPTION
This gets us the same version as `cabal update` then `cabal build` and `cabal freeze` does:

```cabal
- cabal.project.freeze
active-repositories: hackage.haskell.org:merge
constraints: any.HUnit ==1.6.2.0,
...
             any.rest-rewrite ==0.3.0,
...
```