### PR TITLE
Local rewrites

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1410,7 +1410,7 @@ boolP = (reserved "True" >> return True)
     <|> (reserved "False" >> return False)
 
 defsFInfo :: [Def a] -> FInfo a
-defsFInfo defs = {- SCC "defsFI" -} Types.FI cm ws bs ebs lts dts kts qs binfo adts mempty mempty ae
+defsFInfo defs = {- SCC "defsFI" -} Types.FI cm ws bs ebs lts dts kts qs binfo adts mempty mempty ae mempty
   where
     cm         = Misc.safeFromList
                    "defs-cm"        [(cid c, c)         | Cst c       <- defs]

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -429,7 +429,7 @@ updCtx env@InstEnv{..} ctx delta cidMb
                     , icSimpl  = icSimpl ctx <> econsts
                     , icSubcId = cidMb
                     , icANFs   = bs : icANFs ctx
-                    , icLRWs   = mconcat $ icLRWs ctx : newLRWs
+                    , icLRWs   = mconcat $ reverse $ icLRWs ctx : newLRWs
                     }
               , env
               )

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -437,7 +437,7 @@ updCtx env@InstEnv{..} ctx delta cidMb
     eRhs      = maybe PTrue crhs subMb
     binds     = [ (x, y) | i <- delta, let (x, y, _) =  lookupBindEnv i ieBEnv]
     subMb     = getCstr ieCstrs <$> cidMb
-    newLRWs   = Mb.mapMaybe (\k -> M.lookup k ieLRWs) delta
+    newLRWs   = Mb.mapMaybe (`M.lookup` ieLRWs) delta
 
 
 findConstants :: Knowledge -> [Expr] -> [(Expr, Expr)]

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -429,7 +429,7 @@ updCtx env@InstEnv{..} ctx delta cidMb
                     , icSimpl  = icSimpl ctx <> econsts
                     , icSubcId = cidMb
                     , icANFs   = bs : icANFs ctx
-                    , icLRWs   = mconcat $ reverse $ icLRWs ctx : newLRWs
+                    , icLRWs   = mconcat $ icLRWs ctx : newLRWs
                     }
               , env
               )

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -224,6 +224,7 @@ pleTrie t env = loopT env' ctx0 diff0 Nothing res0 t
       , icLRWs        = mempty
       , etaBetaFlag   = etabeta        $ ieCfg env
       , extFlag       = extensionality $ ieCfg env
+      , lrwsFlag      = localRewrites  $ ieCfg env
       }
 
 loopT
@@ -386,6 +387,7 @@ data ICtx    = ICtx
                                               -- generate ho constraints
                                               -- See Note [Eta expansion].
   , extFlag       :: Bool                     -- ^ True if the extensionality flag is turned on
+  , lrwsFlag      :: Bool                     -- ^ True if the locad rewrites flag is turned on
   }
 
 ----------------------------------------------------------------------------------------------
@@ -977,7 +979,8 @@ evalApp γ ctx e0 es et
           return (Nothing, noExpand)
 
 evalApp _ ctx e0 es _
-  | EVar f <- dropECst e0
+  | lrwsFlag ctx
+  , EVar f <- dropECst e0
   , Just rw <- lookupRewrite f $ icLRWs ctx
   = do
       -- expandedTerm <- elaborateExpr "EvalApp rewrite local:" $ eApps rw es
@@ -987,7 +990,8 @@ evalApp _ ctx e0 es _
       return (Just expandedTerm, expand)
 
 evalApp _ ctx e0 es _
-  | deANFed <- deANF ctx e0
+  | lrwsFlag ctx
+  , deANFed <- deANF ctx e0
   , dropECst deANFed /= dropECst e0
   = do
       return (Just $ eApps deANFed es, expand)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -736,9 +736,10 @@ isExprRewritable _ = False
 -- >  in anf2 0
 --
 deANF :: ICtx -> S.HashSet Expr -> S.HashSet Expr
