### PR TITLE
Unfold-unfolded definitions when the extentionality flag is active

### DIFF
--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -861,15 +861,14 @@ evalApp γ ctx e0 es et
   , lambdaArg:remArgs <- es
   = do
       isFuelOk <- checkFuel argName
-      ext <- isExtensionalityOn
-      if isFuelOk && ext 
+      isExtensionalityOn <- gets extensionalityFlag
+      if isFuelOk && isExtensionalityOn
         then do
           useFuel argName
           let argSubst = mkSubst [(argName, lambdaArg)]
           let body' = subst argSubst body
           (body'', fe) <- evalIte γ ctx et body'
           let simpBody = simplify γ ctx (eApps body'' remArgs)
-          -- This is still the same thing I'm doing in the application of functions
           modify $ \st ->
             st { evNewEqualities = S.insert (eApps e0 es, simpBody) (evNewEqualities st) }
           return (Just $ eApps body'' remArgs, fe)
@@ -1228,9 +1227,6 @@ useFuelCount f fc = fc { fcMap = M.insert f (k + 1) m }
   where
     k             = M.lookupDefault 0 f m
     m             = fcMap fc
-
-isExtensionalityOn :: EvalST Bool
-isExtensionalityOn = gets extensionalityFlag
 
 -- | Returns False if there is a fuel count in the evaluation environment and
 -- the fuel count exceeds the maximum. Returns True otherwise.

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -1230,9 +1230,7 @@ useFuelCount f fc = fc { fcMap = M.insert f (k + 1) m }
     m             = fcMap fc
 
 isExtensionalityOn :: EvalST Bool
-isExtensionalityOn = do
-    st <- get
-    return $ extensionalityFlag st
+isExtensionalityOn = gets extensionalityFlag
 
 -- | Returns False if there is a fuel count in the evaluation environment and
 -- the fuel count exceeds the maximum. Returns True otherwise.

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -1231,9 +1231,7 @@ useFuelCount f fc = fc { fcMap = M.insert f (k + 1) m }
     m             = fcMap fc
 
 isExtensionalityOn :: EvalST Bool
-isExtensionalityOn = do
-    st <- get
-    return $ extensionalityFlag st
+isExtensionalityOn = gets extensionalityFlag
 
 -- | Returns False if there is a fuel count in the evaluation environment and
 -- the fuel count exceeds the maximum. Returns True otherwise.

--- a/tests/pos/ext_double_unfold.fq
+++ b/tests/pos/ext_double_unfold.fq
@@ -1,0 +1,19 @@
+fixpoint "--rewrite"
+fixpoint "--extensionality"
+
+constant f : (func(0 , [int; int]))
+define f (x : int) : int = {(13)}
+
+constant g : (func(0, [int; int; int]))
+define g (a : int,  b : int) : int = {(f b)}
+
+constant k : (func(0, [int; int; int]))
+define k (u : int,  m : int) : int = {(13)}
+
+expand [1 : True; 2 : True]
+
+constraint:
+  env []
+  lhs {VV1 : Tuple | true }
+  rhs {VV2 : Tuple | (g = k) }
+  id 1 tag []

--- a/tests/pos/ext_lam.fq
+++ b/tests/pos/ext_lam.fq
@@ -1,0 +1,14 @@
+fixpoint "--rewrite"
+fixpoint "--extensionality"
+fixpoint "--allowho"
+
+constant f : (func(0 , [int; int]))
+define f (x : int) : int = {(13)}
+
+expand [1 : True]
+
+constraint:
+  env []
+  lhs {VV1 : Tuple | true }
+  rhs {VV2 : Tuple | (f = \y : int -> 13) }
+  id 1 tag []

--- a/tests/pos/ext_lam_multi.fq
+++ b/tests/pos/ext_lam_multi.fq
@@ -1,0 +1,14 @@
+fixpoint "--rewrite"
+fixpoint "--extensionality"
+fixpoint "--allowho"
+
+constant f : (func(0 , [int; int; int]))
+define f (x : int, y : int) : int = {(13)}
+
+expand [1 : True]
+
+constraint:
+  env []
+  lhs {VV1 : Tuple | true }
+  rhs {VV2 : Tuple | (f = \y : int -> \k : int -> 13) }
+  id 1 tag []


### PR DESCRIPTION
When trying to prove pretty trivial statements PLE gives up because is not unfolding enough the definitions or lambdas: see the following examples:

```haskell
{-@ LIQUID "--reflection"                @-}
{-@ LIQUID "--ple"                       @-}
{-@ LIQUID "--full"                      @-}
{-@ LIQUID "--extensionality"            @-}
{-@ LIQUID "--dump-opaque-reflections"   @-}
{-@ LIQUID "--ple-with-undecided-guards" @-}

module Example where

{-@ reflect f @-}
f :: Int -> Int
f x = 13

{-@ reflect g @-}
g :: Int -> Int -> Int
g x y = f y

{-@ reflect k @-}
k :: Int -> Int -> Int
k x y = 13


{-@ complexProof :: { f = (\x:Int -> 13) } @-}
complexProof :: ()
complexProof = ()

{-@ complexProof' :: { g = k } @-}
complexProof' :: ()
complexProof' = ()
````