### PR TITLE
Use dot instead of hyphen as separator for model.partial.

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -353,15 +353,12 @@ smtCmd Z3      = "z3 -smt2 -in"
 smtCmd Mathsat = "mathsat -input=smt2"
 smtCmd Cvc4    = "cvc4 --incremental -L smtlib2"
 
--- DON'T REMOVE THIS! z3 changed the names of options between 4.3.1 and 4.3.2...
 smtPreamble :: Config -> SMTSolver -> Context -> IO [LT.Text]
 smtPreamble cfg Z3 me
   = do smtWrite me "(get-info :version)"
        v:_ <- T.words . (!!1) . T.splitOn "\"" <$> smtReadRaw me
        checkValidStringFlag Z3 v cfg
-       if T.splitOn "." v `versionGreaterEq` ["4", "3", "2"]
-         then return $ z3_432_options ++ makeMbqi cfg ++ makeTimeout cfg ++ Thy.preamble cfg Z3
-         else return $ z3_options     ++ makeMbqi cfg ++ makeTimeout cfg ++ Thy.preamble cfg Z3
+       return $ z3_options ++ makeMbqi cfg ++ makeTimeout cfg ++ Thy.preamble cfg Z3
 smtPreamble cfg s _
   = checkValidStringFlag s "" cfg >> return (Thy.preamble cfg s)
 
@@ -519,13 +516,6 @@ makeMbqi :: Config -> [LT.Text]
 makeMbqi cfg
   | gradual cfg = [""]
   | otherwise   = ["\n(set-option :smt.mbqi false)"]
-
--- DON'T REMOVE THIS! z3 changed the names of options between 4.3.1 and 4.3.2...
-z3_432_options :: [LT.Text]
-z3_432_options
-  = [ "(set-option :auto-config false)"
-    , "(set-option :model true)"
-    , "(set-option :model.partial false)"]
 
 z3_options :: [LT.Text]
 z3_options

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -531,7 +531,7 @@ z3_options :: [LT.Text]
 z3_options
   = [ "(set-option :auto-config false)"
     , "(set-option :model true)"
-    , "(set-option :model-partial false)"]
+    , "(set-option :model.partial false)"]
 
 
 


### PR DESCRIPTION
This fixes #614 when `z3 >= 4.10`.

~~Please don't merge until our gh-actions are able to install z3 at that version. We currently install `z3-4.8.7`.~~

Update: I tested with `z3-4.8.7` and it is all good.

```
> cabal run fixpoint --  tests/horn/pos/test01.smt2
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - liquid-fixpoint-0.8.10.7.1 (lib) (configuration changed)
 - liquid-fixpoint-0.8.10.7.1 (exe:fixpoint) (configuration changed)
Configuring library for liquid-fixpoint-0.8.10.7.1..
Preprocessing library for liquid-fixpoint-0.8.10.7.1..
Building library for liquid-fixpoint-0.8.10.7.1..
Configuring executable 'fixpoint' for liquid-fixpoint-0.8.10.7.1..
Preprocessing executable 'fixpoint' for liquid-fixpoint-0.8.10.7.1..
Building executable 'fixpoint' for liquid-fixpoint-0.8.10.7.1..


Liquid-Fixpoint Copyright 2013-21 Regents of the University of California.
All Rights Reserved.

Working 166% [==============================================================]
Safe ( 2  constraints checked)

> z3 --version
Z3 version 4.8.7 - 64 bit
```