### PR TITLE
Add mapToSet and mapPrj

### DIFF
--- a/tests/neg/maps02.fq
+++ b/tests/neg/maps02.fq
@@ -1,0 +1,9 @@
+bind 1 m1 : {v : Map_t Int Int | v = Map_default 0}
+bind 2 s1 : {v : Set_Set Int | v = (Set_cup (Set_sng 10) (Set_sng 30))}
+bind 3 m2 : {v : Map_t Int Int | v = (Map_store (Map_store m1 10 1) 20 1) } 
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Set_Set Int | v = Map_to_set m2 }
+  rhs {v : Set_Set Int | v = s1 } 
+  id 1 tag []

--- a/tests/pos/maps02.fq
+++ b/tests/pos/maps02.fq
@@ -1,0 +1,16 @@
+bind 1 m1 : {v : Map_t Int Int | v = Map_default 0}
+bind 2 s1 : {v : Set_Set Int | v = (Set_cup (Set_sng 10) (Set_sng 20))}
+bind 3 m2 : {v : Map_t Int Int | v = (Map_store (Map_store m1 10 1) 20 1) } 
+bind 4 m3 : {v : Map_t Int Int | v = (Map_store (Map_store m1 20 1) 10 1) } 
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Set_Set Int | v = Map_to_set m2 }
+  rhs {v : Set_Set Int | v = s1 } 
+  id 1 tag []
+
+constraint:
+  env [ 1; 2; 3; 4 ]
+  lhs {v : Set_Set Int | v = Map_to_set m3 }
+  rhs {v : Set_Set Int | v = s1 } 
+  id 2 tag []

--- a/tests/pos/maps03.fq
+++ b/tests/pos/maps03.fq
@@ -1,0 +1,10 @@
+bind 1 m1 : {v : Map_t Int Int | v = Map_default 0}
+bind 2 m2 : {v : Map_t Int Int | v = (Map_store (Map_store (Map_store m1 30 3) 10 1) 20 2) } 
+bind 3 s1 : {v : Set_Set Int | v = (Set_cup (Set_sng 30) (Set_sng 20))}
+bind 4 m3 : {v : Map_t Int Int | v = (Map_store (Map_store m1 20 2) 30 3) } 
+
+constraint:
+  env [ 1; 2; 3; 4 ]
+  lhs {v : Map_t Int Int | v = Map_project s1 m2}
+  rhs {v : Map_t Int Int | v = m3 } 
+  id 1 tag []

--- a/tests/pos/maps04.fq
+++ b/tests/pos/maps04.fq
@@ -1,0 +1,39 @@
+bind 1 m1 : {v : Map_t Int Int | v = Map_default 0}
+bind 2 m2 : {v : Map_t Int Int | v = (Map_store (Map_store (Map_store m1 30 3) 10 1) 20 2) } 
+bind 3 m3 : {v : Map_t Int Int | v = (Map_store (Map_store (Map_store m1 10 1) 20 1) 30 1) } 
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_max m2 m3}
+  rhs {v : Map_t Int Int | v = m2 } 
+  id 1 tag []
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_max m1 m2}
+  rhs {v : Map_t Int Int | v = m2 } 
+  id 2 tag []
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_max m1 m3}
+  rhs {v : Map_t Int Int | v = m3 } 
+  id 3 tag []
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_min m2 m3}
+  rhs {v : Map_t Int Int | v = m3 } 
+  id 4 tag []
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_min m1 m2}
+  rhs {v : Map_t Int Int | v = m1 } 
+  id 5 tag []
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_union_min m1 m3}
+  rhs {v : Map_t Int Int | v = m1 } 
+  id 6 tag []

--- a/tests/pos/maps05.fq
+++ b/tests/pos/maps05.fq
@@ -1,0 +1,9 @@
+bind 1 m1 : {v : Map_t Int Int | v = Map_default 0}
+bind 2 m2 : {v : Map_t Int Int | v = (Map_store (Map_store (Map_store m1 30 3) 10 1) 20 2) } 
+bind 3 m3 : {v : Map_t Int Int | v = (Map_store (Map_store (Map_store m1 130 3) 110 1) 120 2) } 
+
+constraint:
+  env [ 1; 2; 3 ]
+  lhs {v : Map_t Int Int | v = Map_shift 100 m2}
+  rhs {v : Map_t Int Int | v = m3 } 
+  id 1 tag []


### PR DESCRIPTION
Adds `mapToSet` and `mapPrj`, defined like this:

```
(define-fun smt_map_prj ((s LSet) (m Map)) Map ((_ map (ite (Bool Elt Elt) Elt)) s m ((as const (Array Elt Elt)) 0)))
(define-fun smt_map_to_set ((m Map)) LSet ((_ map (> (Elt Elt) Bool)) m ((as const (Array Elt Elt)) 0)))
```

The intent is to make it possible (in the liquidhaskell repo) to write a function that unions two bags (in `Language.Haskell.Liquid.Bag`) by choosing the first non-zero element rather than by summing the elements.

The implementations in this PR bake in zero as a special value, further committing the `Map` type in liquid-fixpoint to bag interpretation.