### PR TITLE
Parameterize EquationVs eqName field type

### DIFF
--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -987,7 +987,7 @@ instance PPrint AxiomEnv where
 
 type Equation = EquationV Symbol
 data EquationV v = Equ
-  { eqName :: !Symbol           -- ^ name of reflected function
+  { eqName :: !v                -- ^ name of reflected function
   , eqArgs :: [(Symbol, Sort)]  -- ^ names of parameters
   , eqBody :: !(ExprV v)        -- ^ definition of body
   , eqSort :: !Sort             -- ^ sort of body


### PR DESCRIPTION
This makes possible to rename the name of the equation with a transformation that changes its type.