### PR TITLE
Configure stack CI jobs to run without link-z3-as-a-library

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -3,6 +3,9 @@ name: stack
 on:
   push:
   pull_request:
+env:
+  # We test in stack jobs that we can build without link-z3-as-a-library
+  STACK_FLAGS: --no-terminal --flag liquid-fixpoint:-link-z3-as-a-library
 
 jobs:
   build:
@@ -45,7 +48,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack-${{ hashFiles('**/*.cabal', './stack/stack-${{ matrix.ghc }}.yaml', './stack/stack-${{ matrix.ghc }}.yaml.lock') }}
 
       - name: Build
-        run: stack test --no-run-tests --no-terminal
+        run: stack test --no-run-tests $STACK_FLAGS
 
       - name: Test
-        run: stack test --no-terminal --test-arguments "--color=always"
+        run: stack test --test-arguments "--color=always" $STACK_FLAGS


### PR DESCRIPTION
Follow up to #663 