### PR TITLE
Automatically scrape qualifiers from predicates in Horn clauses

### DIFF
--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -541,8 +541,8 @@ instance Fixpoint Qualifier where
   toFix = pprQual
 
 instance PPrint Qualifier where
-  -- pprintTidy k q = "qualif" <+> pprintTidy k (qName q) <+> "defined at" <+> pprintTidy k (qPos q)
-  pprintTidy _ q = pprQual q
+  pprintTidy k q = "qualif" <+> pprintTidy k (qName q) <+> "defined at" <+> pprintTidy k (qPos q)
+  -- pprintTidy _ q = pprQual q
 
 pprQual :: Qualifier -> Doc
 pprQual (Q n xts p l) = text "qualif" <+> text (symbolString n) <-> parens args <-> colon <+> parens (toFix p) <+> text "//" <+> toFix l

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -473,8 +473,8 @@ addIds :: [SubC a] -> [(Integer, SubC a)]
 addIds = zipWith (\i c -> (i, shiftId i $ c {_sid = Just i})) [1..]
   where
     -- Adding shiftId to have distinct VV for SMT conversion
-    shiftId i c = c { slhs = shiftSR i $ slhs c }
-                    { srhs = shiftSR i $ srhs c }
+    shiftId i c = c { slhs = shiftSR i (slhs c) }
+                    { srhs = shiftSR i (srhs c) }
     shiftSR i sr = sr { sr_reft = shiftR i $ sr_reft sr }
     shiftR i r@(Reft (v, _)) = shiftVV r (intSymbol v i)
 
@@ -541,7 +541,8 @@ instance Fixpoint Qualifier where
   toFix = pprQual
 
 instance PPrint Qualifier where
