### PR TITLE
Support the newest Z3 version (z3-4.11.2)

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -523,8 +523,7 @@ makeMbqi cfg
 z3_options :: [LT.Text]
 z3_options
   = [ "(set-option :auto-config false)"
-    , "(set-option :model true)"
-    , "(set-option :model.partial false)"]
+    , "(set-option :model true)" ]
 
 
 


### PR DESCRIPTION
Running Liquid Haskell with newer versions of z3 causes this error:
```
crash: SMTLIB2 respSat = Error "line 4 column 27: unknown parameter 'model_partial', this is an old parameter name, invoke 'z3 -p' to obtain the new parameter list"
```
Mentioned in this issue: https://github.com/ucsd-progsys/liquid-fixpoint/issues/622
In this pr we removed the z3 "model.partial false".
On older versions of z3 the default option was already false.
Invoke `z3 -p` and we get:
```
[module] model
    ...
    partial (bool) (default: false)
```