### PR TITLE
Copy over the HOF configuraration options in hornFInfo

### DIFF
--- a/src/Language/Fixpoint/Horn/Info.hs
+++ b/src/Language/Fixpoint/Horn/Info.hs
@@ -17,7 +17,7 @@ import qualified Language.Fixpoint.Types.Config as F
 import qualified Language.Fixpoint.Horn.Types   as H
 import qualified Data.Maybe                     as Mb
 
-hornFInfo :: F.Config -> H.Query a -> F.FInfo a
+hornFInfo :: (F.Fixpoint a, F.PPrint a) => F.Config -> H.Query a -> F.FInfo a
 hornFInfo cfg q = mempty
   { F.cm        = cs
   , F.bs        = be2
@@ -28,6 +28,7 @@ hornFInfo cfg q = mempty
   , F.dLits     = F.fromMapSEnv $ H.qDis q
   , F.ae        = axEnv cfg q cs
   , F.ddecls    = H.qData q
+  , F.hoInfo    = F.cfgHoInfo cfg
   }
   where
     be0         = F.emptyBindEnv
@@ -119,7 +120,7 @@ kvApp kve k ys = F.PKVar (F.KV k) su
     err1       = F.panic ("Unknown Horn variable: " ++ F.showpp k)
 
 ----------------------------------------------------------------------------------
