### PR TITLE
Upgrade from deprecated warning flag syntax.

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -119,7 +119,7 @@ library
   other-modules:    Paths_liquid_fixpoint
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   src
-  ghc-options:      -W -Wno-missing-methods -fwarn-missing-signatures
+  ghc-options:      -W -Wno-missing-methods -Wmissing-signatures
   build-depends:    aeson
                   , ansi-terminal
                   , array

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -119,7 +119,7 @@ library
   other-modules:    Paths_liquid_fixpoint
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   src
-  ghc-options:      -W -fno-warn-missing-methods -fwarn-missing-signatures
+  ghc-options:      -W -Wno-missing-methods -fwarn-missing-signatures
   build-depends:    aeson
                   , ansi-terminal
                   , array
@@ -169,7 +169,7 @@ executable fixpoint
   other-modules:    Paths_liquid_fixpoint
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   bin
-  ghc-options:      -threaded -W -fno-warn-missing-methods
+  ghc-options:      -threaded -W -Wno-missing-methods
   build-depends:    base >= 4.9.1.0 && < 5, liquid-fixpoint
   if flag(devel)
     ghc-options: -Werror

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE ViewPatterns              #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Language.Fixpoint.Types.Errors (
   -- * Concrete Location Type

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE FlexibleContexts     #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 


### PR DESCRIPTION
> In GHC < 8 the syntax for -W<wflag> was -fwarn-<wflag> (e.g. -fwarn-incomplete-patterns). This spelling is deprecated, but still accepted for backwards compatibility. Likewise, -Wno-<wflag> used to be fno-warn-<wflag> (e.g. -fno-warn-incomplete-patterns).
> [Warnings and sanity-checking](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/using-warnings.html)