### PR TITLE
Show ($k x y) such that it can be fed back to the parser

### DIFF
--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -274,7 +274,7 @@ instance Show (Var a) where
 
 instance Show Pred where
   show (Reft p)   = parens $ F.showpp p
-  show (Var x xs) = parens $ unwords (F.symbolString <$> x:xs)
+  show (Var x xs) = parens $ "$" ++ unwords (F.symbolString <$> x:xs)
   show (PAnd ps)  = parens $ unwords $ "and": map show ps
 
 instance Show (Cstr a) where
@@ -291,7 +291,7 @@ instance F.PPrint (Var a) where
 
 instance F.PPrint Pred where
   pprintPrec k t (Reft p)   = P.parens $ F.pprintPrec k t p
-  pprintPrec _ _ (Var x xs) = P.parens $ P.hsep (P.ptext . F.symbolString <$> x:xs)
+  pprintPrec _ _ (Var x xs) = P.parens $ P.ptext "$" <> P.hsep (P.ptext . F.symbolString <$> x:xs)
   pprintPrec k t (PAnd ps)  = P.parens $ P.vcat $ P.ptext "and" : map (F.pprintPrec (k+2) t) ps
 
 instance F.PPrint (Cstr a) where


### PR DESCRIPTION
Even though Haskell is not, by design, a homoiconic language a-la Lisp, in some cases having Show produce strings that can be parsed back is advantageous.  For example, LiquidFixpoint's clients such as Sprite, may dump VCs in LF format; these dumps can be a valuable aid in understanding the code.  This series of commits ensures the dumped VCs are in fact valid LF.