-hornWfs :: F.BindEnv a -> [H.Var a] -> (F.BindEnv a, KVEnv a)
+hornWfs :: (F.PPrint a) => F.BindEnv a -> [H.Var a] -> (F.BindEnv a, KVEnv a)
 ----------------------------------------------------------------------------------
 hornWfs be vars = (be', kve)
   where
@@ -127,7 +128,7 @@ hornWfs be vars = (be', kve)
     (be', is)   = L.mapAccumL kvInfo be vars
     kname       = H.hvName . kvVar
 
-kvInfo :: F.BindEnv a -> H.Var a -> (F.BindEnv a, KVInfo a)
+kvInfo :: (F.PPrint a) => F.BindEnv a -> H.Var a -> (F.BindEnv a, KVInfo a)
 kvInfo be k       = (be', KVInfo k (Misc.fst3 <$> xts) wfc)
   where
     -- make the WfC

--- a/src/Language/Fixpoint/Horn/Solve.hs
+++ b/src/Language/Fixpoint/Horn/Solve.hs
@@ -82,7 +82,7 @@ saveHornJSON cfg q = do
   Aeson.encodeFile hjson q
 
 ----------------------------------------------------------------------------------
-eliminate :: (F.PPrint a) => F.Config -> H.Query a -> IO (H.Query a)
+eliminate :: (F.Fixpoint a, F.PPrint a) => F.Config -> H.Query a -> IO (H.Query a)
 ----------------------------------------------------------------------------------
 eliminate cfg q
   | F.eliminate cfg == F.Existentials = do

--- a/src/Language/Fixpoint/Horn/Transformations.hs
+++ b/src/Language/Fixpoint/Horn/Transformations.hs
@@ -71,7 +71,7 @@ printPiSols piSols =
 -- can depend on other ks, pis cannot directly depend on other pis
 -- - predicate for exists binder is `true`. (TODO: is this pre stale?)
 
-solveEbs :: (F.PPrint a) => F.Config -> Query a -> IO (Query a)
+solveEbs :: (F.Fixpoint a, F.PPrint a) => F.Config -> Query a -> IO (Query a)
 ------------------------------------------------------------------------------
 solveEbs cfg query@(Query {}) = do
   let cons = qCon query
@@ -932,7 +932,7 @@ isNNF (CAnd cs) = all isNNF cs
 isNNF (All _ c) = isNNF c
 isNNF Any{} = False
 
-calculateCuts :: F.Config -> Query a -> Cstr a -> S.Set F.Symbol
+calculateCuts :: (F.Fixpoint a, F.PPrint a) => F.Config -> Query a -> Cstr a -> S.Set F.Symbol
 calculateCuts cfg q@(Query {}) nnf = convert $ FG.depCuts deps
   where
     (_, deps) = elimVars cfg (hornFInfo cfg $ q { qCstr = nnf })

--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -103,7 +103,7 @@ instance F.Subable Pred where
 -------------------------------------------------------------------------------
 quals :: Cstr a -> [F.Qualifier]
 -------------------------------------------------------------------------------
-quals = F.tracepp "horn.quals" . cstrQuals F.emptySEnv F.vv_
+quals = F.notracepp "horn.quals" . cstrQuals F.emptySEnv F.vv_
 
 cstrQuals :: F.SEnv F.Sort -> F.Symbol -> Cstr a -> [F.Qualifier]
 cstrQuals = go

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -234,20 +234,23 @@ simplifyFInfo !cfg !fi0 = do
   reducedFi <- reduceFInfo cfg fi0
   let fi1   = reducedFi { Types.quals = remakeQual <$> Types.quals reducedFi }
   let si0   = {- SCC "convertFormat" -} convertFormat fi1
-  -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si0)
+  writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si0)
   -- rnf si0 `seq` donePhase Loud "Format Conversion"
   let si1   = either die id ({- SCC "sanitize" -} sanitize cfg $!! si0)
-  -- writeLoud $ "fq file after sanitize: \n" ++ render (toFixpoint cfg si1)
+  writeLoud $ "fq file after sanitize: \n" ++ render (toFixpoint cfg si1)
   -- rnf si1 `seq` donePhase Loud "Validated Constraints"
   graphStatistics cfg si1
   let si2  = {- SCC "wfcUniqify" -} wfcUniqify $!! si1
+  writeLoud $ "fq file after wfcUniqify: \n" ++ render (toFixpoint cfg si2)
   let si3  = {- SCC "renameAll"  -} renameAll  $!! si2
   rnf si3 `seq` whenLoud $ donePhase Loud "Uniqify & Rename"
   loudDump 1 cfg si3
   let si4  = {- SCC "defunction" -} defunctionalize cfg $!! si3
+  writeLoud $ "fq file after defunc: \n" ++ render (toFixpoint cfg si4)
   -- putStrLn $ "AXIOMS: " ++ showpp (asserts si4)
   loudDump 2 cfg si4
   let si5  = {- SCC "elaborate" -} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
+  writeLoud $ "fq file after elaborate: \n" ++ render (toFixpoint cfg si5)
   loudDump 3 cfg si5
   let si6 = if extensionality cfg then {- SCC "expand" -} expand cfg si5 else si5
   if rewriteAxioms cfg && noLazyPLE cfg

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -234,23 +234,23 @@ simplifyFInfo !cfg !fi0 = do
   reducedFi <- reduceFInfo cfg fi0
   let fi1   = reducedFi { Types.quals = remakeQual <$> Types.quals reducedFi }
   let si0   = {- SCC "convertFormat" -} convertFormat fi1
-  writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si0)
+  -- writeLoud $ "fq file after format convert: \n" ++ render (toFixpoint cfg si0)
   -- rnf si0 `seq` donePhase Loud "Format Conversion"
   let si1   = either die id ({- SCC "sanitize" -} sanitize cfg $!! si0)
-  writeLoud $ "fq file after sanitize: \n" ++ render (toFixpoint cfg si1)
+  -- writeLoud $ "fq file after sanitize: \n" ++ render (toFixpoint cfg si1)
   -- rnf si1 `seq` donePhase Loud "Validated Constraints"
   graphStatistics cfg si1
   let si2  = {- SCC "wfcUniqify" -} wfcUniqify $!! si1
-  writeLoud $ "fq file after wfcUniqify: \n" ++ render (toFixpoint cfg si2)
+  -- writeLoud $ "fq file after wfcUniqify: \n" ++ render (toFixpoint cfg si2)
   let si3  = {- SCC "renameAll"  -} renameAll  $!! si2
   rnf si3 `seq` whenLoud $ donePhase Loud "Uniqify & Rename"
   loudDump 1 cfg si3
   let si4  = {- SCC "defunction" -} defunctionalize cfg $!! si3
-  writeLoud $ "fq file after defunc: \n" ++ render (toFixpoint cfg si4)
+  -- writeLoud $ "fq file after defunc: \n" ++ render (toFixpoint cfg si4)
   -- putStrLn $ "AXIOMS: " ++ showpp (asserts si4)
   loudDump 2 cfg si4
   let si5  = {- SCC "elaborate" -} elaborate (atLoc dummySpan "solver") (symbolEnv cfg si4) si4
-  writeLoud $ "fq file after elaborate: \n" ++ render (toFixpoint cfg si5)
+  -- writeLoud $ "fq file after elaborate: \n" ++ render (toFixpoint cfg si5)
   loudDump 3 cfg si5
   let si6 = if extensionality cfg then {- SCC "expand" -} expand cfg si5 else si5
   if rewriteAxioms cfg && noLazyPLE cfg

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -89,7 +89,7 @@ runSolverM cfg sI act =
     file     = C.srcFile cfg
     -- only linear arithmentic when: linear flag is on or solver /= Z3
     -- lar     = linear cfg || Z3 /= solver cfg
-    fi       = (siQuery sI) {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
+    fi       = (siQuery sI) {F.hoInfo = F.cfgHoInfo cfg }
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -41,10 +41,7 @@ type SanitizeM a = Either E.Error a
 --------------------------------------------------------------------------------
 sanitize :: Config -> F.SInfo a -> SanitizeM (F.SInfo a)
 --------------------------------------------------------------------------------
-sanitize cfg =    -- banIllScopedKvars
-        --      Misc.fM dropAdtMeasures
-        --      >=>
-                     banIrregularData
+sanitize cfg =       banIrregularData
          >=> Misc.fM dropFuncSortedShadowedBinders
          >=> Misc.fM sanitizeWfC
          >=> Misc.fM replaceDeadKvars

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -129,11 +129,9 @@ instKSig _  _   _ _ [] = error "Empty qsig in Solution.instKSig"
 instKSig ho env v t (qp:qps) = do
   (su0, i0, qs0) <- candidatesP senv [(0, t, [v])] qp
   ixs       <- matchP senv tyss [(i0, qs0)] (applyQPP su0 <$> qps)
-  -- return     $ F.notracepp msg (reverse ixs)
   ys        <- instSymbol tyss (tail $ reverse ixs)
   return (v:ys)
   where
-    -- msg        = "instKSig " ++ F.showpp qsig
     tyss       = zipWith (\i (t, ys) -> (i, t, ys)) [1..] (instCands ho env)
     senv       = (`F.lookupSEnvWithDistance` env)
 
@@ -148,22 +146,6 @@ instSymbol tyss = go
       qsu <- maybeToList (matchSym qp y)
       ys  <- go [ (i', applyQPSubst qsu  qp') | (i', qp') <- is]
       return (y:ys)
-
--- instKQ :: Bool
---        -> F.SEnv F.Sort
---        -> F.Symbol
---        -> F.Sort
---        -> F.Qualifier
---        -> [Sol.EQual]
--- instKQ ho env v t q = do
---   (su0, qsu0, v0) <- candidates senv [(t, [v])] qp
---   xs              <- match senv tyss [v0] (applyQP su0 qsu0 <$> qps)
---   return           $ Sol.eQual q (F.notracepp msg (reverse xs))
---   where
---     msg        = "instKQ " ++ F.showpp (F.qName q) ++ F.showpp (F.qParams q)
---     qp : qps   = F.qParams q
---     tyss       = instCands ho env
---     senv       = (`F.lookupSEnvWithDistance` env)
 
 instCands :: Bool -> F.SEnv F.Sort -> [(F.Sort, [F.Symbol])]
 instCands ho env = filter isOk tyss

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -118,7 +118,7 @@ solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
        -> SolveM a (F.Result (Integer, a), Stats)
 --------------------------------------------------------------------------------
 solve_ cfg fi s0 ks wkl = do
-  let s1   = {-# SCC "sol-init" #-} S.init cfg fi ks
+  let s1   = F.notracepp "solve_ " $ {-# SCC "sol-init" #-} S.init cfg fi ks
   let s2   = mappend s0 s1
   (s3, res0) <- sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
     -- let s3   = solveEbinds fi s2
@@ -178,14 +178,14 @@ refine bindingsInSmt s w
   | Just (c, w', newScc, rnk) <- W.pop w = do
      i       <- tickIter newScc
      (b, s') <- refineC bindingsInSmt i s c
-     lift $ writeLoud $ refineMsg i c b rnk
+     lift $ writeLoud $ refineMsg i c b rnk (showpp s')
      let w'' = if b then W.push c w' else w'
      refine bindingsInSmt s' w''
   | otherwise = return s
   where
     -- DEBUG
-    refineMsg i c b rnk = printf "\niter=%d id=%d change=%s rank=%d\n"
-                            i (F.subcId c) (show b) rnk
+    refineMsg i c b rnk s = printf "\niter=%d id=%d change=%s rank=%d s=%s\n"
+                             i (F.subcId c) (show b) rnk s
 
 ---------------------------------------------------------------------------
 -- | Single Step Refinement -----------------------------------------------

--- a/tests/horn-old/pos/hof_qual.smt2
+++ b/tests/horn-old/pos/hof_qual.smt2
@@ -1,0 +1,23 @@
+(fixpoint "--allowho")
+(fixpoint "--allowhoqs")
+
+(qualif MyQual ((v @(0)) (p @(1))) (p v))
+
+(var $k0 ((int) ((func(0, [int;bool])))))
+
+(constraint
+  (forall ((p0 (func(0, [int;bool]))) (true))
+    (and
+      (forall ((x int) (p0 x))
+        (($k0 x p0)))
+      (forall ((y int) ($k0 y p0))
+        (forall ((v int) ((v = y)))
+         (($k0 v p0))
+        )
+      )
+      (forall ((z int) ($k0 z p0))
+        (tag (p0 z) "h")
+      )
+    )
+  )
+)

--- a/tests/horn/pos/hof_qual.smt2
+++ b/tests/horn/pos/hof_qual.smt2
@@ -1,0 +1,23 @@
+(fixpoint "--allowho")
+(fixpoint "--allowhoqs")
+ 
+ 
+(qualif MyQual ((v @(0)) (p @(1))) (p v))
+ 
+(var $k0 (Int (func 0 (Int) bool)))
+ 
+ 
+ 
+ 
+ 
+(constraint
+  (and
+    (forall ((p0 (func 0 (Int) bool)) (true))
+      (and
+        (forall ((x Int) ((p0 x)))
+          ($k0 x p0))
+        (forall ((y Int) ($k0 y p0))
+          (forall ((v Int) ((= v y)))
+            ($k0 v p0)))
+        (forall ((z Int) ($k0 z p0))
+          ((p0 z)))))))


### PR DESCRIPTION
So that the below works, for example:

```smt2
(fixpoint "--allowho")
(fixpoint "--allowhoqs")

(qualif MyQual ((v @(0)) (p @(1))) (p v))
 
(var $k0 (Int (func 0 (Int) bool)))
 
(constraint
  (and
    (forall ((p0 (func 0 (Int) bool)) (true))
      (and
        (forall ((x Int) ((p0 x)))
          ($k0 x p0))
        (forall ((y Int) ($k0 y p0))
          (forall ((v Int) ((= v y)))
            ($k0 v p0)))
        (forall ((z Int) ($k0 z p0))
          ((p0 z)))))))
```