### PR TITLE
More cleanup for fixpoint/elab/crash/error

### DIFF
--- a/src/Language/Fixpoint/Horn/Solve.hs
+++ b/src/Language/Fixpoint/Horn/Solve.hs
@@ -79,4 +79,3 @@ solve cfg q = do
   whenLoud $ putStrLn $ F.showpp c
   q <- eliminate cfg ({- void $ -} q { H.qCstr = c })
   Solver.solve cfg (hornFInfo cfg q)
-

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1409,7 +1409,7 @@ crashP :: Parser a -> Parser (FixResult a)
 crashP pp = do
   i   <- pp
   msg <- takeWhileP Nothing (const True) -- consume the rest of the input
-  return $ Crash [i] msg
+  return $ Crash [(i, Nothing)] msg
 
 predSolP :: Parser Expr
 predSolP = parens (predP  <* (comma >> iQualP))

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -315,7 +315,7 @@ isUnsafe _ = False
 instance (Ord a, Fixpoint a) => Fixpoint (FixResult (SubC a)) where
   toFix (Safe stats)     = text "Safe (" <+> text (show $ Solver.checked stats) <+> " constraints checked)"
   -- toFix (UnknownError d) = text $ "Unknown Error: " ++ d
-  toFix (Crash xs msg)   = vcat $ [ text "Crash!" ] ++  pprSinfos "CRASH: " xs ++ [parens (text msg)]
+  toFix (Crash xs msg)   = vcat $ [ text "Crash!" ] ++  pprSinfos "CRASH: " (fst <$> xs) ++ [parens (text msg)]
   toFix (Unsafe _ xs)    = vcat $ text "Unsafe:" : pprSinfos "WARNING: " xs
 
 pprSinfos :: (Ord a, Fixpoint a) => String -> [SubC a] -> [Doc]


### PR DESCRIPTION
related to previous PR #636 -- now return the error-string from fixpoint so clients can render it if desired.