### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ Session.vim
 /dist*
 .liquid
 /.vagrant/
-/.stack-work/
+.stack-work
 /build.sh
 /external/fixpoint/config.make
 /external/fixpoint/fixpoint.native


### PR DESCRIPTION
Updated .gitignore to ignore nested .stack-work folders (e.g. the ones in liquidhaskell-boot)

See also [this related issue from liquidhaskell](https://github.com/ucsd-progsys/liquidhaskell/pull/2308)