-deANF ctx = S.map $ inlineInExpr (`HashMap.Lazy.lookup` undoANF id bindEnv)
+deANF ctx = S.map $ inlineInExpr (`HashMap.Lazy.lookup` bindEnv)
   where
-    bindEnv = HashMap.Lazy.filterWithKey (\sym _ -> anfPrefix `isPrefixOfSym` sym)
+    bindEnv = undoANF id
+        $ HashMap.Lazy.filterWithKey (\sym _ -> anfPrefix `isPrefixOfSym` sym)
         $ HashMap.Lazy.unions $ map HashMap.Lazy.fromList $ icANFs ctx
 
 -- |

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -100,6 +100,7 @@ data Config = Config
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
   , pleWithUndecidedGuards :: Bool     -- ^ Unfold invocations with undecided guards in PLE
   , etabeta          :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
+  , localRewrites    :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
   , interpreter      :: Bool           -- ^ Do not use the interpreter to assist PLE
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
@@ -261,6 +262,7 @@ defConfig = Config {
         &= help "Use the interpreter to assist PLE"
   , oldPLE                   = False &= help "Use old version of PLE"
   , etabeta                  = False &= help "Use eta expansion and beta reduction to aid PLE"
+  , localRewrites            = False &= name "local-rewrites" &= help "Perform local rewrites inside PLE"
   , noIncrPle                = False &= help "Don't use incremental PLE"
   , noEnvironmentReduction   =
       False

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -83,6 +83,7 @@ module Language.Fixpoint.Types.Constraints (
   , Rewrite  (..)
   , AutoRewrite (..)
   , dedupAutoRewrites
+  , LRWMap
 
   -- * Misc  [should be elsewhere but here due to dependencies]
   , substVars
@@ -688,6 +689,7 @@ fi cs ws binds ls ds ks qs bi aHO aHOq es axe adts ebs
        , ae       = axe
        , ddecls   = adts
        , ebinds   = ebs
+       , lrws = mempty
        }
   where
     --TODO handle duplicates gracefully instead (merge envs by intersect?)
@@ -733,6 +735,7 @@ data GInfo c a = FI
   , hoInfo   :: !HOInfo                    -- ^ Higher Order info
   , asserts  :: ![Triggered Expr]          -- ^ TODO: what is this?
   , ae       :: AxiomEnv                   -- ^ Information about reflected function defs
+  , lrws     :: LRWMap                     -- ^ Local rewrites
   }
   deriving (Eq, Show, Functor, Generic)
 
@@ -761,6 +764,7 @@ instance Semigroup (GInfo c a) where
                 , hoInfo   = hoInfo i1   <> hoInfo i2
                 , asserts  = asserts i1  <> asserts i2
                 , ae       = ae i1       <> ae i2
+                , lrws     = lrws i1     <> lrws i2
                 }
 
 
@@ -778,6 +782,7 @@ instance Monoid (GInfo c a) where
                      , hoInfo   = mempty
                      , asserts  = mempty
                      , ae       = mempty
+                     , lrws     = mempty
                      }
 
 instance PTable (SInfo a) where
@@ -926,6 +931,8 @@ data AxiomEnv = AEnv
   , aenvExpand   :: M.HashMap SubcId Bool
   , aenvAutoRW   :: M.HashMap SubcId [AutoRewrite]
   } deriving (Eq, Show, Generic)
+
+type LRWMap = M.HashMap BindId (M.HashMap Symbol Expr)
 
 instance S.Store AutoRewrite
 instance S.Store AxiomEnv

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -951,7 +951,7 @@ lookupLocalRewrites :: BindId -> LocalRewritesEnv -> Maybe LocalRewrites
 lookupLocalRewrites i (LocalRewritesMap m) = M.lookup i m
 
 insertRewrites :: BindId -> LocalRewrites -> LocalRewritesEnv -> LocalRewritesEnv
