### PR TITLE
Bump stack

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 
-resolver: lts-18.27
+resolver: lts-20.1
 allow-newer: true
 
 flags:
@@ -10,8 +10,8 @@ packages:
 - '.'
 
 extra-deps:
-- hashable-1.3.5.0
-- rest-rewrite-0.3.0
+- hashable-1.4.2.0
+- rest-rewrite-0.4.1
 - smtlib-backends-0.3
 - smtlib-backends-z3-0.3
 - smtlib-backends-process-0.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,19 +5,19 @@
 
 packages:
 - completed:
-    hackage: hashable-1.3.5.0@sha256:3a2beeafb220f9de706568a7e4a5b3c762cc4c9f25c94d7ef795b8c2d6a691d7,4240
+    hackage: hashable-1.4.2.0@sha256:585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a,4520
     pantry-tree:
-      sha256: 4df2f6b536a0fcc5f7d562cb29e373f27dc4a2747452ac5cc74c1599cab22fc5
+      sha256: 792a6cab3f15c5db29d759c8ca735d0be5f4c94f363329652f8b9780009d0829
       size: 1248
   original:
-    hackage: hashable-1.3.5.0
+    hackage: hashable-1.4.2.0
 - completed:
-    hackage: rest-rewrite-0.3.0@sha256:398f937a5faf6bd3329650ee9aed31bbfe7ed1c23252710908ad7295e3252c94,3890
+    hackage: rest-rewrite-0.4.1@sha256:1254960c0a595cf4c9d5a3b986f42644407c63c74578d75b3568a6a12e5143f0,3886
     pantry-tree:
-      sha256: 6e42cf85257cbc2abf50a9c8f3bac8777920f1b970e6f2cae9358690e1186e99
-      size: 3943
+      sha256: 17b4e99420cc1929e2b7d29558a0f909d6fcabd263fbc590dbf2585f893f5a6e
+      size: 4018
   original:
-    hackage: rest-rewrite-0.3.0
+    hackage: rest-rewrite-0.4.1
 - completed:
     hackage: smtlib-backends-0.3@sha256:917d88540a9ede7beedbe2ed13b492acddbce394d30ccf5d0ef4f4fba9aa2c12,1157
     pantry-tree:
@@ -41,7 +41,7 @@ packages:
     hackage: smtlib-backends-process-0.3
 snapshots:
 - completed:
-    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
-    size: 590102
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/27.yaml
-  original: lts-18.27
+    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
+    size: 648424
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
+  original: lts-20.1


### PR DESCRIPTION
Any objections to bumping the stack lts to the versions used by LH. Makes it easier to build on a mac/m1/2...