### PR TITLE
Extend parser to allow boolean function arguments

### DIFF
--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -200,7 +200,7 @@ data Query a = Query
   , qDis   :: M.HashMap F.Symbol F.Sort  -- ^ list of constants (uninterpreted functions
   , qEqns  :: ![F.Equation]              -- ^ list of equations
   , qMats  :: ![F.Rewrite]               -- ^ list of match-es
-  , qData  :: ![F.DataDecl]            -- ^ list of data-declarations
+  , qData  :: ![F.DataDecl]              -- ^ list of data-declarations
   }
   deriving (Data, Typeable, Generic, Functor)
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -948,9 +948,8 @@ bops cmpFun = foldl' (flip addOperator) initOpTable builtinOps
 funAppP :: Parser Expr
 funAppP      =  litP <|> exprFunP <|> simpleAppP
   where
-    -- predFunP = (\f p -> mkEApp f [p]) <$> funSymbolP <*> parens predP
     exprFunP = mkEApp <$> funSymbolP <*> funRhsP
-    funRhsP  =  some (expr0P) -- <|> pred0P)
+    funRhsP  =  some expr0P
             <|> parens innerP
     innerP   = brackets (sepBy exprP semi)
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -742,6 +742,7 @@ expr0P :: Parser Expr
 expr0P
   =  trueP -- constant "true"
  <|> falseP -- constant "false"
+ <|> (reservedOp "?" *> predP)
  <|> fastIfP EIte exprP -- "if-then-else", starts with "if"
  <|> coerceP exprP -- coercion, starts with "coerce"
  <|> (ESym <$> symconstP) -- string literal, starts with double-quote
@@ -924,6 +925,18 @@ bops cmpFun = foldl' (flip addOperator) initOpTable builtinOps
                  , FInfix  (Just 6) "+"   (Just $ EBin Plus)  AssocLeft
                  , FInfix  (Just 5) "mod" (Just $ EBin Mod)   AssocLeft -- Haskell gives mod 7
                  , FInfix  (Just 9) "."   applyCompose        AssocRight
+                --  --
+                --  , FInfix  (Just 4) "<"   (Just $ PAtom Lt)  AssocNone
+                --  , FInfix  (Just 4) "=="  (Just $ PAtom Eq)  AssocNone
+                --  , FInfix  (Just 4) "="   (Just $ PAtom Eq)  AssocNone
+                --  , FInfix  (Just 4) "~~"  (Just $ PAtom Ueq) AssocNone
+                --  , FInfix  (Just 4) "!="  (Just $ PAtom Ne)  AssocNone
+                --  , FInfix  (Just 4) "/="  (Just $ PAtom Ne)  AssocNone
+                --  , FInfix  (Just 4) "!~"  (Just $ PAtom Une) AssocNone
+                --  , FInfix  (Just 4) "<"   (Just $ PAtom Lt)  AssocNone
+                --  , FInfix  (Just 4) "<="  (Just $ PAtom Le)  AssocNone
+                --  , FInfix  (Just 4) ">"   (Just $ PAtom Gt)  AssocNone
+                --  , FInfix  (Just 4) ">="  (Just $ PAtom Ge)  AssocNone
                  ]
     applyCompose :: Maybe (Expr -> Expr -> Expr)
     applyCompose = (\f x y -> f `eApps` [x,y]) <$> cmpFun
@@ -933,10 +946,11 @@ bops cmpFun = foldl' (flip addOperator) initOpTable builtinOps
 -- Andres, TODO: Why is this so complicated?
 --
 funAppP :: Parser Expr
-funAppP            =  litP <|> exprFunP <|> simpleAppP
+funAppP      =  litP <|> exprFunP <|> simpleAppP
   where
+    -- predFunP = (\f p -> mkEApp f [p]) <$> funSymbolP <*> parens predP
     exprFunP = mkEApp <$> funSymbolP <*> funRhsP
-    funRhsP  =  some expr0P
+    funRhsP  =  some (expr0P) -- <|> pred0P)
             <|> parens innerP
     innerP   = brackets (sepBy exprP semi)
 

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -782,7 +782,7 @@ proj fld x = case fld of
                FBool -> not b
 ```
 
-## The Problem
+**The Problem**
 
 The problem is you cannot encode the body of `proj` as a well-sorted refinement:
 
@@ -795,7 +795,7 @@ The problem is you cannot encode the body of `proj` as a well-sorted refinement:
 The catch is that `x` is being used BOTH as `Int` and as `Bool`
 which is not supported in SMTLIB.
 
-## Approach: Uninterpreted Functions
+**Approach: Uninterpreted Functions**
 
 We encode `coerce` as an explicit **uninterpreted function**:
 
@@ -833,7 +833,7 @@ because we'd get
 
 and the UIF nature of `coerce_int_int` renders the VC invalid.
 
-## Solution: Eliminate Trivial Coercions
+**Solution: Eliminate Trivial Coercions**
 
 HOWEVER, the solution here, may simply be to use UIFs when the
 coercion is non-trivial (e.g. `a ~ int`) but to eschew them when

--- a/tests/tasty/ParserTests.hs
+++ b/tests/tasty/ParserTests.hs
@@ -289,6 +289,12 @@ testPredP =
     , testCase "funApp 3" $
         show (doParse' predP "test" "f ([a; b])") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"
 
+    , testCase "funApp 4" $
+        show (doParse' funAppP "" "f ?(x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
+
+    , testCase "funApp 5" $
+        show (doParse' predP "" "f ?(x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
+
     , testCase "symbol" $
         show (doParse' predP "test" "f") @?= "EVar \"f\""
 


### PR DESCRIPTION
So that `f ?(x > y)` can be parsed as an `Expr` or `Pred`.

Ideally, we'd want to do this _without_ the nasty `?` but I can't seem to unravel the knots needed to do so :-( 