### PR TITLE
Unfold with undecided guards in PLE (take 2)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,3 +6,7 @@ package liquid-fixpoint
 --  z3 library to be at the linker's reach.
 --  flags: +devel +link-z3-as-a-library
   flags: +devel
+
+constraints:
+  -- vector-0.13.2.0 breaks store-0.7.18
+  vector <= 0.13.1.0

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -945,12 +945,13 @@ evalApp γ ctx e0 es et
          (e', fe) <- evalIte γ ctx et newE'        -- TODO:FUEL this is where an "unfolding" happens, CHECK/BUMP counter
          let e2' = stripPLEUnfold e'
          let e3' = simplify γ ctx (eApps e2' es2)  -- reduces a bit the equations
-        
-         if hasUndecidedGuard e' then do
-           -- Don't unfold the expression if there is an if-then-else
-           -- guarding it, just to preserve the size of further
-           -- rewrites.
-           modify $ \st -> st 
+
+         if hasUndecidedGuard e' && guardOf e' == guardOf newE' then do
+           -- Don't unfold the expression if there is an if-then-else guarding
+           -- it, just to preserve the size of further rewrites.
+           -- If evalIte does any modifications, though, we do unfold in order
+           -- to allow analysis of the resulting expression
+           modify $ \st -> st
              { evPendingUnfoldings = M.insert (eApps e0 es) e3' (evPendingUnfoldings st)
              }
            return (Nothing, noExpand)
@@ -977,6 +978,9 @@ evalApp γ ctx e0 es et
 
     hasUndecidedGuard EIte{} = True
     hasUndecidedGuard _ = False
+
+    guardOf (EIte g _ _) = Just g
+    guardOf _ = Nothing
 
 evalApp γ ctx e0 args@(e:es) _
   | EVar f <- dropECst e0

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -942,18 +942,15 @@ evalApp γ ctx e0 es et
                     then elaborateExpr "EvalApp unfold full: " newE 
                     else pure newE
 
-         (newEqs1, (e', fe)) <- collectNewEqualities $ evalIte γ ctx et newE' -- TODO:FUEL this is where an "unfolding" happens, CHECK/BUMP counter
-
+         (e', fe) <- evalIte γ ctx et newE'        -- TODO:FUEL this is where an "unfolding" happens, CHECK/BUMP counter
          let e2' = stripPLEUnfold e'
          let e3' = simplify γ ctx (eApps e2' es2)  -- reduces a bit the equations
-             noNewEqualities = S.null newEqs1
-
-         if hasUndecidedGuard e' && noNewEqualities then do
-           -- Don't unfold the expression if there is an if-then-else guarding
-           -- it, just to preserve the size of further rewrites.
-           -- If there are new equalities after evalIte, however, we do
-           -- unfold in order to allow analysis of the resulting expression.
-           modify $ \st -> st
+        
+         if hasUndecidedGuard e' then do
+           -- Don't unfold the expression if there is an if-then-else
+           -- guarding it, just to preserve the size of further
+           -- rewrites.
+           modify $ \st -> st 
              { evPendingUnfoldings = M.insert (eApps e0 es) e3' (evPendingUnfoldings st)
              }
            return (Nothing, noExpand)
@@ -980,14 +977,6 @@ evalApp γ ctx e0 es et
 
     hasUndecidedGuard EIte{} = True
     hasUndecidedGuard _ = False
-
-    collectNewEqualities :: EvalST a -> EvalST (EvEqualities, a)
-    collectNewEqualities m = do
-      newEqs0 <- state $ \st -> (evNewEqualities st, st { evNewEqualities = S.empty })
-      r <- m
-      newEqs1 <- state $ \st ->
-        (evNewEqualities st, st { evNewEqualities = S.union (evNewEqualities st) newEqs0 })
-      return (newEqs1, r)
 
 evalApp γ ctx e0 args@(e:es) _
   | EVar f <- dropECst e0


### PR DESCRIPTION
Follow up to #716. Instead of collecting new equalities, which might be already known, test for equality the result of evaluating the guards. This measure is more conservative with the unfoldings, still makes the tests pass, and doesn't cause a performance regression for tests/ple/pos/Permutations.hs.