### PR TITLE
Use BindInfo to produce better errors for Elaborate crashes

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -533,7 +533,7 @@ z3_options
 
 
 --------------------------------------------------------------------------------
-declare :: Context -> IO () -- SolveM ()
+declare :: Context -> IO ()
 --------------------------------------------------------------------------------
 declare me = do
   forM_ dss    $           smtDataDecl me
@@ -605,4 +605,3 @@ distinctLiterals xts = [ es | (_, es) <- tess ]
     tess             = Misc.groupList [(t, F.expr x) | (x, t) <- xts, notFun t]
     notFun           = not . F.isFunctionSortedReft . (`F.RR` F.trueReft)
     -- _notStr          = not . (F.strSort ==) . F.sr_sort . (`F.RR` F.trueReft)
-

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -128,7 +128,7 @@ class Elaborate a where
 instance (Loc a) => Elaborate (SInfo a) where
   elaborate x senv si = si
     { F.cm      = elaborate x senv <$> F.cm      si
-    , F.bs      = bs' -- elaborate x senv  $  F.bs      si
+    , F.bs      = bs'
     , F.asserts = elaborate x senv <$> F.asserts si
     }
     where
@@ -213,10 +213,6 @@ instance Loc a => Elaborate (Bindings a) where
                       Just ann -> (msg' i x sr) { loc = l } where SS l _ = srcSpan ann
                       Nothing  -> msg' i x sr
        msg' i x sr = z { val = val z ++ unwords [" elabBE",  show i, show x, show sr] }
-      --  z' i  x sr  = z { val = val z ++ msg i x sr }
-      --  msg i x sr  = unwords [" elabBE",  show i, show x, show sr]
-
-
 instance (Loc a) => Elaborate (SimpC a) where
   elaborate msg env c = c {_crhs = elaborate msg' env (_crhs c) }
     where msg'        = atLoc c (val msg)


### PR DESCRIPTION
cf https://github.com/ucsd-progsys/liquidhaskell/issues/2113

and general elaboration panic which (previously) failed without any source information.