### PR TITLE
Implement let bindings

### DIFF
--- a/src/Language/Fixpoint/Defunctionalize.hs
+++ b/src/Language/Fixpoint/Defunctionalize.hs
@@ -85,6 +85,9 @@ normalizeLamsFromTo i   = go
                               (i2, e2') = go e2
                           in (max i1 i2, EApp e1' e2')
     go (ECst e s)       = fmap (`ECst` s) (go e)
+    go (ELet x e1 e2)   = let (i1, e1') = go e1
+                              (i2, e2') = go e2
+                          in (max i1 i2, ELet x e1' e2')
     go (EIte e1 e2 e3)  = let (i1, e1') = go e1
                               (i2, e2') = go e2
                               (i3, e3') = go e3

--- a/src/Language/Fixpoint/Horn/SMTParse.hs
+++ b/src/Language/Fixpoint/Horn/SMTParse.hs
@@ -260,6 +260,16 @@ bindsP = sMany bindP
 bindP :: FParser (F.Symbol, F.Sort)
 bindP = sPairP symbolP sortP
 
+-- | We only support lets with a single binder, but we parse this as a "singleton list"
+-- to be forward compatible with multiple binders. Note that the semantics of multiple
+-- binders in smtlib is *simulatenous substitution*, so they cannot be desugared to nested
+-- lets.
+exprBindsP :: FParser (F.Symbol, F.Expr)
+exprBindsP = parens exprBindP
+
+exprBindP :: FParser (F.Symbol, F.Expr)
+exprBindP = sPairP symbolP exprP
+
 defineP :: FParser F.Equation
 defineP = do
   name   <- symbolP
@@ -304,6 +314,7 @@ exprP
 pExprP :: FParser F.Expr
 pExprP
   =   (reserved   "if"     >> (F.EIte   <$> exprP <*> exprP <*> exprP))
+  <|> (reserved   "let"    >> (uncurry F.ELet   <$> exprBindsP <*> exprP))
   <|> (reserved   "lit"    >> (mkLit    <$> stringLiteral <*> sortP))
   <|> (reserved   "cast"   >> (F.ECst   <$> exprP <*> sortP))
   <|> (reserved   "not"    >> (F.PNot   <$> exprP))

--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -444,6 +444,7 @@ toHornExpr (F.EVar s)        = toHornSMT s
 toHornExpr (F.ENeg e)        = P.parens ("-" P.<+> toHornExpr e)
 toHornExpr (F.EApp e1 e2)    = toHornSMT [e1, e2]
 toHornExpr (F.EBin o e1 e2)  = toHornOp   (F.toFix o) [e1, e2]
+toHornExpr (F.ELet x e1 e2)  = toHornMany ["let", toHornSMT [(x, e1)], toHornSMT e2]
 toHornExpr (F.EIte e1 e2 e3) = toHornOp "if"  [e1, e2, e3]
 toHornExpr (F.ECst e t)      = toHornMany ["cast", toHornSMT e, toHornSMT t]
 toHornExpr (F.PNot p)        = toHornOp "not"  [p]

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -30,6 +30,9 @@ instance SMTLIB2 (Symbol, Sort) where
   smt2 env c@(sym, t) = -- build "({} {})" (smt2 env sym, smt2SortMono c env t)
                         parenSeqs [smt2 env sym, smt2SortMono c env t]
 
+instance SMTLIB2 (Symbol, Expr) where
+  smt2 env (sym, e) =  parenSeqs [smt2 env sym, smt2 env e]
+
 smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder
 smt2SortMono = smt2Sort False
 smt2SortPoly = smt2Sort True
@@ -139,6 +142,7 @@ instance SMTLIB2 Expr where
   smt2 env e@(EApp _ _)     = smt2App env e
   smt2 env (ENeg e)         = parenSeqs ["-", smt2 env e]
   smt2 env (EBin o e1 e2)   = parenSeqs [smt2 env o, smt2 env e1, smt2 env e2]
+  smt2 env (ELet x e1 e2)   = parenSeqs ["let", parens (smt2 env (x, e1)), smt2 env e2]
   smt2 env (EIte e1 e2 e3)  = parenSeqs ["ite", smt2 env e1, smt2 env e2, smt2 env e3]
   smt2 env (ECst e t)       = smt2Cast env e t
   smt2 _   PTrue            = "true"

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -417,6 +417,7 @@ collectFreeVarOccurrences = go []
       PImp p1 p2 -> go (go acc p2) p1
       PIff p1 p2 -> go (go acc p2) p1
       PAtom _r e1 e2 -> go (go acc e2) e1
+      ELet x e1 e2 -> go (go acc e2 L.\\ [x]) e1
       EIte p e1 e2 -> go (go (go acc e2) e1) p
       PAnd ps -> foldr (flip go) acc ps
       POr ps -> foldr (flip go) acc ps

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -183,6 +183,7 @@ normalize expr' = mytracepp ("normalize: " ++ showpp expr') $ go expr'
     go (EIte e e1 e2)    = go $ PAnd [PImp e e1, PImp (PNot e) e2]
     go (PAnd ps)         = pAnd (go <$> ps)
     go (POr  ps)         = foldl' (\x y -> PImp (PImp (go x) PFalse) y) PFalse ps
+    go e@ELet{}          = e
     go e@(PAll _ _)      = e -- Cannot appear
     go e@(ELam _ _)      = e -- Cannot appear
     go e@(PExist _ _)    = e -- Cannot appear

--- a/src/Language/Fixpoint/Solver/Extensionality.hs
+++ b/src/Language/Fixpoint/Solver/Extensionality.hs
@@ -148,6 +148,8 @@ mapMPosExpr pos f = go pos
     go p (PImp p1 p2)    = f p =<< (PImp        <$>  go (negatePos p) p1 <*> go p p2)
     go p (PAnd ps)       = f p . PAnd =<< (go p `traverse` ps)
 
+    go p (ELet x e1 e2)  = f p =<< ELet x <$> go p e1 <*> go p e2
+
     -- The below cannot appear due to normalization
     go p (PNot e)        = f p . PNot =<< go p e
     go p (PIff p1 p2)    = f p =<< (PIff        <$>  go p p1 <*> go p p2            )

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -452,6 +452,7 @@ eval γ stk = go
     go (PIff e1 e2)     = PIff         <$> go e1 <*> go e2
     go (PAnd es)        = PAnd         <$> (go `traverse` es)
     go (POr es)         = POr          <$> (go `traverse` es)
+    go (ELet x e1 e2)   = ELet x       <$> go e1 <*> go e2
     go e                = return e
 
 -- | `evalArgs` also evaluates all the partial applications for hacky reasons,

--- a/src/Language/Fixpoint/Solver/Interpreter.hs
+++ b/src/Language/Fixpoint/Solver/Interpreter.hs
@@ -358,6 +358,7 @@ notGuardedApps = flip go []
       EIte b _ _ -> go b $ e0 : acc
       ECoerc _ _ e -> go e acc
       ECst e _ -> go e acc
+      ELet{} -> acc
       ESym _ -> acc
       ECon _ -> acc
       EVar _ -> acc
@@ -388,6 +389,7 @@ largestApps = flip go []
       ESym _ -> acc
       ECon _ -> acc
       EVar _ -> e0 : acc
+      ELet{} -> acc
       ELam _ _ -> acc
       ETApp _ _ -> acc
       ETAbs _ _ -> acc
@@ -557,6 +559,9 @@ interpret ie γ ctx env e@(PExist xss e1) = case xss of
 interpret _  _ _   _   e@PGrad{}         = e
 interpret ie γ ctx env (ECoerc s t e)    = let e' = interpret' ie γ ctx env e in
                                              if s == t then e' else ECoerc s t e'
+interpret ie γ ctx env (ELet x e1 e2)    = let e1' = interpret' ie γ ctx env e1
+                                               e2' = interpret' ie γ ctx env e2 in
+                                             ELet x e1' e2'
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -643,6 +643,10 @@ eval γ ctx et = go
       return (Mb.fromMaybe e me', fe)
     go (ECst e t)       = do (e', fe) <- go e
                              return (ECst e' t, fe)
+    go (ELet x e1 e2)   = do (e1', fe1) <- go e1
+                             (e2', fe2) <- go e2
+                             return (ELet x e1' e2', fe1 <|> fe2)
+
     go e                = return (e, noExpand)
 
     binOp f e1 e2 = do

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -225,6 +225,15 @@ subExprs' (PAnd es) = [ (e, PAnd . f) | (e, f) <- subs es ]
 
 subExprs' (POr es) = [ (e, POr . f) | (e, f) <- subs es ]
 
+subExprs' (ELet x e1 e2) = e1'' ++ e2''
+  where
+    e1' = subExprs e1
+    e2' = subExprs e2
+    e1'' :: [SubExpr]
+    e1'' = map (\(e, f) -> (e, \e' -> ELet x (f e') e2)) e1'
+    e2'' :: [SubExpr]
+    e2'' = map (\(e, f) -> (e, \e' -> ELet x e1 (f e'))) e2'
+
 subExprs' _ = []
 
 -- | Computes the subexpressions of a list of expressions.
@@ -308,4 +317,6 @@ unify freeVars template seenExpr = case (dropECst template, seenExpr) of
       unify freeVars rw seen
     (ECoerc _ _ rw, ECoerc _ _ seen) ->
       unify freeVars rw seen
+    (ELet _ rw1 rw2, ELet _ seen1 seen2) ->
+      unifyAll freeVars [rw1, rw2] [seen1, seen2]
     _ -> Nothing

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -248,6 +248,7 @@ elabFMap (EApp (EApp (EApp h@(EVar f) e1) e2) e3)
 elabFMap (EApp e1 e2)      = EApp (elabFMap e1) (elabFMap e2)
 elabFMap (ENeg e)          = ENeg (elabFMap e)
 elabFMap (EBin b e1 e2)    = EBin b (elabFMap e1) (elabFMap e2)
+elabFMap (ELet x e1 e2)    = ELet x (elabFMap e1) (elabFMap e2)
 elabFMap (EIte e1 e2 e3)   = EIte (elabFMap e1) (elabFMap e2) (elabFMap e3)
 elabFMap (ECst e t)        = ECst (elabFMap e) t
 elabFMap (ELam b e)        = ELam b (elabFMap e)
@@ -291,6 +292,7 @@ elabFSetBagZ3 (EApp (EApp h@(EVar f) e1) e2)
 elabFSetBagZ3 (EApp e1 e2)      = EApp (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
 elabFSetBagZ3 (ENeg e)          = ENeg (elabFSetBagZ3 e)
 elabFSetBagZ3 (EBin b e1 e2)    = EBin b (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
+elabFSetBagZ3 (ELet x e1 e2)    = ELet x (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
 elabFSetBagZ3 (EIte e1 e2 e3)   = EIte (elabFSetBagZ3 e1) (elabFSetBagZ3 e2) (elabFSetBagZ3 e3)
 elabFSetBagZ3 (ECst e t)        = ECst (elabFSetBagZ3 e) t
 elabFSetBagZ3 (ELam b e)        = ELam b (elabFSetBagZ3 e)
@@ -325,11 +327,11 @@ validateSort _ Nothing = return ()
 elabExprE :: ElabParam -> Maybe Sort -> Expr -> Either Error Expr
 elabExprE (ElabParam ef msg env) t e =
   case runCM0 (srcSpan msg) (Just ef) $ do
-    (!e', eSort) <- elab (env, envLookup) e
-    validateSort eSort t
-    finalThetaRef <- asks chTVSubst
-    finalTheta <- liftIO $ readIORef finalThetaRef
-    return (applyExpr finalTheta e') of
+        (!e', eSort) <- elab (env, envLookup) e
+        validateSort eSort t
+        finalThetaRef <- asks chTVSubst
+        finalTheta <- liftIO $ readIORef finalThetaRef
+        return (applyExpr finalTheta e') of
     Left (ChError f') ->
       let e' = f' ()
       in Left $ err (srcSpan e') (d (val e'))
@@ -359,6 +361,7 @@ elabApply env = go
     step (POr [])         = PFalse
     step (ENeg e)         = ENeg (go  e)
     step (EBin o e1 e2)   = EBin o (go e1) (go e2)
+    step (ELet x e1 e2)   = ELet x (go e1) (go e2)
     step (EIte e1 e2 e3)  = EIte (go e1) (go e2) (go e3)
     step (ECst e t)       = ECst (go e) t
     step (PAnd ps)        = PAnd (go <$> ps)
@@ -568,6 +571,7 @@ checkExpr _ (ECon (L _ s))  = return s
 checkExpr f (EVar x)        = checkSym f x
 checkExpr f (ENeg e)        = checkNeg f e
 checkExpr f (EBin o e1 e2)  = checkOp f e1 o e2
+checkExpr f (ELet x e1 e2)  = checkLet f x e1 e2
 checkExpr f (EIte p e1 e2)  = checkIte f p e1 e2
 checkExpr f (ECst e t)      = checkCst f t e
 checkExpr f (EApp g e)      = checkApp f Nothing g e
@@ -652,6 +656,11 @@ elab f@(!_,!g) (EIte !p !e1 !e2) = do
   (!e2', !s2) <- elab f (eCst e2 t)
   !s          <- checkIteTy g p e1' e2' s1 s2
   return (EIte p' (eCst e1' s) (eCst e2' s), s)
+
+elab f (ELet !x !e1 !e2) = do
+  (!e1', !t1) <- elab f e1
+  (!e2', !t2) <- elab (elabAddEnv f [(x, t1)]) e2
+  return (ELet x e1' e2', t2)
 
 elab !f (ECst !e !t) = do
   (!e', !_) <- elab f e
@@ -1047,6 +1056,12 @@ refreshNegativeTyVars s = do
     negSort (FFunc s1 s2)    = negSort s1 `S.union` negSort s2
     negSort (FApp s1 s2)     = negSort s1 `S.union` negSort s2
     negSort _                = S.empty
+
+-- | Helper for checking let expressions
+checkLet :: Env -> Symbol -> Expr -> Expr -> CheckM Sort
+checkLet f x e1 e2 = do
+  t <- checkExpr f e1
+  checkExpr (addEnv f [(x, t)]) e2
 
 -- | Helper for checking if-then-else expressions
 checkIte :: Env -> Expr -> Expr -> Expr -> CheckM Sort

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -337,6 +337,7 @@ data ExprV v
           | EApp !(ExprV v) !(ExprV v)
           | ENeg !(ExprV v)
           | EBin !Bop !(ExprV v) !(ExprV v)
+          | ELet !Symbol !(ExprV v) !(ExprV v)
           | EIte !(ExprV v) !(ExprV v) !(ExprV v)
           | ECst !(ExprV v) !Sort
           | ELam !(Symbol, Sort)   !(ExprV v)
@@ -405,6 +406,7 @@ exprSymbolsSet = go
     go (ECoerc _ _ e)     = go e
     go (ENeg e)           = go e
     go (EBin _ e1 e2)     = gos [e1, e2]
+    go (ELet x e1 e2)     = HashSet.union (go e1) (HashSet.delete x $ go e2)
     go (EIte p e1 e2)     = gos [p, e1, e2]
     go (ECst e _)         = go e
     go (PAnd ps)          = gos ps
@@ -451,6 +453,7 @@ exprKVars = go
     go (ECoerc _ _ e)     = go e
     go (ENeg e)           = go e
     go (EBin _ e1 e2)     = gos [e1, e2]
+    go (ELet _ e1 e2)     = gos [e1, e2]
     go (EIte p e1 e2)     = gos [p, e1, e2]
     go (ECst e _)         = go e
     go (PAnd ps)          = gos ps
@@ -520,6 +523,7 @@ debruijnIndex = go
     go (EVar _)        = 1
     go (ENeg e)        = go e
     go (EBin _ e1 e2)  = go e1 + go e2
+    go (ELet _ e1 e2)  = 1 + go e1 + go e2
     go (EIte e e1 e2)  = go e + go e1 + go e2
     go (ETAbs e _)     = go e
     go (ETApp e _)     = go e
@@ -609,6 +613,7 @@ instance (Ord v, Fixpoint v) => Fixpoint (ExprV v) where
   toFix e@(EApp _ _)   = parens $ hcat $ punctuate " " $ toFix <$> (f:es) where (f, es) = splitEApp e
   toFix (ENeg e)       = parens $ text "-"  <+> parens (toFix e)
   toFix (EBin o e1 e2) = parens $ sep [toFix e1  <+> toFix o, nest 2 (toFix e2)]
+  toFix (ELet x e1 e2) = parens $ sep [text "let" <+> toFix x <+> text "=" <+> toFix e1 <+> text "in", nest 2 (toFix e2)]
   toFix (EIte p e1 e2) = parens $ sep [text "if" <+> toFix p <+> text "then", nest 2 (toFix e1), text "else", nest 2 (toFix e2)]
   -- toFix (ECst e _so)   = toFix e
   toFix (ECst e so)    = parens $ toFix e   <+> text " : " <+> toFix so
@@ -789,6 +794,10 @@ instance (Ord v, Fixpoint v, PPrint v) => PPrint (ExprV v) where
                                    pprintTidy k o         <+>
                                    pprintPrec (zo+1) k e2
     where zo = opPrec o
+  pprintPrec _ k (ELet x e1 e2)  = parens
+                                   "let"  <+> toFix x <+> "=" <+> pprintTidy  k e1  <+>
+                                   "in"   <+> pprintTidy k e2
+
   pprintPrec z k (EIte p e1 e2)  = parensIf (z > zi) $
                                    "if"   <+> pprintPrec (zi+1) k p  <+>
                                    "then" <+> pprintPrec (zi+1) k e1 <+>

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -120,17 +120,18 @@ subSymbol (Just (EVar y)) _ = y
 subSymbol Nothing         x = x
 subSymbol a               b = errorstar (printf "Cannot substitute symbol %s with expression %s" (showFix b) (showFix a))
 
-substfLam :: (Symbol -> Expr) -> (Symbol, Sort) -> Expr -> Expr
-substfLam f s@(x, _) e =  ELam s (substf (\y -> if y == x then EVar x else f y) e)
+captureAvoiding :: Symbol -> (Symbol -> Expr) -> Symbol -> Expr
+captureAvoiding x f y = if y == x then EVar x else f y
 
 instance Subable Expr where
   syms                     = exprSymbols
   substa f                 = substf (EVar . f)
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
-  substf f (ELam x e)      = substfLam f x e
+  substf f (ELam (x,t) e)  = ELam (x, t) (substf (captureAvoiding x f) e)
   substf f (ECoerc a t e)  = ECoerc a t (substf f e)
   substf f (ENeg e)        = ENeg (substf f e)
   substf f (EBin op e1 e2) = EBin op (substf f e1) (substf f e2)
+  substf f (ELet x e1 e2)  = ELet x (substf f e1) (substf (captureAvoiding x f) e2)
   substf f (EIte p e1 e2)  = EIte (substf f p) (substf f e1) (substf f e2)
   substf f (ECst e so)     = ECst (substf f e) so
   substf f (EVar x)        = f x
@@ -141,7 +142,7 @@ instance Subable Expr where
   substf f (PIff p1 p2)    = PIff (substf f p1) (substf f p2)
   substf f (PAtom r e1 e2) = PAtom r (substf f e1) (substf f e2)
   substf f (PKVar k (Su su)) = PKVar k (Su $ M.map (substf f) su)
-  substf _  (PAll _ _)     = errorstar "substf: FORALL"
+  substf _ (PAll _ _)      = errorstar "substf: FORALL"
   substf f (PGrad k su i e)= PGrad k su i (substf f e)
   substf _  p              = p
 

--- a/src/Language/Fixpoint/Types/Templates.hs
+++ b/src/Language/Fixpoint/Types/Templates.hs
@@ -46,6 +46,8 @@ matchesTemplate (xs, ENeg t) (ENeg e)
   = matchesTemplate (xs, t) e
 matchesTemplate (xs, EBin b t1 t2) (EBin b' e1 e2)
   = b == b' && matchesTemplate (xs, t1) e1 && matchesTemplate (xs, t2) e2
+matchesTemplate (xs, ELet x t1 t2) (ELet x' e1 e2)
+  = x == x' && matchesTemplate (xs, t1) e1 && matchesTemplate (xs, t2) e2
 matchesTemplate (xs, EIte t1 t2 t3) (EIte e1 e2 e3)
   = matchesTemplate (xs, t1) e1 && matchesTemplate (xs, t2) e2 && matchesTemplate (xs, t3) e3
 matchesTemplate (xs, ECst t s) (ECst e s')

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -112,6 +112,7 @@ instance Visitable Expr where
       step (EApp e1 e2)       = EApp (vE e1) (vE e2)
       step (ENeg e)         = ENeg (vE e)
       step (EBin o e1 e2)   = EBin o (vE e1) (vE e2)
+      step (ELet x e1 e2)   = ELet x (vE e1) (vE e2)
       step (EIte p e1 e2)   = EIte (vE p) (vE e1) (vE e2)
       step (ECst e t)       = ECst (vE e) t
       step (PAnd ps)        = PAnd (map vE ps)
@@ -164,7 +165,7 @@ instance Visitable AxiomEnv where
     aenvEqs = transE v <$> aenvEqs x,
     aenvSimpl = transE v <$> aenvSimpl x
   }
-    
+
 instance Visitable Equation where
   transE v eq = eq {
     eqBody = transE v (eqBody eq)
@@ -180,12 +181,12 @@ execVisitM !v !c !a !f !x = unsafePerformIO $ do
   rn <- newIORef a
   result <- runReaderT (f v c x) rn
   finalAcc <- readIORef rn
-  return (result, finalAcc) 
+  return (result, finalAcc)
 
 type FoldM acc = ReaderT (IORef acc) IO
 
 accum :: (Monoid a) => a -> FoldM a ()
-accum !z = do 
+accum !z = do
   ref <- ask
   liftIO $ modifyIORef' ref (mappend z)
 
@@ -259,6 +260,7 @@ foldExpr !v    = vE
     step !c (EApp f e)      = EApp        <$> vE c f  <*> vE c e
     step !c (ENeg e)        = ENeg        <$> vE c e
     step !c (EBin o e1 e2)  = EBin o      <$> vE c e1 <*> vE c e2
+    step !c (ELet x e1 e2)  = ELet x      <$> vE c e1 <*> vE c e2
     step !c (EIte p e1 e2)  = EIte        <$> vE c p  <*> vE c e1 <*> vE c e2
     step !c (ECst e t)      = (`ECst` t)  <$> vE c e
     step !c (PAnd  ps)      = PAnd        <$> (vE c `traverse` ps)
@@ -318,6 +320,10 @@ mapExprOnExpr f = go
         let !e1' = go e1
             !e2' = go e2
         in EBin o e1' e2'
+      ELet x e1 e2 ->
+        let !e1' = go e1
+            !e2' = go e2
+        in ELet x e1' e2'
       EIte p e1 e2 ->
         let !p' = go p
             !e1' = go e1
@@ -423,6 +429,7 @@ mapMExpr f = go
     go (PImp p1 p2)    = f =<< (PImp        <$>  go p1 <*> go p2          )
     go (PIff p1 p2)    = f =<< (PIff        <$>  go p1 <*> go p2          )
     go (PAtom r e1 e2) = f =<< (PAtom r     <$>  go e1 <*> go e2          )
+    go (ELet x e1 e2)  = f =<< (ELet x      <$>  go e1 <*> go e2          )
     go (EIte p e1 e2)  = f =<< (EIte        <$>  go p  <*> go e1 <*> go e2)
     go (PAnd ps)       = f . PAnd =<< (go `traverse` ps)
     go (POr ps)        = f . POr =<< (go `traverse` ps)
@@ -490,6 +497,7 @@ kvarsExpr = go []
       PImp p1 p2 -> go (go acc p2) p1
       PIff p1 p2 -> go (go acc p2) p1
       PAtom _r e1 e2 -> go (go acc e2) e1
+      ELet _ e1 e2 -> go (go acc e2) e1
       EIte p e1 e2 -> go (go (go acc e2) e1) p
       PAnd ps -> foldr (flip go) acc ps
       POr ps -> foldr (flip go) acc ps

--- a/tests/horn/pos/let-binding00.smt2
+++ b/tests/horn/pos/let-binding00.smt2
@@ -1,0 +1,4 @@
+(constraint
+    (forall ((x Int) (true))
+        ((let ((y 2))
+            (= (* x y) (+ x x))))))

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -78,6 +78,7 @@ subexprs (PAll _ e)      = [e]
 subexprs (PExist _ e)    = [e]
 subexprs (PGrad _ _ _ e) = [e]
 subexprs (ECoerc _ _ e)  = [e]
+subexprs (ELet _ e1 e2)  = [e1, e2]
 
 -- TODO: Adjust frequencies
 -- | To ensure this reliably terminates we require that `zeroExprGen` generates
@@ -107,6 +108,7 @@ arbitraryFiniteExpr zeroExprGen n = frequency
   , (1, PExist <$> arbitraryList arbitrary <*> arbitraryExpr')
   , (1, PGrad <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitraryExpr')
   , (1, ECoerc <$> arbitrary <*> arbitrary <*> arbitraryExpr')
+  , (1, ELet <$> arbitrary <*> arbitraryExpr' <*> arbitraryExpr')
   ]
   where
     arbitraryExpr' = arbitraryFiniteExpr zeroExprGen (n `div` 2)


### PR DESCRIPTION
We've found significant performance improvements when reducing the size of expressions sent to fixpoint (and the smt solver) by deduplicating common subexpressions using let bindings. For simplicity, this only implements one binder per let.

The first commit implements the parts I'm more confident about. The second commit touches PLE stuff that I barely understand, so please review that more carefully.

There are also a couple of functions that match on an expression that I didn't modify, so they don't show up in the PR:

* Language.Fixpoint.Solver.Instantiate.topApps 
* Language.Fixpoint.Solver.PLE.isExprRewritable
* Language.Fixpoint.Solver.PLE.simplify
* Language.Fixpoint.Solver.Rewrite.convert

