### PR TITLE
Fix `tidySymbol` to not drop arg-id

### DIFF
--- a/src/Language/Fixpoint/Horn/Info.hs
+++ b/src/Language/Fixpoint/Horn/Info.hs
@@ -160,10 +160,7 @@ kvEnvWfCs :: KVEnv a -> M.HashMap F.KVar (F.WfC a)
 kvEnvWfCs kve = M.fromList [ (F.KV k, kvWfC info) | (k, info) <- M.toList kve ]
 
 hvarArg :: H.Var a -> Int -> F.Symbol
-hvarArg k i = F.intSymbol (F.suffixSymbol hvarPrefix (H.hvName k)) i
-
-hvarPrefix :: F.Symbol
-hvarPrefix = F.symbol "nnf_arg"
+hvarArg k i = F.hvarArgSymbol (H.hvName k) i
 
 -------------------------------------------------------------------------------
 -- | Automatically scrape qualifiers from all predicates in a constraint

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -240,7 +240,7 @@ matchSym qp y' = case qp of
   F.PatNone       -> Just NoSub
   F.PatExact s    -> if s == y then Just NoSub else Nothing
   where
-    y             =  F.tidySymbol y'
+    y             =  F.unKArgSymbol y'
 
 data QPSubst = NoSub | JustSub Int F.Symbol
 

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -216,8 +216,6 @@ candidatesP env tyss x =
     qPat = F.qpPat  x
     mono = So.isMono xt
 
-
-
 -- --------------------------------------------------------------------------------
 -- candidates :: So.Env -> [(F.Sort, [F.Symbol])] -> F.QualParam
 --            -> [(So.TVSubst, QPSubst, F.Symbol)]

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -73,6 +73,7 @@ module Language.Fixpoint.Types.Names (
   , tempSymbol
   , gradIntSymbol
   , appendSymbolText
+  , hvarArgSymbol
 
   -- * Wrapping Symbols
   , litSymbol
@@ -478,6 +479,10 @@ existSymbol prefix = intSymbol (existPrefix `mappendSym` prefix)
 gradIntSymbol :: Integer -> Symbol
 gradIntSymbol = intSymbol gradPrefix
 
+hvarArgSymbol :: Symbol -> Int -> Symbol
+hvarArgSymbol s i = intSymbol (suffixSymbol hvarPrefix s) i
+
+
 -- | Used to define functions corresponding to binding predicates
 --
 -- The integer is the BindId.
@@ -498,14 +503,22 @@ testPrefix   = "is$"
 -- ctorPrefix  :: Symbol
 -- ctorPrefix   = "mk$"
 
-kArgPrefix, existPrefix :: Symbol
-kArgPrefix   = "lq_karg$"
-existPrefix  = "lq_ext$"
+kArgPrefix, existPrefix, hvarPrefix :: Symbol
+kArgPrefix  = "lq_karg$"
+existPrefix = "lq_ext$"
+hvarPrefix  = "nnf_arg$"
+
 
 -------------------------------------------------------------------------
 tidySymbol :: Symbol -> Symbol
 -------------------------------------------------------------------------
-tidySymbol = unSuffixSymbol . unSuffixSymbol . unPrefixSymbol kArgPrefix
+-- tidySymbol = unSuffixSymbol . unSuffixSymbol . unPrefixSymbol kArgPrefix
+tidySymbol s
+  | s == s'   = s
+  | otherwise = s''
+  where
+    s'        = unPrefixSymbol kArgPrefix s
+    s''       = unPrefixSymbol symSepName . unPrefixSymbol hvarPrefix $ s'
 
 unPrefixSymbol :: Symbol -> Symbol -> Symbol
 unPrefixSymbol p s = fromMaybe s (stripPrefix p s)

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -509,8 +509,26 @@ kArgPrefix  = "lq_karg$"
 existPrefix = "lq_ext$"
 hvarPrefix  = "nnf_arg$"
 
+-- | `unKArgSymbol` is like `tidySymbol` (see comment below) except it
+--    (a) *removes* the argument-index, and
+--    (b) *preserves* the `nnf_arg` (without replacing it with `$`)
+--    For example `unKArgSymbol lq_karg$nnf_arg$##k0##0##k0` ---> `nnf_arg##k0`
+
 unKArgSymbol :: Symbol -> Symbol
 unKArgSymbol = unSuffixSymbol . unSuffixSymbol . unPrefixSymbol kArgPrefix
+
+-- | 'tidySymbol' is used to prettify the names of parameters of kvars appearing in solutions.(*)
+--   For example, if you have a kvar $k0 with two parameters, you may have a solution that looks like
+--       0 <  lq_karg$nnf_arg$##k0##0##k0
+--   where we know it is a kvar-arg because of the
+--      - `kArgPrefix` (`lq_arg`)
+--      - `hvarArgPrefix` (`nnf_arg`)
+--      - `k0` the name of the kvar
+--      - `0`  the parameter index
+--      - `k0` again (IDK why?!)
+--    all of which are separated by `##`
+--   So `tidySymbol` tests if indeed it is a `kArgPrefix`-ed symbol and if so converts
+--      `lq_karg$nnf_arg$##k0##0##k0` ----> `$k0##0`
 
 tidySymbol :: Symbol -> Symbol
 tidySymbol s

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -518,7 +518,7 @@ tidySymbol s
   | otherwise = s''
   where
     s'        = unPrefixSymbol kArgPrefix s
-    s''       = unPrefixSymbol symSepName . unPrefixSymbol hvarPrefix $ s'
+    s''       = consSym '$' . unPrefixSymbol symSepName . unSuffixSymbol . unPrefixSymbol hvarPrefix $ s'
 
 unPrefixSymbol :: Symbol -> Symbol -> Symbol
 unPrefixSymbol p s = fromMaybe s (stripPrefix p s)

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -60,6 +60,7 @@ module Language.Fixpoint.Types.Names (
   , nonSymbol
   , vvCon
   , tidySymbol
+  , unKArgSymbol
 
   -- * Widely used prefixes
   , anfPrefix
@@ -508,11 +509,10 @@ kArgPrefix  = "lq_karg$"
 existPrefix = "lq_ext$"
 hvarPrefix  = "nnf_arg$"
 
+unKArgSymbol :: Symbol -> Symbol
+unKArgSymbol = unSuffixSymbol . unSuffixSymbol . unPrefixSymbol kArgPrefix
 
--------------------------------------------------------------------------
 tidySymbol :: Symbol -> Symbol
--------------------------------------------------------------------------
--- tidySymbol = unSuffixSymbol . unSuffixSymbol . unPrefixSymbol kArgPrefix
 tidySymbol s
   | s == s'   = s
   | otherwise = s''


### PR DESCRIPTION
- also separate `unKArgSymbol` for matching qual-patterns

fixes #658