### PR TITLE
`Language.Fixpoint.Smt.Interface`: replace parseWith with parseOnly

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           version: ${{ matrix.z3 }}
 
+      - name: Workaround runner image issue
+        # https://github.com/actions/runner-images/issues/7061
+        run: sudo chown -R $USER /usr/local/.ghcup
+
       - name: Setup GHC and cabal-install
         uses: haskell/actions/setup@v2
         with:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           version: "4.10.2"
 
+      - name: Workaround runner image issue
+        # https://github.com/actions/runner-images/issues/7061
+        run: sudo chown -R $USER /usr/local/.ghcup
+
       - name: Setup Stack
         uses: haskell/actions/setup@v2
         with:

--- a/.github/workflows/stan.yml
+++ b/.github/workflows/stan.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           submodules: true
 
+      - name: Workaround runner image issue
+        # https://github.com/actions/runner-images/issues/7061
+        run: sudo chown -R $USER /usr/local/.ghcup
+
       - uses: haskell/actions/setup@v1
         name: Setup GHC and cabal-install
         with:

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -181,10 +181,7 @@ command Ctx {..} !cmd       = do
     cmdTxt          =
       {-# SCC "Command-runSmt2" #-} Builder.toLazyText (runSmt2 ctxSymEnv cmd)
     parse resp      = do
-      -- TODO change interface of parser now that the response needn't be read
-      -- line-by-line
-      res <- A.parseWith (return "") responseP resp
-      case A.eitherResult res of
+      case A.parseOnly responseP resp of
         Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
         Right r -> do
           maybe (return ()) (flip LTIO.hPutStrLn $ blt ("; SMT Says: " <> bShow r))


### PR DESCRIPTION
Following #641, the SMT solver's response is supplied in one go and the parser doesn't need the ability to read additional lines. This PR thus replace the call to `fmap A.eitherResult . A.parseWith :: IO Text -> Parser a -> Text -> IO (Either String a)` with a call to `parseOnly :: Parser a -> Text -> Either String a`.