### PR TITLE
Simplify serialization to smtlib

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -78,6 +78,7 @@ import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
 import           Control.Exception
+import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as Char8
@@ -183,10 +184,10 @@ command Ctx {..} !cmd       = do
         Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
         Right r -> do
           forM_ ctxLog $ \h -> do
-            LBS.hPutStr h $ toLazyByteString ("; SMT Says: " <> bShow r)
+            LBS.hPutStr h $ BS.toLazyByteString ("; SMT Says: " <> bShow r)
             LBS.hPutStr h "\n"
           when ctxVerbose $ do
-            LBS.putStr $ toLazyByteString ("SMT Says: " <> bShow r)
+            LBS.putStr $ BS.toLazyByteString ("SMT Says: " <> bShow r)
             LBS.putStr "\n"
           return r
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -177,9 +177,7 @@ command Ctx {..} !cmd       = do
                     LBS.reverse $ Char8.dropWhile isSpace $ LBS.reverse
                     resp
       parse respTxt
-    -- TODO don't rely on Text
-    cmdBS         =
-      {-# SCC "Command-runSmt2" #-} Builder.toBuilder (runSmt2 ctxSymEnv cmd)
+    cmdBS = {-# SCC "Command-runSmt2" #-} runSmt2 ctxSymEnv cmd
     parse resp      = do
       case A.parseOnly responseP resp of
         Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
@@ -248,7 +246,7 @@ makeContext cfg f
        hSetBuffering hLog $ BlockBuffering $ Just $ 1024 * 1024 * 64
        me   <- makeContext' cfg $ Just hLog
        pre  <- smtPreamble cfg (solver cfg) me
-       mapM_ (SMTLIB.Backends.command_ (ctxSolver me) . toBuilder) pre
+       mapM_ (SMTLIB.Backends.command_ (ctxSolver me)) pre
        return me
     where
        smtFile = extFileName Smt2 f
@@ -265,7 +263,7 @@ makeContextNoLog :: Config -> IO Context
 makeContextNoLog cfg
   = do me  <- makeContext' cfg Nothing
        pre <- smtPreamble cfg (solver cfg) me
-       mapM_ (SMTLIB.Backends.command_ (ctxSolver me) . toBuilder) pre
+       mapM_ (SMTLIB.Backends.command_ (ctxSolver me)) pre
        return me
 
 makeProcess

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -112,7 +112,7 @@ instance SMTLIB2 SymConst where
 instance SMTLIB2 Constant where
   smt2 _ (I n)   = bShow n
   smt2 _ (R d)   = bFloat d
-  smt2 _ (L t _) = lbb t
+  smt2 _ (L t _) = fromText t
 
 instance SMTLIB2 Bop where
   smt2 _ Plus   = "+"

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -205,13 +205,11 @@ smt2App env e
 
 smt2Coerc :: SymEnv -> Sort -> Sort -> Expr -> Builder.Builder
 smt2Coerc env t1 t2 e
-  | t1' == t2'  = smt2 env e
+  | t1 == t2  = smt2 env e
   | otherwise = parenSeqs [Builder.fromText coerceFn , smt2 env e]
   where
     coerceFn  = symbolAtName coerceName env (ECoerc t1 t2 e) t
     t         = FFunc t1 t2
-    t1'       = smt2SortMono e env t1
-    t2'       = smt2SortMono e env t2
 
 splitEApp' :: Expr -> (Expr, [Expr])
 splitEApp'            = go []

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -15,6 +15,7 @@
 
 module Language.Fixpoint.Smt.Serialize (smt2SortMono) where
 
+import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Types
 import qualified Language.Fixpoint.Types.Visitor as Vis
@@ -30,44 +31,44 @@ instance SMTLIB2 (Symbol, Sort) where
   smt2 env c@(sym, t) = -- build "({} {})" (smt2 env sym, smt2SortMono c env t)
                         parenSeqs [smt2 env sym, smt2SortMono c env t]
 
-smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder.Builder
+smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder
 smt2SortMono = smt2Sort False
 smt2SortPoly = smt2Sort True
 
-smt2Sort :: (PPrint a) => Bool -> a -> SymEnv -> Sort -> Builder.Builder
+smt2Sort :: (PPrint a) => Bool -> a -> SymEnv -> Sort -> Builder
 smt2Sort poly _ env t = smt2 env (Thy.sortSmtSort poly (seData env) t)
 
-smt2data :: SymEnv -> [DataDecl] -> Builder.Builder
+smt2data :: SymEnv -> [DataDecl] -> Builder
 smt2data env = smt2data' env . map padDataDecl
 
-smt2data' :: SymEnv -> [DataDecl] -> Builder.Builder
+smt2data' :: SymEnv -> [DataDecl] -> Builder
 smt2data' env ds = seqs [ parens $ smt2many (smt2dataname env <$> ds)
                          , parens $ smt2many (smt2datactors env <$> ds)
                          ]
 
 
-smt2dataname :: SymEnv -> DataDecl -> Builder.Builder
+smt2dataname :: SymEnv -> DataDecl -> Builder
 smt2dataname env (DDecl tc as _) = parenSeqs [name, n]
   where
     name  = smt2 env (symbol tc)
     n     = smt2 env as
 
 
-smt2datactors :: SymEnv -> DataDecl -> Builder.Builder
+smt2datactors :: SymEnv -> DataDecl -> Builder
 smt2datactors env (DDecl _ as cs) = parenSeqs ["par", parens tvars, parens ds]
   where
     tvars        = smt2many (smt2TV <$> [0..(as-1)])
     smt2TV       = smt2 env . SVar
     ds           = smt2many (smt2ctor env as <$> cs)
 
-smt2ctor :: SymEnv -> Int -> DataCtor -> Builder.Builder
+smt2ctor :: SymEnv -> Int -> DataCtor -> Builder
 smt2ctor env _  (DCtor c [])  = smt2 env c
 smt2ctor env as (DCtor c fs)  = parenSeqs [smt2 env c, fields]
 
   where
     fields                 = smt2many (smt2field env as <$> fs)
 
-smt2field :: SymEnv -> Int -> DataField -> Builder.Builder
+smt2field :: SymEnv -> Int -> DataField -> Builder
 smt2field env as d@(DField x t) = parenSeqs [smt2 env x, smt2SortPoly d env $ mkPoly as t]
 
 -- | SMTLIB/Z3 don't like "unused" type variables; they get pruned away and
@@ -165,24 +166,24 @@ instance SMTLIB2 Expr where
 -- | smt2Cast uses the 'as x T' pattern needed for polymorphic ADT constructors
 --   like Nil, see `tests/pos/adt_list_1.fq`
 
-smt2Cast :: SymEnv -> Expr -> Sort -> Builder.Builder
+smt2Cast :: SymEnv -> Expr -> Sort -> Builder
 smt2Cast env (EVar x) t = smt2Var env x t
 smt2Cast env e        _ = smt2    env e
 
-smt2Var :: SymEnv -> Symbol -> Sort -> Builder.Builder
+smt2Var :: SymEnv -> Symbol -> Sort -> Builder
 smt2Var env x t
   | isLamArgSymbol x            = smtLamArg env x t
   | Just s <- symEnvSort x env
   , isPolyInst s t              = smt2VarAs env x t
   | otherwise                   = smt2 env x
 
-smtLamArg :: SymEnv -> Symbol -> Sort -> Builder.Builder
+smtLamArg :: SymEnv -> Symbol -> Sort -> Builder
 smtLamArg env x t = Builder.fromText $ symbolAtName x env () (FFunc t FInt)
 
-smt2VarAs :: SymEnv -> Symbol -> Sort -> Builder.Builder
+smt2VarAs :: SymEnv -> Symbol -> Sort -> Builder
 smt2VarAs env x t = parenSeqs ["as", smt2 env x, smt2SortMono x env t]
 
-smt2Lam :: SymEnv -> (Symbol, Sort) -> Expr -> Builder.Builder
+smt2Lam :: SymEnv -> (Symbol, Sort) -> Expr -> Builder
 smt2Lam env (x, xT) (ECst e eT) = parenSeqs [Builder.fromText lambda, x', smt2 env e]
   where
     x'                          = smtLamArg env x xT
@@ -191,7 +192,7 @@ smt2Lam env (x, xT) (ECst e eT) = parenSeqs [Builder.fromText lambda, x', smt2 e
 smt2Lam _ _ e
   = panic ("smtlib2: Cannot serialize unsorted lambda: " ++ showpp e)
 
-smt2App :: SymEnv -> Expr -> Builder.Builder
+smt2App :: SymEnv -> Expr -> Builder
 smt2App env e@(EApp (EApp f e1) e2)
   | Just t <- unApplyAt f
   = parenSeqs [Builder.fromText (symbolAtName applyName env e t), smt2s env [e1, e2]]
@@ -203,7 +204,7 @@ smt2App env e
   where
     (f, es)   = splitEApp' e
 
-smt2Coerc :: SymEnv -> Sort -> Sort -> Expr -> Builder.Builder
+smt2Coerc :: SymEnv -> Sort -> Sort -> Expr -> Builder
 smt2Coerc env t1 t2 e
   | t1 == t2  = smt2 env e
   | otherwise = parenSeqs [Builder.fromText coerceFn , smt2 env e]
@@ -218,12 +219,12 @@ splitEApp'            = go []
   --   go acc (ECst e _) = go acc e
     go acc e          = (e, acc)
 
-mkRel :: SymEnv -> Brel -> Expr -> Expr -> Builder.Builder
+mkRel :: SymEnv -> Brel -> Expr -> Expr -> Builder
 mkRel env Ne  e1 e2 = mkNe env e1 e2
 mkRel env Une e1 e2 = mkNe env e1 e2
 mkRel env r   e1 e2 = parenSeqs [smt2 env r, smt2 env e1, smt2 env e2]
 
-mkNe :: SymEnv -> Expr -> Expr -> Builder.Builder
+mkNe :: SymEnv -> Expr -> Expr -> Builder
 mkNe env e1 e2      = key "not" (parenSeqs ["=",  smt2 env e1, smt2 env e2])
 
 instance SMTLIB2 Command where
@@ -256,13 +257,13 @@ instance SMTLIB2 (Triggered Expr) where
   smt2 env (TR _ e)               = smt2 env e
 
 {-# INLINE smtTr #-}
-smtTr :: SymEnv -> Builder.Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> Builder.Builder
+smtTr :: SymEnv -> Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> Builder
 smtTr env q bs p t = key q (parens (smt2s env bs) <+> key "!" (smt2 env p <+> ":pattern" <> parens (smt2s env (makeTriggers t))))
 
 {-# INLINE smt2s #-}
-smt2s    :: SMTLIB2 a => SymEnv -> [a] -> Builder.Builder
+smt2s    :: SMTLIB2 a => SymEnv -> [a] -> Builder
 smt2s env as = smt2many (smt2 env <$> as)
 
 {-# INLINE smt2many #-}
-smt2many :: [Builder.Builder] -> Builder.Builder
+smt2many :: [Builder] -> Builder
 smt2many = seqs

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -42,6 +42,7 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
+import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -48,7 +48,6 @@ import           Language.Fixpoint.Types
 import           Language.Fixpoint.Smt.Types
 -- import qualified Data.HashMap.Strict      as M
 import           Data.Maybe (catMaybes)
-import qualified Data.Text.Lazy           as T
 -- import           Data.Text.Format
 import qualified Data.Text
 import           Data.String                 (IsString(..))
@@ -169,199 +168,196 @@ concatstrSort = mkFFunc 0 [strSort, strSort, strSort]
 string :: Raw
 string = strConName
 
-bFun :: Raw -> [(Builder, Builder)] -> Builder -> Builder -> T.Text
-bFun name xts out body = blt $ key "define-fun" (seqs [bb name, args, out, body])
+bFun :: Raw -> [(Builder, Builder)] -> Builder -> Builder -> Builder
+bFun name xts out body = key "define-fun" (seqs [fromText name, args, out, body])
   where
     args = parenSeqs [parens (x <+> t) | (x, t) <- xts]
 
-bFun' :: Raw -> [Builder] -> Builder -> T.Text
-bFun' name ts out = blt $ key "declare-fun" (seqs [bb name, args, out])
+bFun' :: Raw -> [Builder] -> Builder -> Builder
+bFun' name ts out = key "declare-fun" (seqs [fromText name, args, out])
   where
     args = parenSeqs ts
 
-bSort :: Raw -> Builder -> T.Text
-bSort name def = blt $ key "define-sort" (bb name <+> "()" <+> def)
+bSort :: Raw -> Builder -> Builder
+bSort name def = key "define-sort" (fromText name <+> "()" <+> def)
 
-z3Preamble :: Config -> [T.Text]
+z3Preamble :: Config -> [Builder]
 z3Preamble u
   = stringPreamble u ++
     [ bSort elt
         "Int"
     , bSort set
-        (key2 "Array" (bb elt) "Bool")
+        (key2 "Array" (fromText elt) "Bool")
     , bFun emp
         []
-        (bb set)
-        (parens (key "as const" (bb set) <+> "false"))
+        (fromText set)
+        (parens (key "as const" (fromText set) <+> "false"))
     , bFun sng
-        [("x", bb elt)]
-        (bb set)
-        (key3 "store" (parens (key "as const" (bb set) <+> "false")) "x" "true")
+        [("x", fromText elt)]
+        (fromText set)
+        (key3 "store" (parens (key "as const" (fromText set) <+> "false")) "x" "true")
     , bFun mem
-        [("x", bb elt), ("s", bb set)]
+        [("x", fromText elt), ("s", fromText set)]
         "Bool"
         "(select s x)"
     , bFun add
-        [("s", bb set), ("x", bb elt)]
-        (bb set)
+        [("s", fromText set), ("x", fromText elt)]
+        (fromText set)
         "(store s x true)"
     , bFun cup
-        [("s1", bb set), ("s2", bb set)]
-        (bb set)
+        [("s1", fromText set), ("s2", fromText set)]
+        (fromText set)
         "((_ map or) s1 s2)"
     , bFun cap
-        [("s1", bb set), ("s2", bb set)]
-        (bb set)
+        [("s1", fromText set), ("s2", fromText set)]
+        (fromText set)
         "((_ map and) s1 s2)"
     , bFun com
-        [("s", bb set)]
-        (bb set)
+        [("s", fromText set)]
+        (fromText set)
         "((_ map not) s)"
     , bFun dif
-        [("s1", bb set), ("s2", bb set)]
-        (bb set)
-        (key2 (bb cap) "s1" (key (bb com) "s2"))
+        [("s1", fromText set), ("s2", fromText set)]
+        (fromText set)
+        (key2 (fromText cap) "s1" (key (fromText com) "s2"))
     , bFun sub
-        [("s1", bb set), ("s2", bb set)]
+        [("s1", fromText set), ("s2", fromText set)]
         "Bool"
-        (key2 "=" (bb emp) (key2 (bb dif) "s1" "s2"))
+        (key2 "=" (fromText emp) (key2 (fromText dif) "s1" "s2"))
 
     -- Maps
     , bSort map
-        (key2 "Array" (bb elt) (bb elt))
+        (key2 "Array" (fromText elt) (fromText elt))
     , bFun sel
-        [("m", bb map), ("k", bb elt)]
-        (bb elt)
+        [("m", fromText map), ("k", fromText elt)]
+        (fromText elt)
         "(select m k)"
     , bFun sto
-        [("m", bb map), ("k", bb elt), ("v", bb elt)]
-        (bb map)
+        [("m", fromText map), ("k", fromText elt), ("v", fromText elt)]
+        (fromText map)
         "(store m k v)"
     , bFun mcup
-        [("m1", bb map), ("m2", bb map)]
-        (bb map)
-        (key2 (key "_ map" (key2 "+" (parens (bb elt <+> bb elt)) (bb elt))) "m1" "m2")
+        [("m1", fromText map), ("m2", fromText map)]
+        (fromText map)
+        (key2 (key "_ map" (key2 "+" (parens (fromText elt <+> fromText elt)) (fromText elt))) "m1" "m2")
     , bFun mprj -- See [Interaction Between Map and Set]
-        [("s", bb set), ("m", bb map)]
-        (bb map)
+        [("s", fromText set), ("m", fromText map)]
+        (fromText map)
         (key3
           (key "_ map"
             (key2 "ite"
-              (parens ("Bool" <+> bb elt <+> bb elt))
-              (bb elt)
+              (parens ("Bool" <+> fromText elt <+> fromText elt))
+              (fromText elt)
             )
           )
           "s"
           "m"
-          (parens (key "as const" (key2 "Array" (bb elt) (bb elt)) <+> "0"))
+          (parens (key "as const" (key2 "Array" (fromText elt) (fromText elt)) <+> "0"))
         )
     , bFun mToSet -- See [Interaction Between Map and Set]
-        [("m", bb map)]
-        (bb set)
+        [("m", fromText map)]
+        (fromText set)
         (key2
           (key "_ map"
             (key2 ">"
-              (parens (bb elt <+> bb elt))
+              (parens (fromText elt <+> fromText elt))
               "Bool"
             )
           )
           "m"
-          (parens (key "as const" (key2 "Array" (bb elt) (bb elt)) <+> "0"))
+          (parens (key "as const" (key2 "Array" (fromText elt) (fromText elt)) <+> "0"))
         )
     , bFun mmax -- See [Map max and min]
-        [("m1", bb map),("m2", bb map)]
-        (bb map)
+        [("m1", fromText map),("m2", fromText map)]
+        (fromText map)
         "(lambda ((i Int)) (ite (> (select m1 i) (select m2 i)) (select m1 i) (select m2 i)))"
     , bFun mmin -- See [Map max and min]
-        [("m1", bb map),("m2", bb map)]
-        (bb map)
+        [("m1", fromText map),("m2", fromText map)]
+        (fromText map)
         "(lambda ((i Int)) (ite (< (select m1 i) (select m2 i)) (select m1 i) (select m2 i)))"
     , bFun mshift -- See [Map key shift]
-        [("n", "Int"),("m", bb map)]
-        (bb map)
+        [("n", "Int"),("m", fromText map)]
+        (fromText map)
         "(lambda ((i Int)) (select m (- i n)))"
     , bFun mdef
-        [("v", bb elt)]
-        (bb map)
-        (key (key "as const" (parens (bb map))) "v")
+        [("v", fromText elt)]
+        (fromText map)
+        (key (key "as const" (parens (fromText map))) "v")
     , bFun boolToIntName
         [("b", "Bool")]
         "Int"
         "(ite b 1 0)"
 
-    , uifDef u (symbolLText mulFuncName) "*"
-    , uifDef u (symbolLText divFuncName) "div"
+    , uifDef u (symbolText mulFuncName) "*"
+    , uifDef u (symbolText divFuncName) "div"
     ]
-
-symbolLText :: Symbol -> T.Text
-symbolLText = T.fromStrict . symbolText
 
 -- RJ: Am changing this to `Int` not `Real` as (1) we usually want `Int` and
 -- (2) have very different semantics. TODO: proper overloading, post genEApp
-uifDef :: Config -> T.Text -> T.Text -> T.Text
+uifDef :: Config -> Data.Text.Text -> Data.Text.Text -> Builder
 uifDef cfg f op
   | linear cfg || Z3 /= solver cfg
   = bFun' f ["Int", "Int"] "Int"
   | otherwise
-  = bFun f [("x", "Int"), ("y", "Int")] "Int" (key2 (bb op) "x" "y")
+  = bFun f [("x", "Int"), ("y", "Int")] "Int" (key2 (fromText op) "x" "y")
 
-cvc4Preamble :: Config -> [T.Text]
+cvc4Preamble :: Config -> [Builder]
 cvc4Preamble z
   = [        "(set-logic ALL_SUPPORTED)"]
   ++ commonPreamble z
   ++ cvc4MapPreamble z
 
-commonPreamble :: Config -> [T.Text]
+commonPreamble :: Config -> [Builder]
 commonPreamble _ --TODO use uif flag u (see z3Preamble)
   = [ bSort elt    "Int"
     , bSort set    "Int"
     , bSort string "Int"
-    , bFun' emp []               (bb set)
-    , bFun' sng [bb elt]         (bb set)
-    , bFun' add [bb set, bb elt] (bb set)
-    , bFun' cup [bb set, bb set] (bb set)
-    , bFun' cap [bb set, bb set] (bb set)
-    , bFun' dif [bb set, bb set] (bb set)
-    , bFun' sub [bb set, bb set] "Bool"
-    , bFun' mem [bb elt, bb set] "Bool"
+    , bFun' emp []               (fromText set)
+    , bFun' sng [fromText elt]         (fromText set)
+    , bFun' add [fromText set, fromText elt] (fromText set)
+    , bFun' cup [fromText set, fromText set] (fromText set)
+    , bFun' cap [fromText set, fromText set] (fromText set)
+    , bFun' dif [fromText set, fromText set] (fromText set)
+    , bFun' sub [fromText set, fromText set] "Bool"
+    , bFun' mem [fromText elt, fromText set] "Bool"
     , bFun boolToIntName [("b", "Bool")] "Int" "(ite b 1 0)"
     ]
 
-cvc4MapPreamble :: Config -> [T.Text]
+cvc4MapPreamble :: Config -> [Builder]
 cvc4MapPreamble _ =
-    [ bSort map    (key2 "Array" (bb elt) (bb elt))
-    , bFun sel [("m", bb map), ("k", bb elt)]                (bb elt) "(select m k)"
-    , bFun sto [("m", bb map), ("k", bb elt), ("v", bb elt)] (bb map) "(store m k v)"
+    [ bSort map    (key2 "Array" (fromText elt) (fromText elt))
+    , bFun sel [("m", fromText map), ("k", fromText elt)]                (fromText elt) "(select m k)"
+    , bFun sto [("m", fromText map), ("k", fromText elt), ("v", fromText elt)] (fromText map) "(store m k v)"
     ]
 
-smtlibPreamble :: Config -> [T.Text]
+smtlibPreamble :: Config -> [Builder]
 smtlibPreamble z --TODO use uif flag u (see z3Preamble)
   = commonPreamble z
  ++ [ bSort map "Int"
-    , bFun' sel [bb map, bb elt] (bb elt)
-    , bFun' sto [bb map, bb elt, bb elt] (bb map)
+    , bFun' sel [fromText map, fromText elt] (fromText elt)
+    , bFun' sto [fromText map, fromText elt, fromText elt] (fromText map)
     ]
 
-stringPreamble :: Config -> [T.Text]
+stringPreamble :: Config -> [Builder]
 stringPreamble cfg | stringTheory cfg
   = [ bSort string "String"
-    , bFun strLen [("s", bb string)] "Int" (key (bb z3strlen) "s")
-    , bFun strSubstr [("s", bb string), ("i", "Int"), ("j", "Int")] (bb string) (key (bb z3strsubstr) "s i j")
-    , bFun strConcat [("x", bb string), ("y", bb string)] (bb string) (key (bb z3strconcat) "x y")
+    , bFun strLen [("s", fromText string)] "Int" (key (fromText z3strlen) "s")
+    , bFun strSubstr [("s", fromText string), ("i", "Int"), ("j", "Int")] (fromText string) (key (fromText z3strsubstr) "s i j")
+    , bFun strConcat [("x", fromText string), ("y", fromText string)] (fromText string) (key (fromText z3strconcat) "x y")
     ]
 
 stringPreamble _
   = [ bSort string "Int"
-    , bFun' strLen [bb string] "Int"
-    , bFun' strSubstr [bb string, "Int", "Int"] (bb string)
-    , bFun' strConcat [bb string, bb string] (bb string)
+    , bFun' strLen [fromText string] "Int"
+    , bFun' strSubstr [fromText string, "Int", "Int"] (fromText string)
+    , bFun' strConcat [fromText string, fromText string] (fromText string)
     ]
 
 --------------------------------------------------------------------------------
 -- | Exported API --------------------------------------------------------------
 --------------------------------------------------------------------------------
 smt2Symbol :: SymEnv -> Symbol -> Maybe Builder
-smt2Symbol env x = fromLazyText . tsRaw <$> symEnvTheory x env
+smt2Symbol env x = fromText . tsRaw <$> symEnvTheory x env
 
 instance SMTLIB2 SmtSort where
   smt2 _ = smt2SmtSort
@@ -370,9 +366,9 @@ smt2SmtSort :: SmtSort -> Builder
 smt2SmtSort SInt         = "Int"
 smt2SmtSort SReal        = "Real"
 smt2SmtSort SBool        = "Bool"
-smt2SmtSort SString      = bb string
-smt2SmtSort SSet         = bb set
-smt2SmtSort SMap         = bb map
+smt2SmtSort SString      = fromText string
+smt2SmtSort SSet         = fromText set
+smt2SmtSort SMap         = fromText map
 smt2SmtSort (SBitVec n)  = key "_ BitVec" (bShow n)
 smt2SmtSort (SVar n)     = "T" <> bShow n
 smt2SmtSort (SData c []) = symbolBuilder c
@@ -388,9 +384,9 @@ type VarAs = SymEnv -> Symbol -> Sort -> Builder
 smt2App :: VarAs -> SymEnv -> Expr -> [Builder] -> Maybe Builder
 --------------------------------------------------------------------------------
 smt2App _ _ (dropECst -> EVar f) [d]
-  | f == setEmpty = Just (bb emp)
-  | f == setEmp   = Just (key2 "=" (bb emp) d)
-  | f == setSng   = Just (key (bb sng) d) -- Just (key2 (bb add) (bb emp) d)
+  | f == setEmpty = Just (fromText emp)
+  | f == setEmp   = Just (key2 "=" (fromText emp) d)
+  | f == setSng   = Just (key (fromText sng) d) -- Just (key2 (bb add) (bb emp) d)
 
 smt2App k env f (d:ds)
   | Just fb <- smt2AppArg k env f
@@ -403,7 +399,7 @@ smt2AppArg k env (ECst (dropECst -> EVar f) t)
   | Just fThy <- symEnvTheory f env
   = Just $ if isPolyCtor fThy t
             then k env f (ffuncOut t)
-            else bb (tsRaw fThy)
+            else fromText (tsRaw fThy)
 
 smt2AppArg _ _ _
   = Nothing
@@ -434,7 +430,7 @@ sortAppInfo t = case bkFFunc t of
   Just (_, ts) -> Just (length ts - 1)
   Nothing      -> Nothing
 
-preamble :: Config -> SMTSolver -> [T.Text]
+preamble :: Config -> SMTSolver -> [Builder]
 preamble u Z3   = z3Preamble u
 preamble u Cvc4 = cvc4Preamble u
 preamble u _    = smtlibPreamble u
@@ -570,8 +566,8 @@ testTheory t x = (sx, Thy sx raw t Test)
     sx         = testSymbol x
     raw        = "is-" <> symbolRaw x
 
-symbolRaw :: Symbol -> T.Text
-symbolRaw = T.fromStrict . symbolSafeText
+symbolRaw :: Symbol -> Data.Text.Text
+symbolRaw = symbolSafeText
 
 --------------------------------------------------------------------------------
 selectSymbols :: DataDecl -> [(Symbol, TheorySymbol)]

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -28,8 +28,8 @@ module Language.Fixpoint.Smt.Types (
 
     ) where
 
+import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types
-import           Language.Fixpoint.Utils.Builder (Builder)
 import qualified Data.Text                as T
 import           Text.PrettyPrint.HughesPJ
 import qualified SMTLIB.Backends

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -128,6 +128,7 @@ module Language.Fixpoint.Types.Names (
 
 import           Control.DeepSeq             (NFData (..))
 import           Control.Arrow               (second)
+import           Data.ByteString.Builder     (Builder)
 import           Data.Char                   (ord)
 import           Data.Maybe                  (fromMaybe)
 import           Data.Generics               (Data)
@@ -144,7 +145,7 @@ import           GHC.Generics                (Generic)
 import           Text.PrettyPrint.HughesPJ   (text)
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
-import           Language.Fixpoint.Utils.Builder as Builder (Builder, fromText)
+import           Language.Fixpoint.Utils.Builder as Builder (fromText)
 import Data.Functor.Contravariant (Contravariant(contramap))
 import qualified Data.Binary as B
 
@@ -546,7 +547,7 @@ symbolBuilder :: (Symbolic a) => a -> Builder
 symbolBuilder = Builder.fromText . symbolSafeText . symbol
 
 {-# INLINE buildMany #-}
-buildMany :: [Builder.Builder] -> Builder.Builder
+buildMany :: [Builder] -> Builder
 buildMany []     = mempty
 buildMany [b]    = b
 buildMany (b:bs) = b <> mconcat [ " " <> b' | b' <- bs ]

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -52,21 +52,14 @@ import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.List                as L
 import           Data.Text (Text)
 import qualified Data.Text                as Text
-import qualified Data.Text.Lazy           as LT
 import qualified Data.Store              as S
 import qualified Data.HashMap.Strict      as M
 import qualified Language.Fixpoint.Misc   as Misc
-import Data.Functor.Contravariant (Contravariant(contramap))
 
 --------------------------------------------------------------------------------
 -- | 'Raw' is the low-level representation for SMT values
 --------------------------------------------------------------------------------
-type Raw = LT.Text
-
-instance S.Store Raw where
-  peek = LT.fromStrict <$> S.peek
-  poke = S.poke . LT.toStrict
-  size = contramap LT.toStrict S.size
+type Raw = Text
 
 --------------------------------------------------------------------------------
 -- | 'SymEnv' is used to resolve the 'Sort' and 'Sem' of each 'Symbol'

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -4,11 +4,10 @@
 
 module Language.Fixpoint.Utils.Builder
   ( Builder
-  , fromLazyByteString
+  , B.lazyByteString
   , fromText
   , fromString
-  , toLazyByteString
-  , toBuilder
+  , B.toLazyByteString
   , parens
   , (<+>)
   , parenSeqs
@@ -24,40 +23,16 @@ module Language.Fixpoint.Utils.Builder
 import           Data.Foldable (fold)
 import           Data.String
 import Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as B
 import qualified Data.Text              as T
 import qualified Data.Text.Encoding     as T
 import qualified Data.List              as L
 import qualified Numeric
 
--- | Offers efficient concatenation, no matter the associativity
-data Builder
-  = Node Builder Builder
-  | Leaf B.Builder
-
-instance IsString Builder where
-  fromString = Leaf . fromString
-
-instance Semigroup Builder where
-  (<>) = Node
-
-instance Monoid Builder where
-  mempty = Leaf mempty
-
-toLazyByteString :: Builder -> ByteString
-toLazyByteString = B.toLazyByteString . toBuilder
-
-toBuilder :: Builder -> B.Builder
-toBuilder = go mempty
-  where
-    go tl (Leaf b) = b <> tl
-    go tl (Node t0 t1) = go (go tl t1) t0
-
-fromLazyByteString :: ByteString -> Builder
-fromLazyByteString = Leaf . B.lazyByteString
 
 fromText :: T.Text -> Builder
-fromText t = Leaf $ B.byteString $ T.encodeUtf8 t
+fromText t = B.byteString $ T.encodeUtf8 t
 
 parens :: Builder -> Builder
 parens b = "(" <>  b <> ")"
@@ -88,4 +63,4 @@ bFloat :: RealFloat a => a -> Builder
 bFloat d = fromString (Numeric.showFFloat Nothing d "")
 
 bb :: ByteString -> Builder
-bb = fromLazyByteString
+bb = B.lazyByteString

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -3,11 +3,8 @@
 -- | Wrapper around `Data.Text.Builder` that exports some useful combinators
 
 module Language.Fixpoint.Utils.Builder
-  ( Builder
-  , B.lazyByteString
-  , fromText
+  ( fromText
   , fromString
-  , B.toLazyByteString
   , parens
   , (<+>)
   , parenSeqs
@@ -21,7 +18,6 @@ module Language.Fixpoint.Utils.Builder
 
 import           Data.Foldable (fold)
 import           Data.String
-import Data.ByteString.Lazy (ByteString)
 import Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as B
 import qualified Data.Text              as T

--- a/src/Language/Fixpoint/Utils/Builder.hs
+++ b/src/Language/Fixpoint/Utils/Builder.hs
@@ -17,7 +17,6 @@ module Language.Fixpoint.Utils.Builder
   , key3
   , bShow
   , bFloat
-  , bb
   ) where
 
 import           Data.Foldable (fold)
@@ -61,6 +60,3 @@ bShow = fromString . show
 
 bFloat :: RealFloat a => a -> Builder
 bFloat d = fromString (Numeric.showFFloat Nothing d "")
-
-bb :: ByteString -> Builder
-bb = B.lazyByteString


### PR DESCRIPTION
Serialization converts AST to smtlib in bytestring form, which is what `smtlib-backends` offers as abstraction to interact with SMT solver libraries and processes.

LF was doing a series of conversions of text to lazy text which this PR eliminates. It also was serializing to lazy text using a custom Builder that this PR removes to use the builder from Data.ByteString.Builder

Lastly, it is eliminating in d44168f a comparison of builders that is unnecessary according to passing tests, and checked it with Niki as well.