### PR TITLE
Use haskell/actions and bump hlint version.

### DIFF
--- a/.github/workflows/hlint-ci.yml
+++ b/.github/workflows/hlint-ci.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: rwe/actions-hlint-setup@v1
+    - uses: haskell/actions/hlint-setup@v2
       name: Set up HLint
       with:
-        version: "3.3.6"
+        version: "3.4"
 
-    - uses: rwe/actions-hlint-run@v2
+    - uses: haskell/actions/hlint-run@v2
       name: hlint
       with:
         path: '["src/", "tests/", "unix/", "win/"]'


### PR DESCRIPTION
The `hlint-setup` and `hlint-run` actions have moved to the haskell organisation. Let's pick these actions up from there and bump the hlint version.