### PR TITLE
Remove the preference for ∧ as the dedicated monoid on Preds

### DIFF
--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -73,12 +73,6 @@ data Pred
   deriving (Data, Typeable, Generic, Eq, ToJSON, FromJSON)
 
 
-instance Semigroup Pred where
-  p1 <> p2 = PAnd [p1, p2]
-
-instance Monoid Pred where
-  mempty = Reft mempty
-
 instance F.Subable Pred where
   syms (Reft e)   = F.syms e
   syms (Var _ xs) = xs


### PR DESCRIPTION
While the Preds certainly do form a monoid under ∧, I don't think this monoid is "better" then other monoids of Preds (e.g. the one under ∨), so there is no compelling reason to dedicate ∧ as *the* implementation of <> in Pred.  It is also not used anywhere in the codebase.