-insertRewrites i rws (LocalRewritesMap m) = LocalRewritesMap $ M.insert i rws m
+insertRewrites i rws (LocalRewritesMap m) = LocalRewritesMap $ M.insertWith (<>) i rws m
 
 
 instance S.Store AutoRewrite

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -802,6 +802,7 @@ toFixpoint :: (Fixpoint a, Fixpoint (c a)) => C.Config -> GInfo c a -> Doc
 toFixpoint cfg x' =    cfgDoc   cfg
                   $++$ declsDoc x'
                   $++$ aeDoc    x'
+                  $++$ lrwsDoc  x'
                   $++$ qualsDoc x'
                   $++$ kutsDoc  x'
                 --   $++$ packsDoc x'
@@ -826,6 +827,7 @@ toFixpoint cfg x' =    cfgDoc   cfg
                $++$ toFix    ebs
     qualsDoc      = vcat     . map toFix . L.sort . quals
     aeDoc         = toFix    . ae
+    lrwsDoc       = toFix    . lrws
     metaDoc (i,d) = toFixMeta (text "bind" <+> toFix i) (toFix d)
     mdata         = C.metadata cfg
     binfoDoc
@@ -1062,6 +1064,13 @@ instance Fixpoint AxiomEnv where
 
 instance Fixpoint Equation where
   toFix (Equ f xs e s _) = "define" <+> toFix f <+> ppArgs xs <+> ":" <+> toFix s <+> text "=" <+> braces (parens (toFix e))
