### PR TITLE
`Language.Fixpoint.Smt.Interface`: use `smtlib-backends` for managing the solver process

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,10 @@
 packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/tweag/smtlib-backends
+    tag: 712cb070a8cf697876554ab190058e8cfd0bcd80
+    subdir:
+      .
+      smtlib-backends-z3
+      smtlib-backends-process

--- a/cabal.project
+++ b/cabal.project
@@ -2,12 +2,3 @@ packages: .
 
 package liquid-fixpoint
   flags: +devel +link-z3-as-a-library
-
-source-repository-package
-    type: git
-    location: https://github.com/tweag/smtlib-backends
-    tag: d309d6cc09298cd575020c791b7affa7e0098f1f
-    subdir:
-      .
-      smtlib-backends-z3
-      smtlib-backends-process

--- a/cabal.project
+++ b/cabal.project
@@ -3,7 +3,7 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/tweag/smtlib-backends
-    tag: 712cb070a8cf697876554ab190058e8cfd0bcd80
+    tag: d309d6cc09298cd575020c791b7affa7e0098f1f
     subdir:
       .
       smtlib-backends-z3

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,8 @@
 packages: .
 
+package liquid-fixpoint
+  flags: +devel +link-z3-as-a-library
+
 source-repository-package
     type: git
     location: https://github.com/tweag/smtlib-backends

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -128,7 +128,7 @@ library
                   , base                 >= 4.9.1.0 && < 5
                   , binary
                   , boxes
-                  , bytestring
+                  , bytestring >= 0.10.2.1
                   , cereal
                   , cmdargs
                   , containers
@@ -145,7 +145,11 @@ library
                   , parser-combinators
                   , pretty               >= 1.1.3.1
                   , process
+                  , typed-process
                   , rest-rewrite >= 0.3.0
+                  , smtlib-backends
+                  , smtlib-backends-process
+                  , smtlib-backends-z3
                   , stm
                   , store
                   , vector < 0.13
@@ -193,6 +197,7 @@ test-suite test
                   , mtl           >= 2.2.2
                   , optparse-applicative
                   , process
+                  , typed-process
                   , stm           >= 2.4
                   , tagged
                   , tasty         >= 0.10

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -41,6 +41,11 @@ source-repository head
   type: git
   location: https://github.com/ucsd-progsys/liquid-fixpoint
 
+flag link-z3-as-a-library
+  description: link z3 as a library for faster interactions with the SMT solver
+  manual: True
+  default: False
+
 flag devel
   description: turn on stricter error reporting for development
   manual: True
@@ -49,6 +54,7 @@ flag devel
 library
   import: warnings
   exposed-modules:  Data.ShareMap
+                    Language.Fixpoint.Conditional.Z3
                     Language.Fixpoint.Defunctionalize
                     Language.Fixpoint.Graph
                     Language.Fixpoint.Graph.Deps
@@ -149,7 +155,6 @@ library
                   , rest-rewrite >= 0.3.0
                   , smtlib-backends
                   , smtlib-backends-process
-                  , smtlib-backends-z3
                   , stm
                   , store
                   , vector < 0.13
@@ -160,6 +165,11 @@ library
   ghc-options:
     -fwrite-ide-info
     -hiedir=.hie
+  if flag(link-z3-as-a-library)
+    build-depends: smtlib-backends-z3
+    hs-source-dirs: src-cond/with-z3
+  else
+    hs-source-dirs: src-cond/without-z3
 
   if flag(devel)
     ghc-options: -Werror

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -153,8 +153,8 @@ library
                   , process
                   , typed-process
                   , rest-rewrite >= 0.3.0
-                  , smtlib-backends
-                  , smtlib-backends-process
+                  , smtlib-backends >= 0.3
+                  , smtlib-backends-process >= 0.3
                   , stm
                   , store
                   , vector < 0.13
@@ -166,7 +166,7 @@ library
     -fwrite-ide-info
     -hiedir=.hie
   if flag(link-z3-as-a-library)
-    build-depends: smtlib-backends-z3
+    build-depends: smtlib-backends-z3 >= 0.3
     hs-source-dirs: src-cond/with-z3
   else
     hs-source-dirs: src-cond/without-z3

--- a/src-cond/with-z3/Language/Fixpoint/Conditional/Z3.hs
+++ b/src-cond/with-z3/Language/Fixpoint/Conditional/Z3.hs
@@ -1,0 +1,12 @@
+module Language.Fixpoint.Conditional.Z3 where
+
+import qualified SMTLIB.Backends
+import qualified SMTLIB.Backends.Z3 as Z3
+
+makeZ3 :: IO (SMTLIB.Backends.Backend, IO ())
+makeZ3 = do
+    handle <- Z3.new Z3.defaultConfig
+    return (Z3.toBackend handle, Z3.close handle)
+
+builtWithZ3AsALibrary :: Bool
+builtWithZ3AsALibrary = True

--- a/src-cond/without-z3/Language/Fixpoint/Conditional/Z3.hs
+++ b/src-cond/without-z3/Language/Fixpoint/Conditional/Z3.hs
@@ -1,0 +1,7 @@
+module Language.Fixpoint.Conditional.Z3 where
+
+makeZ3 :: IO a
+makeZ3 = error "liquid-fixpoint: Not built with the Z3 backend. Please, enable the cabal flag link-z3-as-a-library."
+
+builtWithZ3AsALibrary :: Bool
+builtWithZ3AsALibrary = False

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -273,14 +273,13 @@ makeProcess
   -> Process.Config
   -> IO (SMTLIB.Backends.Backend, IO ())
 makeProcess ctxLog cfg
-  = do handle@Process.Handle {..} <- Process.new $ cfg
+  = do handle@Process.Handle {..} <- Process.new cfg
        case ctxLog of
          Nothing -> return ()
-         Just hLog -> void $ async $
-           (forever $ do
-               err <- LTIO.hGetLine $ hErr
+         Just hLog -> void $ async $ forever
+           (do err <- LTIO.hGetLine hErr
                LTIO.hPutStrLn hLog $ "OOPS, SMT solver error:" <> err
-           ) `catch` \SomeException {} -> return ()
+           ) `catch` \ SomeException {} -> return ()
        let backend = Process.toBackend handle
        hSetBuffering hOut $ BlockBuffering $ Just $ 1024 * 1024 * 64
        hSetBuffering hIn $ BlockBuffering $ Just $ 1024 * 1024 * 64

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -91,7 +91,6 @@ import qualified Data.Text.Lazy.Encoding  as LTE
 import qualified Data.Text.Lazy.IO        as LTIO
 import           System.Directory
 import           System.Console.CmdArgs.Verbosity
