### PR TITLE
Use setup-z3 for `z3-4.8.7` and `z3-4.10.2`

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ghc ${{ matrix.ghc }}
+    name: ghc-${{ matrix.ghc }} z3-${{ matrix.z3 }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,16 +14,26 @@ jobs:
         ghc:
           - "8.10.7"
           - "9.2.3"
+        z3:
+          - "4.8.7"
+          - "4.10.2"
 
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
 
-      - name: Setup z3
+      - name: Setup z3-4.8.7
+        if: ${{ matrix.z3 == '4.8.7' }}
         uses: pavpanchekha/setup-z3@1.2.2
         with:
-          version: "4.8.7"
+          version: ${{ matrix.z3 }}
+
+      - name: Setup z3-4.10.2
+        if: ${{ matrix.z3 == '4.10.2' }}
+        uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
+        with:
+          version: ${{ matrix.z3 }}
 
       - name: Setup GHC and cabal-install
         uses: haskell/actions/setup@v2

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
 
-# WARNING: The setup-z3 action constructs the download filename from
+# NOTE: The setup-z3 action constructs the download filename from
 # z3-version-architecture-distribution. From z3-4.8.10 to z3-4.8.11, the z3
 # releases distribution name for use on ubuntu changed from ubuntu to
 # glibc-2.31.  SEE: https://github.com/Z3Prover/z3/releases
@@ -19,7 +19,6 @@ jobs:
           - "8.10.7"
           - "9.2.3"
         z3:
-          - "4.8.7"
           - "4.10.2"
 
     steps:
@@ -27,15 +26,7 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup z3-4.8.7
-        if: ${{ matrix.z3 == '4.8.7' }}
-        uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
-        with:
-          version: ${{ matrix.z3 }}
-          distribution: ubuntu-16.04
-
       - name: Setup z3-4.10.2
-        if: ${{ matrix.z3 == '4.10.2' }}
         uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
         with:
           version: ${{ matrix.z3 }}

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -32,7 +32,7 @@ jobs:
         uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
         with:
           version: ${{ matrix.z3 }}
-          distribution: ubuntu
+          distribution: ubuntu-16.04
 
       - name: Setup z3-4.10.2
         if: ${{ matrix.z3 == '4.10.2' }}

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+# WARNING: The setup-z3 action constructs the download filename from
+# z3-version-architecture-distribution. From z3-4.8.10 to z3-4.8.11, the z3
+# releases distribution name for use on ubuntu changed from ubuntu to
+# glibc-2.31.  SEE: https://github.com/Z3Prover/z3/releases
 jobs:
   build:
     name: ghc-${{ matrix.ghc }} z3-${{ matrix.z3 }}
@@ -25,9 +29,10 @@ jobs:
 
       - name: Setup z3-4.8.7
         if: ${{ matrix.z3 == '4.8.7' }}
-        uses: pavpanchekha/setup-z3@1.2.2
+        uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
         with:
           version: ${{ matrix.z3 }}
+          distribution: ubuntu
 
       - name: Setup z3-4.10.2
         if: ${{ matrix.z3 == '4.10.2' }}

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: hlint
+    name: hlint-3.4
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ghc ${{ matrix.ghc }}
+    name: ghc-${{ matrix.ghc }} z3-4.10.2
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,9 +20,9 @@ jobs:
           submodules: true
 
       - name: Setup z3
-        uses: pavpanchekha/setup-z3@1.2.2
+        uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
         with:
-          version: "4.8.7"
+          version: "4.10.2"
 
       - name: Setup Stack
         uses: haskell/actions/setup@v2

--- a/.github/workflows/stan.yml
+++ b/.github/workflows/stan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: ghc ${{ matrix.ghc }}
+    name: ghc-${{ matrix.ghc }} z3-4.10.2
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -31,10 +31,10 @@ jobs:
           path: ~/.cabal/store
           key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
-      - uses: pavpanchekha/setup-z3@1.2.2
+      - uses: pavpanchekha/setup-z3@6b2d476d7a9227e0d8d2b94f73cd9fcba91b5e98
         name: setup z3
         with:
-          version: "4.8.7"
+          version: "4.10.2"
 
       - name: update
         run: cabal update


### PR DESCRIPTION
Related to #614. See also https://github.com/pavpanchekha/setup-z3/issues/7. I'm only proposing a matrix of z3 for the cabal action. Other actions get `z3-4.10.2`.