### PR TITLE
Stack project maintenance, remove allow-newer and more

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,19 +1,18 @@
 
-resolver: nightly-2023-11-21
-allow-newer: true
+resolver: nightly-2023-11-27
 
 flags:
   liquid-fixpoint:
     devel: true 
+    link-z3-as-a-library: true
 
 packages:
 - '.'
 
 extra-deps:
-- rest-rewrite-0.4.1
-- smtlib-backends-0.3
-- smtlib-backends-z3-0.3
-- smtlib-backends-process-0.3
+- smtlib-backends-0.3@rev:1
+- smtlib-backends-process-0.3@rev:1
+- smtlib-backends-z3-0.3@rev:1
 
 nix:
   packages: [z3]

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,36 +5,29 @@
 
 packages:
 - completed:
-    hackage: rest-rewrite-0.4.1@sha256:1254960c0a595cf4c9d5a3b986f42644407c63c74578d75b3568a6a12e5143f0,3886
-    pantry-tree:
-      sha256: 17b4e99420cc1929e2b7d29558a0f909d6fcabd263fbc590dbf2585f893f5a6e
-      size: 4018
-  original:
-    hackage: rest-rewrite-0.4.1
-- completed:
     hackage: smtlib-backends-0.3@sha256:69977f97a8db2c11e97bde92fff7e86e793c1fb23827b284bf89938ee463fbf0,1211
     pantry-tree:
       sha256: d7c614eab0f3f256b22724ca2d7ac41651f22209242af1d24f052f41d7a7541f
       size: 275
   original:
-    hackage: smtlib-backends-0.3
-- completed:
-    hackage: smtlib-backends-z3-0.3@sha256:b748fafd29eed0ea3f9e3924053c080196fad1eee5a73abc2f52e91f1dc19224,1907
-    pantry-tree:
-      sha256: e3365fd8b3d5a06e199f58ad5c53db25cc5d98aca369ee5c649b287a807f5d62
-      size: 499
-  original:
-    hackage: smtlib-backends-z3-0.3
+    hackage: smtlib-backends-0.3@rev:1
 - completed:
     hackage: smtlib-backends-process-0.3@sha256:3eee93e91f41c8a2fb2699e95b502a24d8053485ccf7749e2766683d1ebfe11d,1676
     pantry-tree:
       sha256: 579580c8067b4c6640261187fc5d2ac0a02923db4633e0027067de72f947083c
       size: 461
   original:
-    hackage: smtlib-backends-process-0.3
+    hackage: smtlib-backends-process-0.3@rev:1
+- completed:
+    hackage: smtlib-backends-z3-0.3@sha256:b748fafd29eed0ea3f9e3924053c080196fad1eee5a73abc2f52e91f1dc19224,1907
+    pantry-tree:
+      sha256: e3365fd8b3d5a06e199f58ad5c53db25cc5d98aca369ee5c649b287a807f5d62
+      size: 499
+  original:
+    hackage: smtlib-backends-z3-0.3@rev:1
 snapshots:
 - completed:
-    sha256: 35abc77a5b88de3f0eb649bfbfd73ecb86be0e2831b9de3c4c0a6771b3a2b22b
-    size: 698983
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/11/21.yaml
-  original: nightly-2023-11-21
+    sha256: c067098ea221c83ce03ccae4cfd5b104fb8a689b17ebb15dbe9d0793e9db4329
+    size: 699418
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/11/27.yaml
+  original: nightly-2023-11-27


### PR DESCRIPTION
* Remove `allow-newer: true`
* Match flags between Cabal and Stack projects
* Be explicit with the version revisions
* Pick up `rest-rewrite` from stackage
* Bump the nightly resolver

Found when adding `liquid-fixpoint` as an [Updo example](https://github.com/up-do)