### PR TITLE
Only unfold if no undecided guard remains in an equation

### DIFF
--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -879,10 +879,9 @@ shortcut :: Knowledge -> ICtx -> EvalType -> Expr -> [Expr] -> EvalST (Expr, Boo
 shortcut γ ctx et (EIte i e1 e2) es2 = do
       (b, _) <- eval γ ctx et i
       b'  <- mytracepp ("evalEIt POS " ++ showpp (i, b)) <$> isValidCached γ b
-      let changed (a, _, c) = (a, True, c)
       case b' of
-        Just True -> changed <$> shortcut γ ctx et e1 es2
-        Just False -> changed <$> shortcut γ ctx et e2 es2
+        Just True -> shortcut γ ctx et e1 es2
+        Just False -> shortcut γ ctx et e2 es2
         _ -> return (eApps (EIte b e1 e2) es2, False, expand)
 shortcut _ _ _ e' es2 = return (eApps e' es2, True, noExpand)
 


### PR DESCRIPTION
A couple of tests in LH need to be changed as a result of this: facundominguez/liquidhaskell@814b84d

If we have functions like

    reflect at
    at :: xs:[a] -> { i:Int | 0<= i  && i < length xs } -> [a]
    at (y:_ys) 0 = y
    at (_y:ys) i = at ys (i-1)

    reflect filter
    filter :: (a -> Bool) -> xs:[a] -> [a]
    filter p [] = []
    filter p (y:ys) = if p y then y : filter p ys else filter p ys

Before this PR, equations are unfolded as soon as the first guard is decided.
* In the case of `at`, we don't need to know whether the index is `0`.
* In the case of `filter`, we don't need to know what is the return value of `p y`.

After this PR, we don't unfold unless all the guards are decided.
* In the case of `at`, we need to know that the list is non-empty and whether the index is `0`.
* In the case of `filter`, we need to know if the list is non-empty and what is the return value of `p y`.