-  pprintTidy k q = "qualif" <+> pprintTidy k (qName q) <+> "defined at" <+> pprintTidy k (qPos q)
+  -- pprintTidy k q = "qualif" <+> pprintTidy k (qName q) <+> "defined at" <+> pprintTidy k (qPos q)
+  pprintTidy _ q = pprQual q
 
 pprQual :: Qualifier -> Doc
 pprQual (Q n xts p l) = text "qualif" <+> text (symbolString n) <-> parens args <-> colon <+> parens (toFix p) <+> text "//" <+> toFix l

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -77,7 +77,7 @@ module Language.Fixpoint.Types.Refinements (
 
   -- * Destructing
   , flattenRefas
-  , conjuncts
+  , conjuncts, concConjuncts
   , dropECst
   , eApps
   , eAppC
@@ -183,9 +183,13 @@ reftConjuncts :: Reft -> [Reft]
 reftConjuncts (Reft (v, ra)) = [Reft (v, ra') | ra' <- ras']
   where
     ras'                     = if null ps then ks else conj ps : ks  -- see [NOTE:pAnd-SLOW]
-    (ks, ps)                 = partition (\p -> isKvar p || isGradual p) $ refaConjuncts ra
+    (ps, ks)                 = partition isConc (refaConjuncts ra)
 
+isConc :: Expr -> Bool
+isConc p = not (isKvar p || isGradual p)
 
+concConjuncts :: Expr -> [Expr]
+concConjuncts e = filter isConc (refaConjuncts e)
 
 isKvar :: Expr -> Bool
 isKvar (PKVar _ _) = True
@@ -224,6 +228,8 @@ instance HasGradual SortedReft where
 
 refaConjuncts :: Expr -> [Expr]
 refaConjuncts p = [p' | p' <- conjuncts p, not $ isTautoPred p']
+
+
 
 --------------------------------------------------------------------------------
 -- | Kvars ---------------------------------------------------------------------

--- a/tests/horn/pos/scrape00.smt2
+++ b/tests/horn/pos/scrape00.smt2
@@ -1,0 +1,65 @@
+// Tag 0: Goto(bb1) at 27:9: 27:16
+// Tag 1: Ret at 33:5: 33:8
+// Tag 2: Goto(bb1) at 28:18: 32:6
+
+// This is the qualifier we want to auto-scrape
+// (qualif MyQ1 ((a0 int) (a1 int) (a2 int)) (a0 = (a1 - a2)))
+
+(qualif EqZero ((a0 int)) (a0 = 0))
+(qualif GtZero ((a0 int)) (a0 > 0))
+(qualif GeZero ((a0 int)) (a0 >= 0))
+(qualif LtZero ((a0 int)) (a0 < 0))
+(qualif LeZero ((a0 int)) (a0 <= 0))
+(qualif Eq ((a0 int) (a1 int)) (a0 = a1))
+(qualif Gt ((a0 int) (a1 int)) (a0 > a1))
+(qualif Ge ((a0 int) (a1 int)) (a0 >= a1))
+(qualif Lt ((a0 int) (a1 int)) (a0 < a1))
+(qualif Le ((a0 int) (a1 int)) (a0 <= a1))
+(qualif Le1 ((a0 int) (a1 int)) (a0 <= (a1 - 1)))
+
+(data Pair 2 = [| Pair { fst: @(0), snd: @(1) } ])
+(data Unit 0 = [| Unit { }])
+(var $k0 ((int) (int) (int))) // orig: $k0
+(var $k1 ((int) (int) (int) (int))) // orig: $k0
+
+(constraint
+  (forall ((a0 int) (true))
+    (forall ((a1 int) (true))
+      (forall ((_ Unit) (a0 >= 0))
+        (forall ((_ Unit) (a0 <= a1))
+          (forall ((_ Unit) (a1 >= 0))
+            (and
+              (forall ((a2 int) (a2 = 0))
+                (and
+                  (tag ($k0 a0 a0 a1) "0")
+                  (tag ($k1 a2 a0 a0 a1) "0")
+                )
+              )
+              (forall ((a3 int) (true))
+                (forall ((a4 int) (true))
+                  (forall ((_ Unit) (and ($k0 a4 a0 a1) ($k1 a3 a4 a0 a1)))
+                    (and
+                      (forall ((_ Unit) (~(a4 < a1)))
+                        (tag (a3 = (a1 - a0)) "1")
+                      )
+                      (forall ((_ Unit) (a4 < a1))
+                        (forall ((a5 int) (a5 = (a3 + 1)))
+                          (forall ((a6 int) (a6 = (a4 + 1)))
+                            (and
+                              (tag ($k0 a6 a0 a1) "2")
+                              (tag ($k1 a5 a6 a0 a1) "2")
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/horn/pos/scrape00.smt2
+++ b/tests/horn/pos/scrape00.smt2
@@ -1,9 +1,8 @@
 // (fixpoint "--scrape=head")
 
-// This is the qualifier we want to auto-scrape
+// These are the qualifiers we want to auto-scrape
 // (qualif MyQ1 ((a0 int) (a1 int) (a2 int)) (a0 = (a1 - a2)))
-
-(qualif Le ((a0 int) (a1 int)) (a0 <= a1))
+// (qualif Le ((a0 int) (a1 int)) (a0 <= a1))
 
 (data Pair 2 = [| Pair { fst: @(0), snd: @(1) } ])
 (data Unit 0 = [| Unit { }])

--- a/tests/horn/pos/scrape00.smt2
+++ b/tests/horn/pos/scrape00.smt2
@@ -1,30 +1,7 @@
-// Tag 0: Goto(bb1) at 27:9: 27:16
-// Tag 1: Ret at 33:5: 33:8
-// Tag 2: Goto(bb1) at 28:18: 32:6
-// (qualif AUTO1 ((a0 int)) (a0 >= 0))
-// (qualif AUTO2 ((a1 int)) (a1 >= 0))
-// (qualif AUTO3 ((a1 int) (a0 int)) (a0 <= a1))
-// (qualif AUTO4 ((a2 int)) (a2 = 0))
-// (qualif AUTO6 ((a4 int) (a1 int)) (~ ((a4 < a1))))
-// (qualif AUTO7 ((a4 int) (a1 int)) (a4 < a1))
-// (qualif AUTO8 ((a5 int) (a3 int)) (a5 = (a3 + 1)))
-// (qualif AUTO9 ((a6 int) (a4 int)) (a6 = (a4 + 1)))
-// (qualif AUTO5 ((a3 int) (a1 int) (a0 int)) (a3 = (a1 - a0)))
+// (fixpoint "--scrape=head")
 
 // This is the qualifier we want to auto-scrape
 // (qualif MyQ1 ((a0 int) (a1 int) (a2 int)) (a0 = (a1 - a2)))
-
-// (qualif GeZero ((a0 int)) (a0 >= 0))
-// (qualif EqZero ((a0 int)) (a0 = 0))
-// (qualif GtZero ((a0 int)) (a0 > 0))
-// (qualif GeZero ((a0 int)) (a0 >= 0))
-// (qualif LtZero ((a0 int)) (a0 < 0))
-// (qualif LeZero ((a0 int)) (a0 <= 0))
-// (qualif Eq ((a0 int) (a1 int)) (a0 = a1))
-// (qualif Gt ((a0 int) (a1 int)) (a0 > a1))
-// (qualif Ge ((a0 int) (a1 int)) (a0 >= a1))
-// (qualif Lt ((a0 int) (a1 int)) (a0 < a1))
-// (qualif Le1 ((a0 int) (a1 int)) (a0 <= (a1 - 1)))
 
 (qualif Le ((a0 int) (a1 int)) (a0 <= a1))
 

--- a/tests/horn/pos/scrape00.smt2
+++ b/tests/horn/pos/scrape00.smt2
@@ -1,21 +1,32 @@
 // Tag 0: Goto(bb1) at 27:9: 27:16
 // Tag 1: Ret at 33:5: 33:8
 // Tag 2: Goto(bb1) at 28:18: 32:6
+// (qualif AUTO1 ((a0 int)) (a0 >= 0))
+// (qualif AUTO2 ((a1 int)) (a1 >= 0))
+// (qualif AUTO3 ((a1 int) (a0 int)) (a0 <= a1))
+// (qualif AUTO4 ((a2 int)) (a2 = 0))
+// (qualif AUTO6 ((a4 int) (a1 int)) (~ ((a4 < a1))))
+// (qualif AUTO7 ((a4 int) (a1 int)) (a4 < a1))
+// (qualif AUTO8 ((a5 int) (a3 int)) (a5 = (a3 + 1)))
+// (qualif AUTO9 ((a6 int) (a4 int)) (a6 = (a4 + 1)))
+// (qualif AUTO5 ((a3 int) (a1 int) (a0 int)) (a3 = (a1 - a0)))
 
 // This is the qualifier we want to auto-scrape
 // (qualif MyQ1 ((a0 int) (a1 int) (a2 int)) (a0 = (a1 - a2)))
 
-(qualif EqZero ((a0 int)) (a0 = 0))
-(qualif GtZero ((a0 int)) (a0 > 0))
-(qualif GeZero ((a0 int)) (a0 >= 0))
-(qualif LtZero ((a0 int)) (a0 < 0))
-(qualif LeZero ((a0 int)) (a0 <= 0))
-(qualif Eq ((a0 int) (a1 int)) (a0 = a1))
-(qualif Gt ((a0 int) (a1 int)) (a0 > a1))
-(qualif Ge ((a0 int) (a1 int)) (a0 >= a1))
-(qualif Lt ((a0 int) (a1 int)) (a0 < a1))
+// (qualif GeZero ((a0 int)) (a0 >= 0))
+// (qualif EqZero ((a0 int)) (a0 = 0))
+// (qualif GtZero ((a0 int)) (a0 > 0))
+// (qualif GeZero ((a0 int)) (a0 >= 0))
+// (qualif LtZero ((a0 int)) (a0 < 0))
+// (qualif LeZero ((a0 int)) (a0 <= 0))
+// (qualif Eq ((a0 int) (a1 int)) (a0 = a1))
+// (qualif Gt ((a0 int) (a1 int)) (a0 > a1))
+// (qualif Ge ((a0 int) (a1 int)) (a0 >= a1))
+// (qualif Lt ((a0 int) (a1 int)) (a0 < a1))
+// (qualif Le1 ((a0 int) (a1 int)) (a0 <= (a1 - 1)))
+
 (qualif Le ((a0 int) (a1 int)) (a0 <= a1))
-(qualif Le1 ((a0 int) (a1 int)) (a0 <= (a1 - 1)))
 
 (data Pair 2 = [| Pair { fst: @(0), snd: @(1) } ])
 (data Unit 0 = [| Unit { }])

--- a/tests/horn/pos/scrape01.smt2
+++ b/tests/horn/pos/scrape01.smt2
@@ -1,8 +1,8 @@
-(fixpoint "--scrape=both")
+(fixpoint "--scrape=head")
 
 // These are the qualifiers we want to auto-scrape
 // (qualif MyQ1 ((a0 int) (a1 int) (a2 int)) (a0 = (a1 - a2)))
-// (qualif Le ((a0 int) (a1 int)) (a0 <= a1))
+(qualif Le ((a0 int) (a1 int)) (a0 <= a1))
 
 (data Pair 2 = [| Pair { fst: @(0), snd: @(1) } ])
 (data Unit 0 = [| Unit { }])

--- a/tests/pos/meas00.fq
+++ b/tests/pos/meas00.fq
@@ -1,5 +1,4 @@
-qualif Sz(v: Tree): (0 < thinginess v)
-qualif Sz(v: Tree): (1 < 0)
+fixpoint "--eliminate=some"
 
 constant thinginess : func(0, [Tree; int])
 
@@ -16,6 +15,6 @@ constraint:
   rhs {v : Tree | 0 < thinginess v }
   id 2 tag []
 
-wf: 
+wf:
   env [ ]
   reft { v: Tree | $k1 }


### PR DESCRIPTION
This is experimental hence hidden behind a flag:

* `--scrape=no` (default) do nothing, only use user specified qualifiers
* `--scrape=head` : scrape qualifiers from the _head_ of the horn clauses (RHS)
* `--scrape=both` : scrape qualifiers from the _head_ and the _body_ of the clauses (RHS+LHS)
