### PR TITLE
Fail gracefully when SMT returns EOF

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -264,7 +264,10 @@ smtWriteRaw me !s = {- SCC "smtWriteRaw" -} do
 
 -- | Reads a line of output from the SMT solver.
 smtReadRaw :: Context -> IO T.Text
-smtReadRaw me = TIO.hGetLine (ctxOut me)
+smtReadRaw me = do
+  eof <- hIsEOF (ctxOut me)
+  if eof then Misc.errorstar "SMT returned End of File" else
+    TIO.hGetLine (ctxOut me)
 {-# SCC smtReadRaw  #-}
 
 hPutStrLnNow :: Handle -> LT.Text -> IO ()


### PR DESCRIPTION
Fixes #231
Whenever the SMT command returns EOF (typically when the SMT command is not found), the program stops with message "SMT returned End of File".

To test it,
```sh
$ command -v z3
$ echo $?
1
$ stack exec fixpoint -- tests/pos/adt.fq
[...]
Working   0% [.................................................................]
fixpoint: 
**** ERROR *********************************************************************
**** ERROR *********************************************************************
**** ERROR *********************************************************************
SMT returned End of File
**** ERROR *********************************************************************
**** ERROR *********************************************************************
**** ERROR *********************************************************************

CallStack (from HasCallStack):
  error, called at src/Language/Fixpoint/Misc.hs:156:14 in liquid-fixpoint-0.8.10.7.1-6wSG354KhckBRT3ofw9cCu:Language.Fixpoint.Misc
  errorstar, called at src/Language/Fixpoint/Smt/Interface.hs:269:15 in liquid-fixpoint-0.8.10.7.1-6wSG354KhckBRT3ofw9cCu:Language.Fixpoint.Smt.Interface
```