-import           System.Exit              hiding (die)
 import           System.FilePath
 import           System.IO
 import qualified System.Process.Typed
@@ -309,11 +308,11 @@ makeContext' cfg ctxLog
                   , ctxSymEnv  = mempty
                   }
 
--- | Close file handles and wait for the solver process to terminate.
-cleanupContext :: Context -> IO ExitCode
+-- | Close file handles and release the solver backend's resources.
+cleanupContext :: Context -> IO ()
 cleanupContext Ctx {..} = do
   maybe (return ()) (hCloseMe "ctxLog") ctxLog
-  ctxClose >> return ExitSuccess
+  ctxClose
 
 hCloseMe :: String -> Handle -> IO ()
 hCloseMe msg h = hClose h `catch` (\(exn :: IOException) -> putStrLn $ "OOPS, hClose breaks: " ++ msg ++ show exn)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE UndecidableInstances      #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 {-# LANGUAGE PatternGuards             #-}
+{-# LANGUAGE DoAndIfThenElse           #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
@@ -17,23 +18,6 @@
 --   By implementing a binary interface over the SMTLIB2 format defined at
 --   http://www.smt-lib.org/
 --   http://www.grammatech.com/resource/smt/SMTLIBTutorial.pdf
-
--- Note [Async SMT API]
---
--- The SMT solver is started in a separate process and liquid-fixpoint
--- communicates with it via pipes. This mechanism introduces some latency
--- since the queries need to reach the buffers in a separate process and
--- the OS has to switch contexts.
---
--- A remedy we currently try for this is to send multiple queries
--- together without waiting for the reply to each one, i.e. asynchronously.
--- We then collect the multiple answers after sending all of the queries.
---
--- The functions named @smt*Async@ implement this scheme.
---
--- An asynchronous thread is used to write the queries to prevent the
--- caller from blocking on IO, should the write buffer be full or should
--- an 'hFlush' call be necessary.
 
 module Language.Fixpoint.Smt.Interface (
 
@@ -55,7 +39,6 @@ module Language.Fixpoint.Smt.Interface (
 
     -- * Execute Queries
     , command
-    , smtExit
     , smtSetMbqi
 
     -- * Query API
@@ -70,12 +53,6 @@ module Language.Fixpoint.Smt.Interface (
     , smtBracket, smtBracketAt
     , smtDistinct
     , smtPush, smtPop
-    , smtAssertAsync
-    , smtCheckUnsatAsync
-    , readCheckUnsat
-    , smtBracketAsyncAt
-    , smtPushAsync
-    , smtPopAsync
 
     -- * Check Validity
     , checkValid
@@ -85,9 +62,6 @@ module Language.Fixpoint.Smt.Interface (
 
     ) where
 
-import           Control.Concurrent.Async (async, cancel)
-import           Control.Concurrent.STM
-  (TVar, atomically, modifyTVar, newTVarIO, readTVar, retry, writeTVar)
 import           Language.Fixpoint.Types.Config ( SMTSolver (..)
                                                 , Config
                                                 , solver
@@ -105,20 +79,23 @@ import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
 import           Control.Exception
+import           Data.ByteString.Builder  (lazyByteString)
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Char
 import qualified Data.HashMap.Strict      as M
 import           Data.Maybe              (fromMaybe)
 import qualified Data.Text                as T
+import qualified Data.Text.Encoding       as TE
 -- import           Data.Text.Format
-import qualified Data.Text.IO             as TIO
 import qualified Data.Text.Lazy           as LT
+import qualified Data.Text.Lazy.Encoding  as LTE
 import qualified Data.Text.Lazy.IO        as LTIO
 import           System.Directory
 import           System.Console.CmdArgs.Verbosity
 import           System.Exit              hiding (die)
 import           System.FilePath
 import           System.IO
-import           System.Process
+import           System.Process.Typed
 import qualified Data.Attoparsec.Text     as A
 -- import qualified Data.HashMap.Strict      as M
 import           Data.Attoparsec.Internal.Types (Parser)
@@ -127,6 +104,9 @@ import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Utils.Builder as Builder
 -- import qualified Language.Fixpoint.Types as F
 -- import           Language.Fixpoint.Types.PrettyPrint (tracepp)
+import qualified SMTLIB.Backends as Bck
+import qualified SMTLIB.Backends.Process as Process
+import qualified SMTLIB.Backends.Z3 as Z3
 
 {-
 runFile f
@@ -183,36 +163,40 @@ checkValids cfg f xts ps
 {-# SCC command #-}
 command              :: Context -> Command -> IO Response
 --------------------------------------------------------------------------------
-command me !cmd       = say >> hear cmd
+command Ctx {..} !cmd       = do
+  -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
+  --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
+  maybe (return ()) (`LTIO.hPutStrLn` cmdTxt) ctxLog
+  case cmd of
+    CheckSat   -> commandRaw
+    GetValue _ -> commandRaw
+    _          -> commandRaw_ >> return Ok
   where
-    env               = ctxSymEnv me
-    say               = smtWrite me ({-# SCC "Command-runSmt2" #-} Builder.toLazyText (runSmt2 env cmd))
-    hear CheckSat     = smtRead me
-    hear (GetValue _) = smtRead me
-    hear _            = return Ok
-
-smtExit :: Context -> IO ()
-smtExit me = asyncCommand me Exit
+    commandRaw_     = sendWith Bck.command_
+    commandRaw      = do
+      resp <- sendWith Bck.command
+      let respTxt = TE.decodeUtf8With (const $ const $ Just ' ') $ LBS.toStrict $ 
+                    LBS.reverse $ LBS.dropWhile isSpace $ LBS.reverse
+                    resp
+      parse respTxt
+    sendWith sender = sender ctxSolver $ lazyByteString $ LTE.encodeUtf8 cmdTxt
+    -- TODO don't rely on Text
+    cmdTxt          =
+      {-# SCC "Command-runSmt2" #-} Builder.toLazyText (runSmt2 ctxSymEnv cmd)
+    parse resp      = do
+      -- TODO change interface of parser now that the response needn't be read
+      -- line-by-line
+      res <- A.parseWith (return "") responseP resp
+      case A.eitherResult res of
+        Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
+        Right r -> do
+          maybe (return ()) (flip LTIO.hPutStrLn $ blt ("; SMT Says: " <> bShow r))
+            ctxLog
+          when ctxVerbose $ LTIO.putStrLn $ blt ("SMT Says: " <> bShow r)
+          return r
 
 smtSetMbqi :: Context -> IO ()
-smtSetMbqi me = asyncCommand me SetMbqi
-
-smtWrite :: Context -> Raw -> IO ()
-smtWrite me !s = smtWriteRaw me s
-
-smtRead :: Context -> IO Response
-smtRead me = {- SCC "smtRead" -} do
-  when (ctxVerbose me) $ LTIO.putStrLn "SMT READ"
-  ln  <- smtReadRaw me
-  res <- A.parseWith (smtReadRaw me) responseP ln
-  case A.eitherResult res of
-    Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
-    Right r -> do
-      maybe (return ()) (\h -> LTIO.hPutStrLn h $ blt ("; SMT Says: " <> bShow r)) (ctxLog me)
-      when (ctxVerbose me) $ LTIO.putStrLn $ blt ("SMT Says: " <> bShow r)
-      return r
-
-
+smtSetMbqi me = interact' me SetMbqi
 
 type SmtParser a = Parser T.Text a
 
@@ -254,42 +238,21 @@ negativeP
   = do v <- A.char '(' *> A.takeWhile1 (/=')') <* A.char ')'
        return $ "(" <> v <> ")"
 
--- | Writes a line of input for the SMT solver and to the log if there is one.
-smtWriteRaw :: Context -> Raw -> IO ()
-smtWriteRaw me !s = {- SCC "smtWriteRaw" -} do
-  -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
-  --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
-  hPutStrLnNow (ctxIn me) s
-  maybe (return ()) (`LTIO.hPutStrLn` s) (ctxLog me)
-
--- | Reads a line of output from the SMT solver.
-smtReadRaw :: Context -> IO T.Text
-smtReadRaw me = do
-  eof <- hIsEOF (ctxOut me)
-  if eof then Misc.errorstar "SMT returned End of File" else
-    TIO.hGetLine (ctxOut me)
-{-# SCC smtReadRaw  #-}
-
-hPutStrLnNow :: Handle -> LT.Text -> IO ()
-hPutStrLnNow h !s = LTIO.hPutStrLn h s >> hFlush h
-{-# SCC hPutStrLnNow #-}
-
 --------------------------------------------------------------------------
 -- | SMT Context ---------------------------------------------------------
 --------------------------------------------------------------------------
 
 --------------------------------------------------------------------------
-makeContext   :: Config -> FilePath -> IO Context
+makeContext :: Config -> FilePath -> IO Context
 --------------------------------------------------------------------------
 makeContext cfg f
-  = do me   <- makeProcess cfg
-       pre  <- smtPreamble cfg (solver cfg) me
-       createDirectoryIfMissing True $ takeDirectory smtFile
+  = do createDirectoryIfMissing True $ takeDirectory smtFile
        hLog <- openFile smtFile WriteMode
-       hSetBuffering hLog $ BlockBuffering $ Just $ 1024*1024*64
-       let me' = me { ctxLog = Just hLog }
-       mapM_ (smtWrite me') pre
-       return me'
+       hSetBuffering hLog $ BlockBuffering $ Just $ 1024 * 1024 * 64
+       me   <- makeContext' cfg $ Just hLog
+       pre  <- smtPreamble cfg (solver cfg) me
+       mapM_ (Bck.command_ (ctxSolver me) . lazyByteString . LTE.encodeUtf8) pre
+       return me
     where
        smtFile = extFileName Smt2 f
 
@@ -303,75 +266,81 @@ makeContextWithSEnv cfg f env = do
 
 makeContextNoLog :: Config -> IO Context
 makeContextNoLog cfg
-  = do me  <- makeProcess cfg
+  = do me  <- makeContext' cfg Nothing
        pre <- smtPreamble cfg (solver cfg) me
-       mapM_ (smtWrite me) pre
+       mapM_ (Bck.command_ (ctxSolver me) . lazyByteString . LTE.encodeUtf8) pre
        return me
 
-makeProcess :: Config -> IO Context
-makeProcess cfg
-  = do (hIn, hOut, _ ,pid) <- runInteractiveCommand $ smtCmd (solver cfg)
-       loud <- isLoud
-       hSetBuffering hOut $ BlockBuffering $ Just $ 1024*1024*64
-       hSetBuffering hIn $ BlockBuffering $ Just $ 1024*1024*64
-       -- See Note [Async SMT API]
-       queueTVar <- newTVarIO mempty
-       writerAsync <- async $ forever $ do
-         t <- atomically $ do
-           builder <- readTVar queueTVar
-           let t = Builder.toLazyText builder
-           when (LT.null t) retry
-           writeTVar queueTVar mempty
-           return t
-         LTIO.hPutStr hIn t
-         hFlush hIn
-       return Ctx { ctxPid     = pid
-                  , ctxIn      = hIn
-                  , ctxOut     = hOut
-                  , ctxLog     = Nothing
+makeProcess :: Maybe Handle -> ((LBS.ByteString -> IO ()) -> Process.Config) -> IO (Bck.Backend, ContextHandle)
+makeProcess ctxLog cfg
+  = do handle     <- Process.new $ cfg $
+                       \s -> case ctxLog of
+                         Nothing -> return ()
+                         Just hLog ->
+                           LBS.hPutStrLn hLog $
+                             "OOPS, external process error: " <> s
+       let backend = Process.toBackend handle
+           p       = Process.process handle
+           hIn     = getStdin p
+           hOut    = getStdout p
+       hSetBuffering hOut $ BlockBuffering $ Just $ 1024 * 1024 * 64
+       hSetBuffering hIn $ BlockBuffering $ Just $ 1024 * 1024 * 64
+       return (backend, Process handle)
+
+makeZ3 :: IO (Bck.Backend, ContextHandle)
+makeZ3
+  = do handle     <- Z3.new Z3.defaultConfig
+       let backend = Z3.toBackend handle
+       return (backend, Z3lib handle)
+
+makeContext' :: Config -> Maybe Handle -> IO Context
+makeContext' cfg ctxLog
+  = do (backend, handle) <- case solver cfg of
+         Z3      ->
+           {- "z3 -smt2 -in"                   -}
+           {- "z3 -smtc SOFT_TIMEOUT=1000 -in" -}
+           {- "z3 -smtc -in MBQI=false"        -}
+           makeProcess ctxLog $ Process.Config "z3" ["-smt2", "-in"]
+         Z3mem   -> makeZ3
+         Mathsat -> makeProcess ctxLog $ Process.Config "mathsat" ["-input=smt2"]
+         Cvc4    -> makeProcess ctxLog $
+                      Process.Config "cvc4" ["--incremental", "-L", "smtlib2"]
+       solver            <- Bck.initSolver Bck.Queuing backend
+       loud              <- isLoud
+       return Ctx { ctxSolver  = solver
+                  , ctxHandle  = handle
+                  , ctxLog     = ctxLog
                   , ctxVerbose = loud
                   , ctxSymEnv  = mempty
-                  , ctxAsync   = writerAsync
-                  , ctxTVar    = queueTVar
                   }
 
 -- | Close file handles and wait for the solver process to terminate.
 cleanupContext :: Context -> IO ExitCode
-cleanupContext Ctx{..} = do
-  cancel ctxAsync
-  hCloseMe "ctxIn" ctxIn
-  hCloseMe "ctxOut"  ctxOut
+cleanupContext Ctx {..} = do
   maybe (return ()) (hCloseMe "ctxLog") ctxLog
-  waitForProcess ctxPid
+  case ctxHandle of
+    Process h -> Process.kill h >> return ExitSuccess
+    Z3lib h -> Z3.close h >> return ExitSuccess
 
 hCloseMe :: String -> Handle -> IO ()
 hCloseMe msg h = hClose h `catch` (\(exn :: IOException) -> putStrLn $ "OOPS, hClose breaks: " ++ msg ++ show exn)
 
-{- "z3 -smt2 -in"                   -}
-{- "z3 -smtc SOFT_TIMEOUT=1000 -in" -}
-{- "z3 -smtc -in MBQI=false"        -}
-
-smtCmd         :: SMTSolver -> String --  T.Text
-smtCmd Z3      = "z3 -smt2 -in"
-smtCmd Mathsat = "mathsat -input=smt2"
-smtCmd Cvc4    = "cvc4 --incremental -L smtlib2"
-
 smtPreamble :: Config -> SMTSolver -> Context -> IO [LT.Text]
-smtPreamble cfg Z3 me
-  = do v <- getZ3Version me
-       checkValidStringFlag Z3 v cfg
-       return $ z3_options ++ makeMbqi cfg ++ makeTimeout cfg ++ Thy.preamble cfg Z3
-smtPreamble cfg s _
-  = checkValidStringFlag s [] cfg >> return (Thy.preamble cfg s)
+smtPreamble cfg s me
+  | s == Z3 || s == Z3mem
+    = do v <- getZ3Version me
+         checkValidStringFlag Z3 v cfg
+         return $ z3_options ++ makeMbqi cfg ++ makeTimeout cfg ++ Thy.preamble cfg Z3
+  | otherwise
+    = checkValidStringFlag s [] cfg >> return (Thy.preamble cfg s)
 
 getZ3Version :: Context -> IO [Int]
 getZ3Version me
-  = do smtWrite me "(get-info :version)"
-       -- resp is like (:version "4.8.15")
-       resp <- smtReadRaw me
-       case T.splitOn "\"" resp of
+  = do -- resp is like (:version "4.8.15")
+       resp <- Bck.command (ctxSolver me) "(get-info :version)"
+       case LBS.split '"' resp of
          _:vText:_ -> do
-           let parsedComponents = [ reads (T.unpack cText) | cText <- T.splitOn "." vText ]
+           let parsedComponents = [ reads (LBS.unpack cText) | cText <- LBS.split '.' vText ]
            sequence
              [ case pComponent of
                  [(c, "")] -> return c
@@ -419,7 +388,7 @@ smtDataDecl me ds = interact' me (DeclData ds)
 deconSort :: Sort -> ([Sort], Sort)
 deconSort t = case functionSort t of
                 Just (_, ins, out) -> (ins, out)
-                Nothing            -> ([] , t  )
+                Nothing            -> ([], t)
 
 -- hack now this is used only for checking gradual condition.
 smtCheckSat :: Context -> Expr -> IO Bool
@@ -443,47 +412,6 @@ smtDefineFunc me name params rsort e =
           e
 
 -----------------------------------------------------------------
--- Async calls to the smt
---
--- See Note [Async SMT API]
------------------------------------------------------------------
-
-asyncCommand :: Context -> Command -> IO ()
-asyncCommand me cmd = do
-  let env = ctxSymEnv me
-      cmdText = {-# SCC "asyncCommand-runSmt2" #-} Builder.toLazyText $ runSmt2 env cmd
-  asyncPutStrLn (ctxTVar me) cmdText
-  maybe (return ()) (`LTIO.hPutStrLn` cmdText) (ctxLog me)
-  where
-    asyncPutStrLn :: TVar Builder.Builder -> LT.Text -> IO ()
-    asyncPutStrLn tv t = atomically $
-      modifyTVar tv (`mappend` (Builder.fromLazyText t `mappend` Builder.fromString "\n"))
-
-smtAssertAsync :: Context -> Expr -> IO ()
-smtAssertAsync me p  = asyncCommand me $ Assert Nothing p
-
-smtCheckUnsatAsync :: Context -> IO ()
-smtCheckUnsatAsync me = asyncCommand me CheckSat
-
-smtBracketAsyncAt :: SrcSpan -> Context -> String -> IO a -> IO a
-smtBracketAsyncAt sp x y z = smtBracketAsync x y z `catch` dieAt sp
-
-smtBracketAsync :: Context -> String -> IO a -> IO a
-smtBracketAsync me _msg a   = do
-  smtPushAsync me
-  r <- a
-  smtPopAsync me
-  return r
-
-smtPushAsync, smtPopAsync   :: Context -> IO ()
-smtPushAsync me = asyncCommand me Push
-smtPopAsync me = asyncCommand me Pop
-
------------------------------------------------------------------
-
-{-# SCC readCheckUnsat #-}
-readCheckUnsat :: Context -> IO Bool
-readCheckUnsat me = respSat <$> smtRead me
 
 smtAssertAxiom :: Context -> Triggered Expr -> IO ()
 smtAssertAxiom me p  = interact' me (AssertAx p)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -170,16 +170,15 @@ command Ctx {..} !cmd       = do
   case cmd of
     CheckSat   -> commandRaw
     GetValue _ -> commandRaw
-    _          -> commandRaw_ >> return Ok
+    _          -> SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
   where
-    commandRaw_     = sendWith SMTLIB.Backends.command_
     commandRaw      = do
-      resp <- sendWith SMTLIB.Backends.command
+      resp <- SMTLIB.Backends.command ctxSolver cmdBS
       let respTxt = TE.decodeUtf8With (const $ const $ Just ' ') $ LBS.toStrict $ 
                     LBS.reverse $ LBS.dropWhile isSpace $ LBS.reverse
                     resp
       parse respTxt
-    sendWith sender = sender ctxSolver $ lazyByteString $ LTE.encodeUtf8 cmdTxt
+    cmdBS = lazyByteString $ LTE.encodeUtf8 cmdTxt
     -- TODO don't rely on Text
     cmdTxt          =
       {-# SCC "Command-runSmt2" #-} Builder.toLazyText (runSmt2 ctxSymEnv cmd)

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -25,7 +25,6 @@ module Language.Fixpoint.Smt.Types (
 
     -- * SMTLIB2 Process Context
     , Context (..)
-    , ContextHandle (..)
 
     ) where
 
@@ -34,8 +33,6 @@ import           Language.Fixpoint.Utils.Builder (Builder)
 import qualified Data.Text                as T
 import           Text.PrettyPrint.HughesPJ
 import qualified SMTLIB.Backends
-import qualified SMTLIB.Backends.Process as Process
-import qualified SMTLIB.Backends.Z3 as Z3
 
 import           System.IO                (Handle)
 -- import           Language.Fixpoint.Misc   (traceShow)
@@ -94,16 +91,13 @@ data Response     = Ok
                   | Error !T.Text
                   deriving (Eq, Show)
 
--- | Represention of the SMT solver backend
-data ContextHandle = Process Process.Handle | Z3lib Z3.Handle
-
 -- | Additional information around the SMT solver backend
 data Context = Ctx
   {
   -- | The high-level interface for interacting with the SMT solver backend.
     ctxSolver  :: SMTLIB.Backends.Solver
-  -- | The low-level handle for managing the SMT solver backend.
-  , ctxHandle :: ContextHandle
+  -- | The close operation of the SMT solver backend.
+  , ctxClose   :: IO ()
   , ctxLog     :: !(Maybe Handle)
   , ctxVerbose :: !Bool
   , ctxSymEnv  :: !SymEnv

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -33,7 +33,7 @@ import           Language.Fixpoint.Types
 import           Language.Fixpoint.Utils.Builder (Builder)
 import qualified Data.Text                as T
 import           Text.PrettyPrint.HughesPJ
-import qualified SMTLIB.Backends as Bck
+import qualified SMTLIB.Backends
 import qualified SMTLIB.Backends.Process as Process
 import qualified SMTLIB.Backends.Z3 as Z3
 
@@ -101,7 +101,7 @@ data ContextHandle = Process Process.Handle | Z3lib Z3.Handle
 data Context = Ctx
   {
   -- | The high-level interface for interacting with the SMT solver backend.
-    ctxSolver :: Bck.Solver
+    ctxSolver  :: SMTLIB.Backends.Solver
   -- | The low-level handle for managing the SMT solver backend.
   , ctxHandle :: ContextHandle
   , ctxLog     :: !(Maybe Handle)

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -25,18 +25,19 @@ module Language.Fixpoint.Smt.Types (
 
     -- * SMTLIB2 Process Context
     , Context (..)
+    , ContextHandle (..)
 
     ) where
 
-import           Control.Concurrent.Async (Async)
-import           Control.Concurrent.STM (TVar)
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Utils.Builder (Builder)
 import qualified Data.Text                as T
 import           Text.PrettyPrint.HughesPJ
+import qualified SMTLIB.Backends as Bck
+import qualified SMTLIB.Backends.Process as Process
+import qualified SMTLIB.Backends.Z3 as Z3
 
 import           System.IO                (Handle)
-import           System.Process
 -- import           Language.Fixpoint.Misc   (traceShow)
 
 --------------------------------------------------------------------------------
@@ -93,19 +94,19 @@ data Response     = Ok
                   | Error !T.Text
                   deriving (Eq, Show)
 
--- | Information about the external SMT process
+-- | Represention of the SMT solver backend
+data ContextHandle = Process Process.Handle | Z3lib Z3.Handle
+
+-- | Additional information around the SMT solver backend
 data Context = Ctx
-  { ctxPid     :: !ProcessHandle
-    -- | The handle for writing queries to, for input to the SMT solver.
-  , ctxIn      :: !Handle
-    -- | The handle for reading responses from, the output from the SMT solver.
-  , ctxOut     :: !Handle
+  {
+  -- | The high-level interface for interacting with the SMT solver backend.
+    ctxSolver :: Bck.Solver
+  -- | The low-level handle for managing the SMT solver backend.
+  , ctxHandle :: ContextHandle
   , ctxLog     :: !(Maybe Handle)
   , ctxVerbose :: !Bool
   , ctxSymEnv  :: !SymEnv
-  , ctxAsync   :: Async ()
-    -- | The next batch of queries to send to the SMT solver
-  , ctxTVar    :: TVar Builder
   }
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -799,7 +799,7 @@ withCtx cfg file env k = do
   ctx <- SMT.makeContextWithSEnv cfg file env
   _   <- SMT.smtPush ctx
   res <- k ctx
-  _   <- SMT.cleanupContext ctx
+  SMT.cleanupContext ctx
   return res
 
 infixl 9 ~>

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -77,7 +77,6 @@ runSolverM :: Config -> SolverInfo ann c -> SolveM ann a -> IO a
 runSolverM cfg sI act =
   bracket acquire release $ \ctx -> do
     res <- runStateT act' (s0 ctx)
-    smtExit ctx
     return (fst res)
   where
     s0 ctx   = SS ctx be (stats0 fi)
@@ -200,15 +199,12 @@ filterValid sp p qs = do
 {-# SCC filterValid_ #-}
 filterValid_ :: F.SrcSpan -> F.Expr -> F.Cand a -> Context -> IO [a]
 filterValid_ sp p qs me = catMaybes <$> do
-  smtAssertAsync me p
-  forM_ qs $ \(q, _x) ->
-    smtBracketAsyncAt sp me "filterValidRHS" $ do
-      smtAssertAsync me (F.PNot q)
-      smtCheckUnsatAsync me
-  forM qs $ \(_, x) -> do
-    valid <- readCheckUnsat me
-    return $ if valid then Just x else Nothing
-
+  smtAssert me p
+  forM qs $ \(q, x) ->
+    smtBracketAt sp me "filterValidRHS" $ do
+      smtAssert me (F.PNot q)
+      valid <- smtCheckUnsat me
+      return $ if valid then Just x else Nothing
 
 --------------------------------------------------------------------------------
 -- | `filterValidGradual ps [(x1, q1),...,(xn, qn)]` returns the list `[ xi | p => qi]`

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -1094,7 +1094,7 @@ withCtx cfg file env k = do
   ctx <- SMT.makeContextWithSEnv cfg file env
   _   <- SMT.smtPush ctx
   res <- k ctx
-  _   <- SMT.cleanupContext ctx
+  SMT.cleanupContext ctx
   return res
 
 

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -139,14 +139,15 @@ instance Read RESTOrdering where
 
 ---------------------------------------------------------------------------------------
 
-data SMTSolver = Z3 | Cvc4 | Mathsat
+data SMTSolver = Z3 | Z3mem | Cvc4 | Mathsat
                  deriving (Eq, Data, Typeable, Generic)
 
 instance Default SMTSolver where
-  def = Z3
+  def = Z3mem
 
 instance Show SMTSolver where
   show Z3      = "z3"
+  show Z3mem   = "z3 API"
   show Cvc4    = "cvc4"
   show Mathsat = "mathsat"
 

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -40,6 +40,7 @@ import System.Console.CmdArgs
 import System.Console.CmdArgs.Explicit
 import System.Environment
 
+import qualified Language.Fixpoint.Conditional.Z3 as Conditional.Z3
 import Language.Fixpoint.Utils.Files
 
 
@@ -143,7 +144,7 @@ data SMTSolver = Z3 | Z3mem | Cvc4 | Mathsat
                  deriving (Eq, Data, Typeable, Generic)
 
 instance Default SMTSolver where
-  def = Z3mem
+  def = if Conditional.Z3.builtWithZ3AsALibrary then Z3mem else Z3
 
 instance Show SMTSolver where
   show Z3      = "z3"

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,9 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
+- smtlib-backends-0.2
+- smtlib-backends-process-0.2
+- smtlib-backends-z3-0.2
 
 nix:
   packages: [z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,12 +13,12 @@ extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
 - git: https://github.com/tweag/smtlib-backends
-  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
 - git: https://github.com/tweag/smtlib-backends
-  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+  commit: d309d6cc09298cd575020c791b7affa7e0098f
   subdir: smtlib-backends-z3
 - git: https://github.com/tweag/smtlib-backends
-  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+  commit: d309d6cc09298cd575020c791b7affa7e009
   subdir: smtlib-backends-process
 - typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,12 +12,6 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
-- git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-  subdirs:
-    - .
-    - smtlib-backends-z3
-    - smtlib-backends-process
 
 nix:
   packages: [z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,14 +14,10 @@ extra-deps:
 - rest-rewrite-0.3.0
 - git: https://github.com/tweag/smtlib-backends
   commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-- git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-  subdir: smtlib-backends-z3
-- git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-  subdir: smtlib-backends-process
-- typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
-
+  subdirs:
+    - .
+    - smtlib-backends-z3
+    - smtlib-backends-process
 
 nix:
   packages: [z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,9 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
+- smtlib-backends-0.3
+- smtlib-backends-z3-0.3
+- smtlib-backends-process-0.3
 
 nix:
   packages: [z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,13 +9,19 @@ flags:
 packages:
 - '.'
 
-
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
-- smtlib-backends-0.2
-- smtlib-backends-process-0.2
-- smtlib-backends-z3-0.2
+- git: https://github.com/tweag/smtlib-backends
+  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+- git: https://github.com/tweag/smtlib-backends
+  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+  subdir: smtlib-backends-z3
+- git: https://github.com/tweag/smtlib-backends
+  commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+  subdir: smtlib-backends-process
+- typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
+
 
 nix:
   packages: [z3]

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,10 +15,10 @@ extra-deps:
 - git: https://github.com/tweag/smtlib-backends
   commit: d309d6cc09298cd575020c791b7affa7e0098f1f
 - git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e0098f
+  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
   subdir: smtlib-backends-z3
 - git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e009
+  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
   subdir: smtlib-backends-process
 - typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -7,20 +7,41 @@ packages:
 - completed:
     hackage: hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
     pantry-tree:
-      size: 1248
       sha256: 4df2f6b536a0fcc5f7d562cb29e373f27dc4a2747452ac5cc74c1599cab22fc5
+      size: 1248
   original:
     hackage: hashable-1.3.5.0
 - completed:
     hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
     pantry-tree:
-      size: 3943
       sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
+      size: 3943
   original:
     hackage: rest-rewrite-0.3.0
+- completed:
+    hackage: smtlib-backends-0.2@sha256:8135796ab4cd03c6511dc88d02f152b8dfe32c31d2c31c4867b4d06d03b13899,1205
+    pantry-tree:
+      sha256: 7d7f39dcf03d13362c9fa7c66a6ad3ef5086d577cc23c8db9cbadb6176f498cb
+      size: 274
+  original:
+    hackage: smtlib-backends-0.2
+- completed:
+    hackage: smtlib-backends-process-0.2@sha256:65bb9c83b39266db0155dce6b5a55a0e9c92cb9c97a8ce70775de0fdac551dea,1762
+    pantry-tree:
+      sha256: 374a45b6b1cb0f1c81d4505e01057b28d52fe1f70f01c412878e53aa09bbb35d
+      size: 401
+  original:
+    hackage: smtlib-backends-process-0.2
+- completed:
+    hackage: smtlib-backends-z3-0.2@sha256:3656cb3b0a337da9458c499915cd19500abb83257b4fea31e379160148c468c8,1950
+    pantry-tree:
+      sha256: a7f4aace1eafcec5c3bd98eb75c768d56b79e727b6ed231c6ba2ed02f8f7e26b
+      size: 390
+  original:
+    hackage: smtlib-backends-z3-0.2
 snapshots:
 - completed:
+    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
     size: 590102
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/27.yaml
-    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
   original: lts-18.27

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,26 +19,49 @@ packages:
   original:
     hackage: rest-rewrite-0.3.0
 - completed:
-    hackage: smtlib-backends-0.2@sha256:8135796ab4cd03c6511dc88d02f152b8dfe32c31d2c31c4867b4d06d03b13899,1205
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
+    name: smtlib-backends
     pantry-tree:
-      sha256: 7d7f39dcf03d13362c9fa7c66a6ad3ef5086d577cc23c8db9cbadb6176f498cb
-      size: 274
+      sha256: 1512451cd1b43d00344113f59a07602db6fadd5bd2e155f15785b9c173b32d61
+      size: 2600
+    version: '0.3'
   original:
-    hackage: smtlib-backends-0.2
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
 - completed:
-    hackage: smtlib-backends-process-0.2@sha256:65bb9c83b39266db0155dce6b5a55a0e9c92cb9c97a8ce70775de0fdac551dea,1762
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
+    name: smtlib-backends-z3
     pantry-tree:
-      sha256: 374a45b6b1cb0f1c81d4505e01057b28d52fe1f70f01c412878e53aa09bbb35d
-      size: 401
+      sha256: 89cd9eed0f80339077a5588c92abe7044f1f259a1e9a82aa7b2f70044553ae44
+      size: 453
+    subdir: smtlib-backends-z3
+    version: '0.3'
   original:
-    hackage: smtlib-backends-process-0.2
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
+    subdir: smtlib-backends-z3
 - completed:
-    hackage: smtlib-backends-z3-0.2@sha256:3656cb3b0a337da9458c499915cd19500abb83257b4fea31e379160148c468c8,1950
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
+    name: smtlib-backends-process
     pantry-tree:
-      sha256: a7f4aace1eafcec5c3bd98eb75c768d56b79e727b6ed231c6ba2ed02f8f7e26b
-      size: 390
+      sha256: 3218f35c149a504fbb5e2eb8a068865ad8a51aec04821b5ed237d3a5c0ca5bb0
+      size: 469
+    subdir: smtlib-backends-process
+    version: '0.3'
   original:
-    hackage: smtlib-backends-z3-0.2
+    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    git: https://github.com/tweag/smtlib-backends
+    subdir: smtlib-backends-process
+- completed:
+    hackage: typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
+    pantry-tree:
+      sha256: b3d6511483d5c869fdfb7220dc13b205730502162a1f6bdca9307a676f3fcb8c
+      size: 529
+  original:
+    hackage: typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
 snapshots:
 - completed:
     sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,45 +18,6 @@ packages:
       size: 3943
   original:
     hackage: rest-rewrite-0.3.0
-- completed:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    name: smtlib-backends
-    pantry-tree:
-      sha256: a73fe54aaa4fda7359595978928fd951c7d23cefc1bef2c2434de993d28fce3b
-      size: 2761
-    subdir: .
-    version: '0.3'
-  original:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    subdir: .
-- completed:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    name: smtlib-backends-z3
-    pantry-tree:
-      sha256: 4960cfc73b3d3621f8b93aaa1a674e961a4acfde097ec9cde96d83e649ee0ea8
-      size: 512
-    subdir: smtlib-backends-z3
-    version: '0.3'
-  original:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    subdir: smtlib-backends-z3
-- completed:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    name: smtlib-backends-process
-    pantry-tree:
-      sha256: c7661a98f129a1e8d78531353d03a68aa127d53506803b12f0b775e506ba2319
-      size: 528
-    subdir: smtlib-backends-process
-    version: '0.3'
-  original:
-    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-    git: https://github.com/tweag/smtlib-backends
-    subdir: smtlib-backends-process
 snapshots:
 - completed:
     sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,40 +19,40 @@ packages:
   original:
     hackage: rest-rewrite-0.3.0
 - completed:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     name: smtlib-backends
     pantry-tree:
-      sha256: 1512451cd1b43d00344113f59a07602db6fadd5bd2e155f15785b9c173b32d61
-      size: 2600
+      sha256: a73fe54aaa4fda7359595978928fd951c7d23cefc1bef2c2434de993d28fce3b
+      size: 2761
     version: '0.3'
   original:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
 - completed:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     name: smtlib-backends-z3
     pantry-tree:
-      sha256: 89cd9eed0f80339077a5588c92abe7044f1f259a1e9a82aa7b2f70044553ae44
-      size: 453
+      sha256: 4960cfc73b3d3621f8b93aaa1a674e961a4acfde097ec9cde96d83e649ee0ea8
+      size: 512
     subdir: smtlib-backends-z3
     version: '0.3'
   original:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     subdir: smtlib-backends-z3
 - completed:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     name: smtlib-backends-process
     pantry-tree:
-      sha256: 3218f35c149a504fbb5e2eb8a068865ad8a51aec04821b5ed237d3a5c0ca5bb0
-      size: 469
+      sha256: c7661a98f129a1e8d78531353d03a68aa127d53506803b12f0b775e506ba2319
+      size: 528
     subdir: smtlib-backends-process
     version: '0.3'
   original:
-    commit: 745f24891f0adb065551d2ad9b13dbfb43f504b8
+    commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     subdir: smtlib-backends-process
 - completed:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -18,6 +18,27 @@ packages:
       size: 3943
   original:
     hackage: rest-rewrite-0.3.0
+- completed:
+    hackage: smtlib-backends-0.3@sha256:917d88540a9ede7beedbe2ed13b492acddbce394d30ccf5d0ef4f4fba9aa2c12,1157
+    pantry-tree:
+      sha256: 59b578ae7df155a6c73a513358370747e3cc6229ebb44adaba9e0935f811539c
+      size: 275
+  original:
+    hackage: smtlib-backends-0.3
+- completed:
+    hackage: smtlib-backends-z3-0.3@sha256:cca514fa7349a34becb659ff747ec144b7d1902fec2826ff3a51f81388e1eafd,1822
+    pantry-tree:
+      sha256: e7aee82930b082ed4af91b32a80b8b65249441d458e392cbf2b4d47338e62404
+      size: 499
+  original:
+    hackage: smtlib-backends-z3-0.3
+- completed:
+    hackage: smtlib-backends-process-0.3@sha256:d4d7d02859383e0a43db2d8ce7ef01deffe1bcd356b2ff8626925c3a1c8db922,1600
+    pantry-tree:
+      sha256: d7d8ec52d07f4a59614000fd93d77b109d085d58f2d96e2c4b972f541c4e8287
+      size: 461
+  original:
+    hackage: smtlib-backends-process-0.3
 snapshots:
 - completed:
     sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,10 +25,12 @@ packages:
     pantry-tree:
       sha256: a73fe54aaa4fda7359595978928fd951c7d23cefc1bef2c2434de993d28fce3b
       size: 2761
+    subdir: .
     version: '0.3'
   original:
     commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
+    subdir: .
 - completed:
     commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
@@ -55,13 +57,6 @@ packages:
     commit: d309d6cc09298cd575020c791b7affa7e0098f1f
     git: https://github.com/tweag/smtlib-backends
     subdir: smtlib-backends-process
-- completed:
-    hackage: typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
-    pantry-tree:
-      sha256: b3d6511483d5c869fdfb7220dc13b205730502162a1f6bdca9307a676f3fcb8c
-      size: 529
-  original:
-    hackage: typed-process-0.2.10.1@sha256:cc35b76f2ce32c708cb2f68a1c4f661a8138196d958e34a2f214208333a73f46,2070
 snapshots:
 - completed:
     sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe

--- a/stack/stack-8.10.7.yaml
+++ b/stack/stack-8.10.7.yaml
@@ -12,3 +12,9 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
+- git: https://github.com/tweag/smtlib-backends
+  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
+  subdirs:
+    - .
+    - smtlib-backends-z3
+    - smtlib-backends-process

--- a/stack/stack-8.10.7.yaml
+++ b/stack/stack-8.10.7.yaml
@@ -12,9 +12,3 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
-- git: https://github.com/tweag/smtlib-backends
-  commit: d309d6cc09298cd575020c791b7affa7e0098f1f
-  subdirs:
-    - .
-    - smtlib-backends-z3
-    - smtlib-backends-process

--- a/stack/stack-8.10.7.yaml
+++ b/stack/stack-8.10.7.yaml
@@ -12,3 +12,6 @@ packages:
 extra-deps:
 - hashable-1.3.5.0
 - rest-rewrite-0.3.0
+- smtlib-backends-0.3
+- smtlib-backends-z3-0.3
+- smtlib-backends-process-0.3


### PR DESCRIPTION
This PR replaces the code for creating, writing to, reading from, and closing the SMT solver external process by calls to [the smtlib-backends library](https://github.com/tweag/smtlib-backends), "a Haskell library providing low-level functions for SMTLIB-based interaction with SMT solvers". There are two main advantages to using this library:
- there is less code to maintain on the side of liquid-fixpoint;
- additionally to running solvers as external processes, smtlib-backends also offers the option to send SMTLIB commands to Z3 through its bindings, which is both faster and less error-prone.

The code is definitely hacky as liquid-fixpoint wasn't designed around the use of smtlib-backends and I just tried to get a working version, so the point of this PR is not to be merged as is (although this is still possible) but rather to create a discussion around the use of smtlib-backends.

# What changed

## In `Language.Fixpoint.Types.Config`

The `SMTSolver` datatype is augmented with the `Z3mem` constructor which represents communication with Z3 through its bindings. Since this is faster and safer than running solvers as external processes, this constructor is set as the default value for this datatype.

## In `Language.Fixpoint.Smt.Types`

The `Context` datatype no longer contains a PID and input and output channels, but instead a `SMTLIB.Backends.Solver`, a high-level wrapper to SMT solver backends represented by the new `ContextHandle` datatype. This latter datatype is just a sum type of the different backend types available in smtlib-backends, that is `SMTLIB.Backends.Process.Handle` datatype from smtlib-backends-process (for running a solver as an external process) and the `SMTLIB.Backends.Z3.Handle` datatype from smtlib-backends-z3 (for communicating with Z3 through its bindings).

The `Context` datatype also no longer contains the fields used when sending commands asynchronously: I decided to not re-implement this for now, but it's definitely possible if deemed necessary.

## In `Language.Fixpoint.Smt.Interface`

Instead of manually spawing an external process, the `makeContext` function now uses the `new` function from either `SMTLIB.Backends.Process` or `SMTLIB.Backends.Z3` for initializing the solver backend. The corresponding `ContextHandle` is kept inside the context so that they're available at cleaning-up time.

The `SMTLIB.Backends.Solver` object is created from this backend along with the `Queuing` parameter. The latter means the solver comes with a queue to write commands to. This queue is only flushed and actually sent to the solver when absolutely necessary (that is when we need the solver's response), reducing the amount of interaction between liquid-fixpoint and the solver backend (sending commands to the solver is the costlier part of the interaction hence we try to do it as rarely as possible).

The writing of commands and reading of responses on the solver's input and output channels are replaced with calls to the `SMTLIB.Backends.command` and `SMTLIB.Backends.command_` functions. Since these functions write the command and read the solver's response in one atomic operation, this required adding an `IORef ByteString` buffer for holding the solver's response until liquid-fixpoint actually tries to read it.

The body of the `asyncCommand` function was replaced by a call to `smtWrite`, and the parallel process that sends the commands asynchronously was removed.

# Benchmarks

Here are the results I got when running LiquidHaskell's benchmarks:
![perf](https://user-images.githubusercontent.com/62126931/214088981-66fff8a9-e471-4773-801a-67cba357f3b7.png)

For most of the benchmarks, it seems the use of smtlib-backends doesn't matter much as LiquidHaskell probably doesn't spend a lot of time interacting with the SMT solver overall. But there are a few other benchmarks where using smtlib-backends seems to yield a significant speed-up.

Since this PR removes sending commands asynchronously, I also tried comparing my branch to [a version of liquid-fixpoint where I removed asynchronicity](https://github.com/ucsd-progsys/liquid-fixpoint/compare/develop...qaristote:liquid-fixpoint:qa/no_async):
![perf](https://user-images.githubusercontent.com/62126931/214090288-aa9d5f73-5463-43ca-8904-2f1eb7b1105d.png)

The results look weird to me as using smtlib-backends introduces both huge speed-ups and huge slow-downs. But I actually get the same differences when comparing liquid-fixpoint with no asynchronicity vs plain liquid-fixpoint, so this doesn't look like a problem with my branch:
![perf](https://user-images.githubusercontent.com/62126931/214091245-ae48fa2d-01c6-4d8a-baf3-27eecd8a3fda.png)

(I might have made some kind of mistake when running these benchmarks though).

# What's next

Ideally, liquid-fixpoint would be redesigned a bit around the use of smtlib-backends before it is actually merged. This would mainly entail not separating sending commands from reading the solver's response, since this requires the kinda dirty hack of keeping the solver's response around in a buffer. I'm not sure the intermediate representation of commands as `Text` is necessary anymore (smtlib-backends uses bytestrings).