### PR TITLE
Handles are stdin, stdout, and stderr respectively.

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -264,7 +264,7 @@ smtWriteRaw me !s = {- SCC "smtWriteRaw" -} do
 
 -- | Reads a line of output from the SMT solver.
 smtReadRaw :: Context -> IO T.Text
-smtReadRaw me = {- SCC "smtReadRaw" -} TIO.hGetLine (ctxOut me)
+smtReadRaw me = TIO.hGetLine (ctxOut me)
 {-# SCC smtReadRaw  #-}
 
 hPutStrLnNow :: Handle -> LT.Text -> IO ()

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -254,18 +254,20 @@ negativeP
   = do v <- A.char '(' *> A.takeWhile1 (/=')') <* A.char ')'
        return $ "(" <> v <> ")"
 
-smtWriteRaw      :: Context -> Raw -> IO ()
+-- | Writes a line of input for the SMT solver and to the log if there is one.
+smtWriteRaw :: Context -> Raw -> IO ()
 smtWriteRaw me !s = {- SCC "smtWriteRaw" -} do
   -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
   --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
-  hPutStrLnNow (ctxCout me) s
+  hPutStrLnNow (ctxIn me) s
   maybe (return ()) (`LTIO.hPutStrLn` s) (ctxLog me)
 
-smtReadRaw       :: Context -> IO T.Text
-smtReadRaw me    = {- SCC "smtReadRaw" -} TIO.hGetLine (ctxCin me)
+-- | Reads a line of output from the SMT solver.
+smtReadRaw :: Context -> IO T.Text
+smtReadRaw me = {- SCC "smtReadRaw" -} TIO.hGetLine (ctxOut me)
 {-# SCC smtReadRaw  #-}
 
-hPutStrLnNow     :: Handle -> LT.Text -> IO ()
+hPutStrLnNow :: Handle -> LT.Text -> IO ()
 hPutStrLnNow h !s = LTIO.hPutStrLn h s >> hFlush h
 {-# SCC hPutStrLnNow #-}
 
@@ -305,7 +307,7 @@ makeContextNoLog cfg
 
 makeProcess :: Config -> IO Context
 makeProcess cfg
-  = do (hOut, hIn, _ ,pid) <- runInteractiveCommand $ smtCmd (solver cfg)
+  = do (hIn, hOut, _ ,pid) <- runInteractiveCommand $ smtCmd (solver cfg)
        loud <- isLoud
        hSetBuffering hOut $ BlockBuffering $ Just $ 1024*1024*64
        hSetBuffering hIn $ BlockBuffering $ Just $ 1024*1024*64
@@ -318,11 +320,11 @@ makeProcess cfg
            when (LT.null t) retry
            writeTVar queueTVar mempty
            return t
-         LTIO.hPutStr hOut t
-         hFlush hOut
+         LTIO.hPutStr hIn t
+         hFlush hIn
        return Ctx { ctxPid     = pid
-                  , ctxCin     = hIn
-                  , ctxCout    = hOut
+                  , ctxIn      = hIn
+                  , ctxOut     = hOut
                   , ctxLog     = Nothing
                   , ctxVerbose = loud
                   , ctxSymEnv  = mempty
@@ -334,8 +336,8 @@ makeProcess cfg
 cleanupContext :: Context -> IO ExitCode
 cleanupContext Ctx{..} = do
   cancel ctxAsync
-  hCloseMe "ctxCin"  ctxCin
-  hCloseMe "ctxCout" ctxCout
+  hCloseMe "ctxIn" ctxIn
+  hCloseMe "ctxOut"  ctxOut
   maybe (return ()) (hCloseMe "ctxLog") ctxLog
   waitForProcess ctxPid
 

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -96,12 +96,13 @@ data Response     = Ok
 -- | Information about the external SMT process
 data Context = Ctx
   { ctxPid     :: !ProcessHandle
-  , ctxCin     :: !Handle
-  , ctxCout    :: !Handle
+    -- | The handle for writing queries to, for input to the SMT solver.
+  , ctxIn      :: !Handle
+    -- | The handle for reading responses from, the output from the SMT solver.
+  , ctxOut     :: !Handle
   , ctxLog     :: !(Maybe Handle)
   , ctxVerbose :: !Bool
   , ctxSymEnv  :: !SymEnv
-    -- | The handle of the thread writing queries to the SMT solver
   , ctxAsync   :: Async ()
     -- | The next batch of queries to send to the SMT solver
   , ctxTVar    :: TVar Builder


### PR DESCRIPTION
I was trying out `typed-process` on this repo as a learning exercise and noticed that the call to `runInteractiveCommand` has flipped the names of the handles.

> `runInteractiveCommand :: String -> IO (Handle, Handle, Handle, ProcessHandle)`
> Runs a command using the shell, and returns Handles that may be used to communicate with the process via its stdin, stdout, and stderr respectively.
> [runInteractiveCommand](https://hackage.haskell.org/package/process-1.6.14.0/docs/System-Process.html#v:runInteractiveCommand)