+
+instance Fixpoint LocalRewritesEnv where
+  toFix (LocalRewritesMap rws) = vcat $ uncurry toFixLocal <$> M.toList rws
+    where
+      toFixLocal bid (LocalRewrites rws) = text "defineLocal" <+> toFix bid 
+        <+> brackets (vcat $ punctuate ";" $ uncurry toFixRewrite <$> M.toList rws)
+      toFixRewrite sym eq = toFix sym <+> text ":=" <+> toFix eq
 
 instance Fixpoint Rewrite where
   toFix (SMeasure f d xs e)

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -44,7 +44,7 @@ module Language.Fixpoint.Types.Environments (
   , BindEnv, beBinds
   , emptyBindEnv
   , fromListBindEnv
-  , insertBindEnv, lookupBindEnv, currentBindEnvId
+  , insertBindEnv, lookupBindEnv, bindEnvSize
   , filterBindEnv, mapBindEnv, mapWithKeyMBindEnv, adjustBindEnv
   , bindEnvFromList, bindEnvToList, deleteBindEnv, elemsBindEnv
   , EBindEnv, splitByQuantifiers
@@ -210,8 +210,8 @@ fromListIBindEnv = FB . S.fromList
 insertBindEnv :: Symbol -> SortedReft -> a -> BindEnv a -> (BindId, BindEnv a)
 insertBindEnv x r a (BE n m) = (n, BE (n + 1) (M.insert n (x, r, a) m))
 
-currentBindEnvId :: BindEnv a -> BindId
-currentBindEnvId (BE n _) = n
+bindEnvSize :: BindEnv a -> Int
+bindEnvSize (BE n _) = n
 
 fromListBindEnv :: [(BindId, (Symbol, SortedReft, a))] -> BindEnv a
 fromListBindEnv xs = BE (length xs) (M.fromList xs)

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -44,7 +44,7 @@ module Language.Fixpoint.Types.Environments (
   , BindEnv, beBinds
   , emptyBindEnv
   , fromListBindEnv
-  , insertBindEnv, lookupBindEnv
+  , insertBindEnv, lookupBindEnv, currentBindEnvId
   , filterBindEnv, mapBindEnv, mapWithKeyMBindEnv, adjustBindEnv
   , bindEnvFromList, bindEnvToList, deleteBindEnv, elemsBindEnv
   , EBindEnv, splitByQuantifiers
@@ -209,6 +209,9 @@ fromListIBindEnv = FB . S.fromList
 -- | Functions for Global Binder Environment
 insertBindEnv :: Symbol -> SortedReft -> a -> BindEnv a -> (BindId, BindEnv a)
 insertBindEnv x r a (BE n m) = (n, BE (n + 1) (M.insert n (x, r, a) m))
+
+currentBindEnvId :: BindEnv a -> BindId
+currentBindEnvId (BE n _) = n
 
 fromListBindEnv :: [(BindId, (Symbol, SortedReft, a))] -> BindEnv a
 fromListBindEnv xs = BE (length xs) (M.fromList xs)

--- a/tests/neg/localrw.fq
+++ b/tests/neg/localrw.fq
@@ -1,0 +1,16 @@
+fixpoint "--localrewrites"
+fixpoint "--rewrite"
+fixpoint "--allowho"
+
+bind 1 g : { V : Int | true }
+bind 2 g : { V : Int | true }
+
+defineLocal 1 [g := (40 + 1)]
+
+expand [1 : True]
+
+constraint:
+    env [2]
+    lhs { V : Tuple | true }
+    rhs { V : Tuple | (g = 41) }
+    id 1 tag []

--- a/tests/pos/localrw.fq
+++ b/tests/pos/localrw.fq
@@ -1,0 +1,16 @@
+fixpoint "--localrewrites"
+fixpoint "--rewrite"
+fixpoint "--allowho"
+
+bind 1 g : { V : Int | true }
+bind 2 g : { V : Int | true }
+
+defineLocal 1 [g := (40 + 1)]
+
+expand [1 : True]
+
+constraint:
+    env [1]
+    lhs { V : Tuple | true }
+    rhs { V : Tuple | (g = 41) }
+    id 1 tag []

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -37,5 +37,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icEquals = S.empty,     -- :: EvAccum
           icSimpl = SM.empty,     -- :: !ConstMap
           icSubcId = Nothing,     -- :: Maybe SubcId
-          icANFs = []             -- :: [[(Symbol, SortedReft)]]
+          icANFs = [],            -- :: [[(Symbol, SortedReft)]]
+          icLRWs = SM.empty       -- :: M.HashMap Symbol Expr
         }

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -38,5 +38,8 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icSimpl = SM.empty,     -- :: !ConstMap
           icSubcId = Nothing,     -- :: Maybe SubcId
           icANFs = [],            -- :: [[(Symbol, SortedReft)]]
-          icLRWs = mempty
+          icLRWs = mempty,
+          etaBetaFlag = False,
+          extFlag = False,
+          lrwsFlag = False
         }

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -38,5 +38,5 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icSimpl = SM.empty,     -- :: !ConstMap
           icSubcId = Nothing,     -- :: Maybe SubcId
           icANFs = [],            -- :: [[(Symbol, SortedReft)]]
-          icLRWs = SM.empty       -- :: M.HashMap Symbol Expr
+          icLRWs = mempty
         }

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -39,7 +39,7 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icSubcId = Nothing,     -- :: Maybe SubcId
           icANFs = [],            -- :: [[(Symbol, SortedReft)]]
           icLRWs = mempty,
-          etaBetaFlag = False,
-          extFlag = False,
-          lrwsFlag = False
+          icEtaBetaFlag        = False,
+          icExtensionalityFlag = False,
+          icLocalRewritesFlag  = False
         }


### PR DESCRIPTION
Following the discussion on #705 the local rewrites features is implemented standalone.

This PR implements proposal 1 of [#2371/liquid-haskell](https://github.com/ucsd-progsys/liquidhaskell/pull/2371)

Depends on [#2384/liquid-haskell](https://github.com/ucsd-progsys/liquidhaskell/pull/2384)

WIP: at the moment we don't read the local rewrites from `horn` files.