### PR TITLE
Build liquid-fixpoint with ghc-9.6.3

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -14,8 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.6"]
+        cabal: ["3.10.1.0"]
         ghc:
+          - "9.6.3"
           - "9.4.7"
           - "9.2.3"
         z3:

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -170,6 +170,8 @@ library
   else
     hs-source-dirs: src-cond/without-z3
 
+  if impl(ghc<9.6)
+    ghc-options: -Wno-unused-imports
   if flag(devel)
     ghc-options: -Werror
   if !os(windows)

--- a/src/Language/Fixpoint/Defunctionalize.hs
+++ b/src/Language/Fixpoint/Defunctionalize.hs
@@ -26,6 +26,7 @@ module Language.Fixpoint.Defunctionalize
 
 import qualified Data.HashMap.Strict as M
 import           Data.Hashable
+import           Control.Monad ((>=>))
 import           Control.Monad.State
 import           Language.Fixpoint.Misc            (fM, secondM, mapSnd)
 import           Language.Fixpoint.Solver.Sanitize (symbolEnv)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -103,6 +103,7 @@ module Language.Fixpoint.Parse (
 
   ) where
 
+import           Control.Monad (unless, void)
 import           Control.Monad.Combinators.Expr
 import qualified Data.IntMap.Strict          as IM
 import qualified Data.HashMap.Strict         as M

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -35,6 +35,7 @@ import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import qualified Language.Fixpoint.Solver.PLE as PLE      (instantiate)
 import qualified Language.Fixpoint.Solver.Common as Common (toSMT)
 import           Language.Fixpoint.Solver.Common          (askSMT)
+import           Control.Monad ((>=>), foldM, forM, forM_, join)
 import           Control.Monad.State
 import           Data.Bifunctor (second)
 import qualified Data.Text            as T

--- a/src/Language/Fixpoint/Solver/Interpreter.hs
+++ b/src/Language/Fixpoint/Solver/Interpreter.hs
@@ -41,6 +41,7 @@ import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Graph.Deps             (isTarget)
 import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import           Language.Fixpoint.Solver.Simplify
+import           Control.Monad (foldM)
 import           Control.Monad.State
 import qualified Data.HashMap.Strict  as M
 import qualified Data.HashSet         as S

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -29,6 +29,7 @@ module Language.Fixpoint.Solver.Monad
        )
        where
 
+import           Control.Monad (foldM, forM, forM_, when)
 import           Language.Fixpoint.Utils.Progress
 import qualified Language.Fixpoint.Types.Config  as C
 import           Language.Fixpoint.Types.Config  (Config)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -52,6 +52,7 @@ import Language.REST.ExploredTerms as ExploredTerms
 import Language.REST.RuntimeTerm as RT
 import Language.REST.SMT (withZ3, SolverHandle)
 
+import           Control.Monad (filterM, foldM, forM_, when)
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (second)

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -21,7 +21,7 @@ module Language.Fixpoint.Solver.Rewrite
   , RESTOrdering(..)
   ) where
 
-import           Control.Monad.State (guard)
+import           Control.Monad (guard)
 import           Control.Monad.Trans.Maybe
 import           Data.Hashable
 import qualified Data.HashMap.Strict  as M

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -70,7 +70,6 @@ module Language.Fixpoint.SortCheck  (
 --  import           Control.DeepSeq
 import           Control.Exception (Exception, catch, try, throwIO)
 import           Control.Monad
-import           Control.Monad.Except      -- (MonadError(..))
 import           Control.Monad.Reader
 
 import qualified Data.HashMap.Strict       as M

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 
-resolver: lts-21.20
+resolver: nightly-2023-11-21
 allow-newer: true
 
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,13 +5,6 @@
 
 packages:
 - completed:
-    hackage: hashable-1.4.2.0@sha256:585792335d5541dba78fa8dfcb291a89cd5812a281825ff7a44afa296ab5d58a,4520
-    pantry-tree:
-      sha256: 792a6cab3f15c5db29d759c8ca735d0be5f4c94f363329652f8b9780009d0829
-      size: 1248
-  original:
-    hackage: hashable-1.4.2.0
-- completed:
     hackage: rest-rewrite-0.4.1@sha256:1254960c0a595cf4c9d5a3b986f42644407c63c74578d75b3568a6a12e5143f0,3886
     pantry-tree:
       sha256: 17b4e99420cc1929e2b7d29558a0f909d6fcabd263fbc590dbf2585f893f5a6e
@@ -19,29 +12,29 @@ packages:
   original:
     hackage: rest-rewrite-0.4.1
 - completed:
-    hackage: smtlib-backends-0.3@sha256:917d88540a9ede7beedbe2ed13b492acddbce394d30ccf5d0ef4f4fba9aa2c12,1157
+    hackage: smtlib-backends-0.3@sha256:69977f97a8db2c11e97bde92fff7e86e793c1fb23827b284bf89938ee463fbf0,1211
     pantry-tree:
-      sha256: 59b578ae7df155a6c73a513358370747e3cc6229ebb44adaba9e0935f811539c
+      sha256: d7c614eab0f3f256b22724ca2d7ac41651f22209242af1d24f052f41d7a7541f
       size: 275
   original:
     hackage: smtlib-backends-0.3
 - completed:
-    hackage: smtlib-backends-z3-0.3@sha256:cca514fa7349a34becb659ff747ec144b7d1902fec2826ff3a51f81388e1eafd,1822
+    hackage: smtlib-backends-z3-0.3@sha256:b748fafd29eed0ea3f9e3924053c080196fad1eee5a73abc2f52e91f1dc19224,1907
     pantry-tree:
-      sha256: e7aee82930b082ed4af91b32a80b8b65249441d458e392cbf2b4d47338e62404
+      sha256: e3365fd8b3d5a06e199f58ad5c53db25cc5d98aca369ee5c649b287a807f5d62
       size: 499
   original:
     hackage: smtlib-backends-z3-0.3
 - completed:
-    hackage: smtlib-backends-process-0.3@sha256:d4d7d02859383e0a43db2d8ce7ef01deffe1bcd356b2ff8626925c3a1c8db922,1600
+    hackage: smtlib-backends-process-0.3@sha256:3eee93e91f41c8a2fb2699e95b502a24d8053485ccf7749e2766683d1ebfe11d,1676
     pantry-tree:
-      sha256: d7d8ec52d07f4a59614000fd93d77b109d085d58f2d96e2c4b972f541c4e8287
+      sha256: 579580c8067b4c6640261187fc5d2ac0a02923db4633e0027067de72f947083c
       size: 461
   original:
     hackage: smtlib-backends-process-0.3
 snapshots:
 - completed:
-    sha256: b73b2b116143aea728c70e65c3239188998bac5bc3be56465813dacd74215dc5
-    size: 648424
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/1.yaml
-  original: lts-20.1
+    sha256: 35abc77a5b88de3f0eb649bfbfd73ecb86be0e2831b9de3c4c0a6771b3a2b22b
+    size: 698983
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/11/21.yaml
+  original: nightly-2023-11-21


### PR DESCRIPTION
Only some additional imports were necessary. Because these cause `unused-imports` warnings in older GHCs, I'm disabling those warnings when using `ghc`s older than `9.6`.