### PR TITLE
Constrain vector < 0.13.

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -148,6 +148,7 @@ library
                   , rest-rewrite >= 0.3.0
                   , stm
                   , store
+                  , vector < 0.13
                   , syb
                   , text
                   , transformers


### PR DESCRIPTION
I need to constrain `vector < 0.13` in order to build `store` otherwise I get errors like:

```
src/Data/Store/Internal.hs:824:3: error:
    • No instance for (Store (Data.Vector.Unboxed.Base.Vector b))
        arising from a use of ‘peek’
```

Looking at `vector-0.13` release notes, this is the breaking change:

* Remove redundant `Storable` constraints on to/from `ForeignPtr` conversions: [#394](https://github.com/haskell/vector/pull/394)