### PR TITLE
Bump stack.yaml.lock

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -58,14 +58,9 @@ jobs:
         if: ${{ matrix.vers.ghc == matrix.ghc-default }}
         run: grep "${{ matrix.vers.stackage }}" stack.yaml
 
-      # The lock file is not used if --resolver is specified, dropping this
-      # option with --dry-run is enough to regenerate the lock file that we then
-      # check.
       - name: Stack lock check
         if: ${{ matrix.vers.ghc == matrix.ghc-default }}
-        run: |
-          stack test --no-run-tests --dry-run
-          git diff --exit-code stack.yaml.lock
+        run: stack test --no-run-tests --dry-run --lock-file=error-on-write
 
       - name: Build
         run: stack test --no-run-tests $STACK_FLAGS --resolver ${{ matrix.vers.stackage }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -88,4 +88,4 @@ jobs:
         if: steps.pantry.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.setup.outputs.stack-root }}/pantry
-          key: ${{ steps.cache.outputs.cache-primary-key }}
+          key: ${{ steps.pantry.outputs.cache-primary-key }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         cabal: ["3.10.3.0"]
         vers:
+          # Reminder to also update the lock check.
           - {ghc: "9.8.2", stackage: "nightly-2024-05-25"}
           - {ghc: "9.6.5", stackage: "lts-22.23"}
           - {ghc: "9.4.8", stackage: "lts-21.25"}
@@ -51,6 +52,15 @@ jobs:
             ~/.stack
             .stack-work
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack-${{ hashFiles('**/*.cabal', './stack.yaml', './stack.yaml.lock') }}
+
+      # The lock file is not used if --resolver is specified, dropping this
+      # option with --dry-run is enough to regenerate the lock file that we then
+      # check.
+      - name: Stack lock check
+        if: ${{ matrix.vers.ghc == '9.8.2' }}
+        run: |
+          stack test --no-run-tests --dry-run
+          git diff --exit-code stack.yaml.lock
 
       - name: Build
         run: stack test --no-run-tests $STACK_FLAGS --resolver ${{ matrix.vers.stackage }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -40,19 +40,34 @@ jobs:
 
       - name: Setup Stack
         uses: haskell-actions/setup@v2
+        id: setup
         with:
           ghc-version: ${{ matrix.vers.ghc }}
           cabal-version: ${{ matrix.cabal }}
           enable-stack: true
-          stack-version: "latest"
+          stack-version: '2.15.7'
 
-      - name: Cache ~/.stack and .stack-work
-        uses: actions/cache@v3
+      - name: Configure stack
+        run: |
+          stack config set system-ghc --global true
+          stack config set install-ghc --global false
+
+      - name: List dependencies
+        run: stack ls dependencies json | jq > stack-deps.json
+
+      - name: Restore cached dependency of Pantry (Stackage package index)
+        uses: actions/cache/restore@v4
+        id: pantry
+        env:
+          key: ghc-${{ steps.setup.outputs.ghc-version }}-stack-${{ steps.setup.outputs.stack-version }}
         with:
-          path: |
-            ~/.stack
-            .stack-work
-          key: ${{ runner.os }}-${{ matrix.ghc }}-stack-${{ hashFiles('**/*.cabal', './stack.yaml', './stack.yaml.lock') }}
+          path: ${{ steps.setup.outputs.stack-root }}/pantry
+          key: ${{ env.key }}-plan-${{ hashFiles('stack-deps.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Recompute Stackage package index (~/.stack/pantry)
+        if: steps.pantry.outputs.cache-hit != 'true'
+        run: stack update
 
       - name: Stack resolver check
         if: ${{ matrix.vers.ghc == matrix.ghc-default }}
@@ -63,7 +78,14 @@ jobs:
         run: stack test --no-run-tests --dry-run --lock-file=error-on-write
 
       - name: Build
-        run: stack test --no-run-tests $STACK_FLAGS --resolver ${{ matrix.vers.stackage }}
+        run: stack test --no-run-tests $STACK_FLAGS --resolver ${{ matrix.vers.stackage }} --lock-file=ignore
 
       - name: Test
-        run: stack test --test-arguments "--color=always" $STACK_FLAGS --resolver ${{ matrix.vers.stackage }}
+        run: stack test --test-arguments "--color=always" $STACK_FLAGS --resolver ${{ matrix.vers.stackage }} --lock-file=ignore
+
+      - name: Save cached dependencies of Pantry
+        uses: actions/cache/save@v4
+        if: steps.pantry.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.stack-root }}/pantry
+          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -18,10 +18,11 @@ jobs:
       matrix:
         cabal: ["3.10.3.0"]
         vers:
-          # Reminder to also update the lock check.
           - {ghc: "9.8.2", stackage: "nightly-2024-05-25"}
           - {ghc: "9.6.5", stackage: "lts-22.23"}
           - {ghc: "9.4.8", stackage: "lts-21.25"}
+        ghc-default:
+          - "9.8.2"
         z3:
           - "4.10.2"
 
@@ -53,11 +54,15 @@ jobs:
             .stack-work
           key: ${{ runner.os }}-${{ matrix.ghc }}-stack-${{ hashFiles('**/*.cabal', './stack.yaml', './stack.yaml.lock') }}
 
+      - name: Stack resolver check
+        if: ${{ matrix.vers.ghc == matrix.ghc-default }}
+        run: grep "${{ matrix.vers.stackage }}" stack.yaml
+
       # The lock file is not used if --resolver is specified, dropping this
       # option with --dry-run is enough to regenerate the lock file that we then
       # check.
       - name: Stack lock check
-        if: ${{ matrix.vers.ghc == '9.8.2' }}
+        if: ${{ matrix.vers.ghc == matrix.ghc-default }}
         run: |
           stack test --no-run-tests --dry-run
           git diff --exit-code stack.yaml.lock

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
 
-resolver: nightly-2024-01-26
+resolver: nightly-2024-05-25
 
 flags:
   liquid-fixpoint:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: rest-rewrite-0.4.2@sha256:4afd57aaad716827485240428c1deb5a60b81a3c069968f3b0f27a3cb9faf247,3929
+    hackage: rest-rewrite-0.4.3@sha256:915fb98b8c0a0f518c1a4b75bcf3ae27a3ebd5b10d60cc16a216c2fca2148ab0,3929
     pantry-tree:
-      sha256: a72c2400f09a609d891198b8df1360dd9b50d2fd9d3628a887b04b24636e6401
+      sha256: 4de44fbeb7bd655caeafe605406c0bc5fe1788d9cf37cdac2f18b018ee4cf5e6
       size: 4075
   original:
-    hackage: rest-rewrite-0.4.2
+    hackage: rest-rewrite-0.4.3
 - completed:
     hackage: smtlib-backends-0.3@sha256:a947aead99f6a314833bddca9b502d5faea8d3bd2fc76ffb53c34d5c5b7557bc,1211
     pantry-tree:
@@ -40,15 +40,22 @@ packages:
   original:
     hackage: store-0.7.18
 - completed:
-    hackage: store-core-0.4.4.6@sha256:37d4a628785b72dd26f0d8565895d01f36b4a7b2539100d735c239cf12d76b53,1489
+    hackage: store-core-0.4.4.7@sha256:a2ea427ff0dde30252474dcb0641cb6928cb8a93cd5ee27d4c22adba8e729683,1489
     pantry-tree:
-      sha256: da7e56dce68e291ea431b552a5cbc7cb0736296f9436e339931b193d48072e68
+      sha256: 67828df739695d14f81cd572a3085c76f65ac75f8417095afef8dfb2815f523e
       size: 271
   original:
-    hackage: store-core-0.4.4.6
+    hackage: store-core-0.4.4.7
+- completed:
+    hackage: tasty-1.5@sha256:8da3f47fff790714f7d676692f1207aac156b41f705c55f14d1d8147a751264b,2787
+    pantry-tree:
+      sha256: d139b379075ff0204ad2aa2e20ba668534b21d03f8d712077e03e6d9294b2b8f
+      size: 1944
+  original:
+    hackage: tasty-1.5
 snapshots:
 - completed:
-    sha256: 876a5c75d90718add42e1ad36d66000bf35050ce1c66748119897a32df613186
-    size: 563963
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/1/26.yaml
-  original: nightly-2024-01-26
+    sha256: 0af122fa731a06ffc902bfce4ea19a296ab78729ce717c4da126167c440d5ad3
+    size: 645596
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/5/25.yaml
+  original: nightly-2024-05-25


### PR DESCRIPTION
Minor glitch with #689 that slipped by me, the `stack.yaml.lock` file was out of date or rather I was testing a matrix of `GHC = {9.8.2, 9.6.5, 9.4.8}` but had forgot to update the resolver to match in `stack.yaml` that was for `ghc-9.8.1`.

```
$ cat .github/workflows/stack.yml
...
          # Reminder to also update the lock check.
          - {ghc: "9.8.2", stackage: "nightly-2024-05-25"}

$ cat stack.yaml

resolver: nightly-2024-01-26
...
```

~@facundominguez do you think we need to check for this in CI?~ I went ahead and checked the resolver and the lock file.