### PR TITLE
print SMT preamble to the logfile when constructing context + fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ version: 2.0
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202107-02
+      image: default
     steps:
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq curl git ssh unzip wget libtinfo-dev gcc make
       - add_ssh_keys
-      - run: 
-          name: Install z3 
+      - run:
+          name: Install z3
           command: |
             wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip
             unzip z3-4.8.7-x64-ubuntu-16.04.zip

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -245,7 +245,7 @@ makeContext cfg f
        hSetBuffering hLog $ BlockBuffering $ Just $ 1024 * 1024 * 64
        me   <- makeContext' cfg $ Just hLog
        pre  <- smtPreamble cfg (solver cfg) me
-       mapM_ (SMTLIB.Backends.command_ (ctxSolver me)) pre
+       mapM_ (\l -> SMTLIB.Backends.command_ (ctxSolver me) l >> BS.hPutBuilder hLog l >> LBS.hPutStr hLog "\n") pre
        return me
     where
        smtFile = extFileName Smt2 f


### PR DESCRIPTION
While investigating https://github.com/ucsd-progsys/liquidhaskell/issues/2272 we've discovered that since https://github.com/ucsd-progsys/liquid-fixpoint/pull/641 the SMT preamble is no longer printed to the `.smt2` logfile. This PR fixes that.