### PR TITLE
generate apply tags dynamically

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -73,7 +73,7 @@ module Language.Fixpoint.Smt.Interface (
     ) where
 
 import           Language.Fixpoint.Types.Config ( SMTSolver (..), solverFlags
-                                                , Config (solver, smtTimeout, gradual, stringTheory, save))
+                                                , Config (solver, smtTimeout, gradual, stringTheory, save, allowHO))
 import qualified Language.Fixpoint.Misc          as Misc
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
@@ -363,6 +363,7 @@ makeContext' cfg ctxLog
                   , ctxSymEnv    = mempty
                   , ctxIxs       = []
                   , ctxDefines   = mempty
+                  , ctxLams      = allowHO cfg
                   }
 
 -- | Close file handles and release the solver backend's resources.
@@ -534,7 +535,7 @@ interactDecl' cmd  = do
   ctx <- get
   let env = -- trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
                   (ctxSymEnv ctx)
-  let ats = funcSortVars env
+  let ats = funcSortVars (ctxLams ctx) env
   forM_ ats $ uncurry $ smtFuncDecl
   put (ctx {ctxSymEnv = env {seAppls = mergeTopAppls (seApplsCur env) (seAppls env), seApplsCur = M.empty} })
   void $ command' cmdBS
@@ -585,16 +586,15 @@ symbolSorts env = [(x, tx t) | (x, t) <- F.toListSEnv env ]
 dataDeclarations :: SymEnv -> [[DataDecl]]
 dataDeclarations = orderDeclarations . map snd . F.toListSEnv . F.seData
 
-funcSortVars :: F.SymEnv -> [(T.Text, ([F.SmtSort], F.SmtSort))]
-funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
-                 ++ [(var coerceName t       , ([t1],t2)) | t@(t1, t2) <- ts]
-                 ++ [(var lambdaName t       , lamSort t) | t <- ts]
-                 ++ [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ]
+funcSortVars :: Bool -> F.SymEnv -> [(T.Text, ([F.SmtSort], F.SmtSort))]
+funcSortVars lams env =
+                  [(var applyName  t       , appSort t) | t <- ts]
+  ++              [(var coerceName t       , ([t1],t2)) | t@(t1, t2) <- ts]
+  ++              [(var lambdaName t       , lamSort t) | t <- ts]
+  ++ if lams then [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ] else []
   where
-    var n t       =
-        let vr = evalState (F.symbolAtSmtName n () t) env
-        in -- trace ("var " ++ show vr)
-           vr
+    var :: F.Symbol -> F.FuncSort -> T.Text
+    var n t       = evalState (F.symbolAtSmtName n () t) env
     ts            = M.keys $ F.seApplsCur env
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -215,7 +215,7 @@ command !cmd       = do
   ctxLog <- gets ctxLog
   ctxSolver <- gets ctxSolver
   ctxVerbose <- gets ctxVerbose
-  cmdBS <- hoistSMT $ runSmt2 cmd
+  cmdBS <- liftSym $ runSmt2 cmd
   ctx <- gets ctxSymEnv
   let cmdBS' = trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx)) cmdBS
   forM_ ctxLog $ \h -> lift $ do
@@ -527,7 +527,7 @@ interact' cmd  = void $ command cmd
 
 interactDecl' :: Command -> SmtM ()
 interactDecl' cmd  = do
-  cmdBS <- hoistSMT $ runSmt2 cmd
+  cmdBS <- liftSym $ runSmt2 cmd
   ctx <- get
   let env = trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
                   (ctxSymEnv ctx)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -38,6 +38,9 @@ module Language.Fixpoint.Smt.Interface (
 
     -- * Execute Queries
     , command
+
+    , command'
+
     , smtSetMbqi
 
     -- * Query API
@@ -45,11 +48,17 @@ module Language.Fixpoint.Smt.Interface (
     , smtDecls
     , smtDefineFunc
     , smtAssert
+
+    , smtAssertDecl
+
     , smtFuncDecl
     , smtAssertAxiom
     , smtCheckUnsat
     , smtCheckSat
     , smtBracket, smtBracketAt
+
+--    , smtBracketDecl
+
     , smtDistinct
     , smtPush, smtPop
 
@@ -58,6 +67,8 @@ module Language.Fixpoint.Smt.Interface (
     , checkValid'
     , checkValidWithContext
     , checkValids
+
+    , funcSortVars
 
     ) where
 
@@ -105,6 +116,7 @@ import qualified SMTLIB.Backends
 import qualified SMTLIB.Backends.Process as Process
 import qualified Language.Fixpoint.Conditional.Z3 as Conditional.Z3
 import Control.Concurrent.Async (async)
+import Debug.Trace
 
 {-
 runFile f
@@ -177,6 +189,21 @@ commandRaw ctxLog ctxSolver ctxVerbose cmdBS = do
         Data.Text.IO.putStrLn textResponse
       return r
 
+command'              :: Builder -> SmtM Response
+--------------------------------------------------------------------------------
+command' cmdBS       = do
+  -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
+  --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
+  ctxLog <- gets ctxLog
+  ctxSolver <- gets ctxSolver
+  -- ctxVerbose <- gets ctxVerbose
+  ctx <- gets ctxSymEnv
+  let cmdBS' = trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx)) cmdBS
+  forM_ ctxLog $ \h -> lift $ do
+    BS.hPutBuilder h cmdBS'
+    LBS.hPutStr h "\n"
+  lift $ (SMTLIB.Backends.command_ ctxSolver cmdBS) >> return Ok
+
 --------------------------------------------------------------------------------
 {-# SCC command #-}
 command              :: Command -> SmtM Response
@@ -188,8 +215,10 @@ command !cmd       = do
   ctxSolver <- gets ctxSolver
   ctxVerbose <- gets ctxVerbose
   cmdBS <- hoistSMT $ runSmt2 cmd
+  ctx <- gets ctxSymEnv
+  let cmdBS' = trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx)) cmdBS
   forM_ ctxLog $ \h -> lift $ do
-    BS.hPutBuilder h cmdBS
+    BS.hPutBuilder h cmdBS'
     LBS.hPutStr h "\n"
   lift $ case cmd of
     CheckSat   -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
@@ -394,7 +423,7 @@ smtDecl x t = do
   let env = seData (ctxSymEnv me)
   let ins' = sortSmtSort False env <$> ins
   let out' = sortSmtSort False env     out
-  interact' ({- notracepp msg $ -} Declare (symbolSafeText x) ins' out')
+  interact' (tracepp _msg $ Declare (symbolSafeText x) ins' out')
   where
     (ins, out) = deconSort t
     _msg       = "smtDecl: " ++ showpp (x, t, ins, out)
@@ -421,19 +450,21 @@ smtCheckSat p
 smtAssert :: Expr -> SmtM ()
 smtAssert p = interact' (Assert Nothing p)
 
+smtAssertDecl :: Expr -> SmtM ()
+smtAssertDecl p = interactDecl' (Assert Nothing p)
+
 smtDefineEqn :: Equation -> SmtM ()
 smtDefineEqn Equ {..} = smtDefineFunc eqName eqArgs eqSort eqBody
 
 smtDefineFunc :: Symbol -> [(Symbol, F.Sort)] -> F.Sort -> Expr -> SmtM ()
 smtDefineFunc name symList rsort e =
-  do me <- get
-     let env = seData (ctxSymEnv me)
-     interact' $
-           DefineFunc
-             name
-             (map (sortSmtSort False env <$>) symList)
-             (sortSmtSort False env rsort)
-             e
+  do env <- gets (seData . ctxSymEnv)
+     interactDecl' $
+        DefineFunc
+          name
+          (map (sortSmtSort False env <$>) symList)
+          (sortSmtSort False env rsort)
+          e
 
 -----------------------------------------------------------------
 
@@ -453,9 +484,23 @@ smtBracketAt sp _msg a =
 smtBracket :: String -> SmtM a -> SmtM a
 smtBracket _msg a = do
   smtPush
-  r <- a
+  r <- trace ("BRACKET " ++ _msg) a
   smtPop
   return r
+
+{-
+smtBracketDecl :: String -> SmtM a -> SmtM a
+smtBracketDecl _msg a = do
+  smtPush
+  ctx <- get
+  let env = ctxSymEnv ctx
+  let ats = funcSortVars env
+  forM_ ats $ uncurry $ smtFuncDecl
+  put (ctx {ctxSymEnv = env {seAppls = seAppls env <> seApplsNew env, seApplsNew = M.empty} })
+  r <- trace ("BRACKETDECL " ++ _msg) a
+  smtPop
+  return r
+-}
 
 respSat :: Response -> Bool
 respSat Unsat   = True
@@ -466,6 +511,15 @@ respSat r       = die $ err dummySpan $ text ("crash: SMTLIB2 respSat = " ++ sho
 interact' :: Command -> SmtM ()
 interact' cmd  = void $ command cmd
 
+interactDecl' :: Command -> SmtM ()
+interactDecl' cmd  = do
+  cmdBS <- hoistSMT $ runSmt2 cmd
+  ctx <- get
+  let env = ctxSymEnv ctx
+  let ats = funcSortVars env
+  forM_ ats $ uncurry $ smtFuncDecl
+  put (ctx {ctxSymEnv = env {seAppls = seAppls env <> seApplsNew env, seApplsNew = M.empty} })
+  void $ command' cmdBS
 
 makeTimeout :: Config -> [Builder]
 makeTimeout cfg
@@ -492,14 +546,14 @@ declare = do
   let thyXTs     =             [ (x, t) | (x, t) <- xts, symKind env x == Just F.Uninterp ]
   let qryXTs     = fmap tx <$> [ (x, t) | (x, t) <- xts, symKind env x == Nothing ]
   let -- isKind n   = (n ==)  . symKind env . fst
-  let ats        = funcSortVars env
+--  let ats        = funcSortVars env
   let MkDefinedFuns defs = ctxDefines me
   let ess        = distinctLiterals  lts
   let axs        = Thy.axiomLiterals lts
   forM_ dss    $           smtDataDecl
   forM_ thyXTs $ uncurry $ smtDecl
   forM_ qryXTs $ uncurry $ smtDecl
-  forM_ ats    $ uncurry $ smtFuncDecl
+--  forM_ ats    $ uncurry $ smtFuncDecl
   forM_ defs   $           smtDefineEqn
   forM_ ess    $           smtDistinct
   forM_ axs    $           smtAssert
@@ -519,8 +573,10 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
                  ++ [(var lambdaName t       , lamSort t) | t <- ts]
                  ++ [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ]
   where
-    var n t       = evalState (F.symbolAtSmtName n () t) env
-    ts            = M.keys (F.seAppls env)
+    var n t       =
+        let vr = evalState (F.symbolAtSmtName n () t) env
+        in trace ("var " ++ show vr) vr
+    ts            = M.keys (F.seApplsNew env)
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)
     argSort (s,_) = ([]    , s)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -73,6 +73,7 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
+import           Control.Monad.State
 import           Control.Exception
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BS
@@ -175,7 +176,7 @@ command Ctx{..} !cmd       = do
             TE.decodeUtf8With (const $ const $ Just ' ') $
             LBS.toStrict resp
       parse respTxt
-    cmdBS = {-# SCC "Command-runSmt2" #-} runSmt2 ctxSymEnv cmd
+    cmdBS = {-# SCC "Command-runSmt2" #-} evalState (runSmt2 cmd) ctxSymEnv
     parse resp      = do
       case A.parseOnly responseP resp of
         Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
@@ -502,7 +503,7 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
                  ++ [(var lambdaName t       , lamSort t) | t <- ts]
                  ++ [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ]
   where
-    var n         = F.symbolAtSmtName n env ()
+    var n t       = evalState (F.symbolAtSmtName n () t) env
     ts            = M.keys (F.seAppls env)
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -93,6 +93,7 @@ import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Lazy.Char8 as Char8
 import           Data.Char
 import qualified Data.HashMap.Strict      as M
+import           Data.List                (uncons)
 import           Data.Maybe              (fromMaybe)
 --import           Data.Functor.Identity   -- TODO remove
 import qualified Data.Text                as T
@@ -147,7 +148,7 @@ checkValid cfg f xts p q = do
 checkValid' :: [(Symbol, Sort)] -> Expr -> Expr -> SmtM Bool
 checkValid' xts p q = do
   smtDecls xts
-  smtAssert $ pAnd [p, PNot q]
+  smtAssertDecl $ pAnd [p, PNot q]
   smtCheckUnsat
 
 -- | If you already HAVE a context, where all the variables have declared types
@@ -300,8 +301,8 @@ makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do
   ctx     <- makeContext cfg f
   let ctx' = ctx {ctxSymEnv = env, ctxDefines = defns}
-  _ <- runStateT declare ctx'
-  return ctx'
+  (_, ctx'') <- runStateT declare ctx'
+  return ctx''
 
 makeContextNoLog :: Config -> IO Context
 makeContextNoLog cfg = do
@@ -358,6 +359,7 @@ makeContext' cfg ctxLog
                   , ctxLog       = ctxLog
                   , ctxVerbose   = loud
                   , ctxSymEnv    = mempty
+                  , ctxIxs       = []
                   , ctxDefines   = mempty
                   }
 
@@ -484,8 +486,20 @@ smtBracketAt sp _msg a =
 smtBracket :: String -> SmtM a -> SmtM a
 smtBracket _msg a = do
   smtPush
+  modify $ \ctx ->
+    let env = ctxSymEnv ctx in
+    ctx { ctxSymEnv = env { seAppls = pushAppls (seAppls env) }
+        , ctxIxs = seIx env : ctxIxs ctx}
+--  hoistSMT $ modify $ \env -> env { seAppls = pushAppls (seAppls env) }
   r <- trace ("BRACKET " ++ _msg) a
   smtPop
+  modify $ \ctx ->
+    let env = ctxSymEnv ctx
+        (i , is) = fromMaybe (0, []) (uncons $ ctxIxs ctx)
+      in
+    ctx { ctxSymEnv = env {seAppls = popAppls (seAppls env) , seIx = i}
+        , ctxIxs = is}
+--  hoistSMT $ modify $ \env -> env { seAppls = popAppls (seAppls env) }
   return r
 
 {-
@@ -515,10 +529,11 @@ interactDecl' :: Command -> SmtM ()
 interactDecl' cmd  = do
   cmdBS <- hoistSMT $ runSmt2 cmd
   ctx <- get
-  let env = ctxSymEnv ctx
+  let env = trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
+                  (ctxSymEnv ctx)
   let ats = funcSortVars env
   forM_ ats $ uncurry $ smtFuncDecl
-  put (ctx {ctxSymEnv = env {seAppls = seAppls env <> seApplsNew env, seApplsNew = M.empty} })
+  put (ctx {ctxSymEnv = env {seAppls = mergeTopAppls (seApplsCur env) (seAppls env), seApplsCur = M.empty} })
   void $ command' cmdBS
 
 makeTimeout :: Config -> [Builder]
@@ -576,7 +591,7 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
     var n t       =
         let vr = evalState (F.symbolAtSmtName n () t) env
         in trace ("var " ++ show vr) vr
-    ts            = M.keys (F.seApplsNew env)
+    ts            = M.keys $ F.seApplsCur env
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)
     argSort (s,_) = ([]    , s)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -280,8 +280,7 @@ makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do
   ctx      <- makeContext cfg f
   let ctx' = ctx {ctxSymEnv = env, ctxDefines = defns}
-  ctx''    <- execStateT declare ctx'
-  return ctx''
+  execStateT declare ctx'
 
 makeContextNoLog :: Config -> IO Context
 makeContextNoLog cfg = do

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -68,12 +68,12 @@ import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Types         hiding (allowHO)
 import qualified Language.Fixpoint.Types         as F
-import           Language.Fixpoint.Smt.Types
+import Language.Fixpoint.Smt.Types
 import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
-import           Control.Monad.State
+import           Control.Monad.Reader
 import           Control.Exception
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BS
@@ -82,6 +82,7 @@ import qualified Data.ByteString.Lazy.Char8 as Char8
 import           Data.Char
 import qualified Data.HashMap.Strict      as M
 import           Data.Maybe              (fromMaybe)
+--import           Data.Functor.Identity   -- TODO remove
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as TE
 import qualified Data.Text.IO
@@ -118,35 +119,39 @@ runCommands cmds
        return zs
 -}
 
-checkValidWithContext :: Context -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
-checkValidWithContext me xts p q =
-  smtBracket me "checkValidWithContext" $
-    checkValid' me xts p q
+checkValidWithContext :: [(Symbol, Sort)] -> Expr -> Expr -> SmtM Bool
+checkValidWithContext xts p q =
+  smtBracket "checkValidWithContext" $
+    checkValid' xts p q
 
 -- | type ClosedPred E = {v:Pred | subset (vars v) (keys E) }
 -- checkValid :: e:Env -> ClosedPred e -> ClosedPred e -> IO Bool
 checkValid :: Config -> FilePath -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
 checkValid cfg f xts p q = do
   me <- makeContext cfg f
-  checkValid' me xts p q
+  runReaderT (checkValid' xts p q) me
 
-checkValid' :: Context -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
-checkValid' me xts p q = do
-  smtDecls me xts
-  smtAssert me $ pAnd [p, PNot q]
-  smtCheckUnsat me
+checkValid' :: [(Symbol, Sort)] -> Expr -> Expr -> SmtM Bool
+checkValid' xts p q = do
+  smtDecls xts
+  smtAssert $ pAnd [p, PNot q]
+  smtCheckUnsat
 
 -- | If you already HAVE a context, where all the variables have declared types
 --   (e.g. if you want to make MANY repeated Queries)
 
 -- checkValid :: e:Env -> [ClosedPred e] -> IO [Bool]
 checkValids :: Config -> FilePath -> [(Symbol, Sort)] -> [Expr] -> IO [Bool]
-checkValids cfg f xts ps
-  = do me <- makeContext cfg f
-       smtDecls me xts
-       forM ps $ \p ->
-          smtBracket me "checkValids" $
-            smtAssert me (PNot p) >> smtCheckUnsat me
+checkValids cfg f xts ps = do
+  me <- makeContext cfg f
+  runReaderT (checkValids' xts ps) me
+
+checkValids' :: [(Symbol, Sort)] -> [Expr] -> SmtM [Bool]
+checkValids' xts ps = do
+  smtDecls xts
+  forM ps $ \p ->
+     smtBracket "checkValids" $
+       smtAssert (PNot p) >> smtCheckUnsat
 
 -- debugFile :: FilePath
 -- debugFile = "DEBUG.smt2"
@@ -155,41 +160,47 @@ checkValids cfg f xts ps
 -- | SMT IO --------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+commandRaw :: Maybe Handle -> SMTLIB.Backends.Solver -> Bool -> Builder -> IO Response
+commandRaw ctxLog ctxSolver ctxVerbose cmdBS = do
+  resp <- SMTLIB.Backends.command ctxSolver cmdBS
+  let respTxt =
+        TE.decodeUtf8With (const $ const $ Just ' ') $
+        LBS.toStrict resp
+  case A.parseOnly responseP respTxt of
+    Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
+    Right r -> do
+      let textResponse = "; SMT Says: " <> T.pack (show r)
+      forM_ ctxLog $ \h ->
+        Data.Text.IO.hPutStrLn h textResponse
+      when ctxVerbose $
+        Data.Text.IO.putStrLn textResponse
+      return r
+
 --------------------------------------------------------------------------------
 {-# SCC command #-}
-command              :: Context -> Command -> IO Response
+command              :: Command -> SmtM Response
 --------------------------------------------------------------------------------
-command Ctx{..} !cmd       = do
+command !cmd       = do
   -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
   --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
-  forM_ ctxLog $ \h -> do
+  ctxLog <- asks ctxLog
+  ctxSolver <- asks ctxSolver
+  ctxVerbose <- asks ctxVerbose
+  cmdBS <- hoistSMT $ runSmt2 cmd
+  forM_ ctxLog $ \h -> lift $ do
     BS.hPutBuilder h cmdBS
     LBS.hPutStr h "\n"
-  case cmd of
-    CheckSat   -> commandRaw
-    GetValue _ -> commandRaw
-    _          -> SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
-  where
-    commandRaw      = do
-      resp <- SMTLIB.Backends.command ctxSolver cmdBS
-      let respTxt =
-            TE.decodeUtf8With (const $ const $ Just ' ') $
-            LBS.toStrict resp
-      parse respTxt
-    cmdBS = {-# SCC "Command-runSmt2" #-} evalState (runSmt2 cmd) ctxSymEnv
-    parse resp      = do
-      case A.parseOnly responseP resp of
-        Left e  -> Misc.errorstar $ "SMTREAD:" ++ e
-        Right r -> do
-          let textResponse = "; SMT Says: " <> T.pack (show r)
-          forM_ ctxLog $ \h ->
-            Data.Text.IO.hPutStrLn h textResponse
-          when ctxVerbose $
-            Data.Text.IO.putStrLn textResponse
-          return r
+  lift $ case cmd of
+    CheckSat   -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
+    GetValue _ -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
+    _          -> (SMTLIB.Backends.command_ ctxSolver cmdBS) >> return Ok
+--  where
+--    cmdBS :: Builder
+--    cmdBS = {-# SCC "Command-runSmt2" #-} evalState (runSmt2 cmd) ctxSymEnv
 
-smtSetMbqi :: Context -> IO ()
-smtSetMbqi me = interact' me SetMbqi
+
+smtSetMbqi :: SmtM ()
+smtSetMbqi = interact' SetMbqi
 
 type SmtParser a = Parser T.Text a
 
@@ -259,7 +270,7 @@ makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do
   ctx     <- makeContext cfg f
   let ctx' = ctx {ctxSymEnv = env, ctxDefines = defns}
-  declare ctx'
+  runReaderT declare ctx'
   return ctx'
 
 makeContextNoLog :: Config -> IO Context
@@ -369,27 +380,29 @@ noString smt v cfg
 -- | SMT Commands -----------------------------------------------------------
 -----------------------------------------------------------------------------
 
-smtPush, smtPop   :: Context -> IO ()
-smtPush me        = interact' me Push
-smtPop me         = interact' me Pop
+smtPush, smtPop   :: SmtM ()
+smtPush = interact' Push
+smtPop  = interact' Pop
 
-smtDecls :: Context -> [(Symbol, Sort)] -> IO ()
-smtDecls = mapM_ . uncurry . smtDecl
+smtDecls :: [(Symbol, Sort)] -> SmtM ()
+smtDecls = mapM_ $ uncurry smtDecl
 
-smtDecl :: Context -> Symbol -> Sort -> IO ()
-smtDecl me x t = interact' me ({- notracepp msg $ -} Declare (symbolSafeText x) ins' out')
+smtDecl :: Symbol -> Sort -> SmtM ()
+smtDecl x t = do
+  me <- ask
+  let env = seData (ctxSymEnv me)
+  let ins' = sortSmtSort False env <$> ins
+  let out' = sortSmtSort False env     out
+  interact' ({- notracepp msg $ -} Declare (symbolSafeText x) ins' out')
   where
-    ins'       = sortSmtSort False env <$> ins
-    out'       = sortSmtSort False env     out
     (ins, out) = deconSort t
-    _msg        = "smtDecl: " ++ showpp (x, t, ins, out)
-    env        = seData (ctxSymEnv me)
+    _msg       = "smtDecl: " ++ showpp (x, t, ins, out)
 
-smtFuncDecl :: Context -> T.Text -> ([SmtSort],  SmtSort) -> IO ()
-smtFuncDecl me x (ts, t) = interact' me (Declare x ts t)
+smtFuncDecl :: T.Text -> ([SmtSort],  SmtSort) -> SmtM ()
+smtFuncDecl x (ts, t) = interact' (Declare x ts t)
 
-smtDataDecl :: Context -> [DataDecl] -> IO ()
-smtDataDecl me ds = interact' me (DeclData ds)
+smtDataDecl :: [DataDecl] -> SmtM ()
+smtDataDecl ds = interact' (DeclData ds)
 
 deconSort :: Sort -> ([Sort], Sort)
 deconSort t = case functionSort t of
@@ -397,48 +410,50 @@ deconSort t = case functionSort t of
                 Nothing            -> ([], t)
 
 -- hack now this is used only for checking gradual condition.
-smtCheckSat :: Context -> Expr -> IO Bool
-smtCheckSat me p
- = smtAssert me p >> (ans <$> command me CheckSat)
+smtCheckSat :: Expr -> SmtM Bool
+smtCheckSat p
+ = smtAssert p >> (ans <$> command CheckSat)
  where
    ans Sat = True
    ans _   = False
 
-smtAssert :: Context -> Expr -> IO ()
-smtAssert me p = interact' me (Assert Nothing p)
+smtAssert :: Expr -> SmtM ()
+smtAssert p = interact' (Assert Nothing p)
 
-smtDefineEqn :: Context -> Equation -> IO ()
-smtDefineEqn me Equ {..} = smtDefineFunc me eqName eqArgs eqSort eqBody
+smtDefineEqn :: Equation -> SmtM ()
+smtDefineEqn Equ {..} = smtDefineFunc eqName eqArgs eqSort eqBody
 
-smtDefineFunc :: Context -> Symbol -> [(Symbol, F.Sort)] -> F.Sort -> Expr -> IO ()
-smtDefineFunc me name symList rsort e =
-  let env = seData (ctxSymEnv me)
-  in interact' me $
-        DefineFunc
-          name
-          (map (sortSmtSort False env <$>) symList)
-          (sortSmtSort False env rsort)
-          e
+smtDefineFunc :: Symbol -> [(Symbol, F.Sort)] -> F.Sort -> Expr -> SmtM ()
+smtDefineFunc name symList rsort e =
+  do me <- ask
+     let env = seData (ctxSymEnv me)
+     interact' $
+           DefineFunc
+             name
+             (map (sortSmtSort False env <$>) symList)
+             (sortSmtSort False env rsort)
+             e
 
 -----------------------------------------------------------------
 
-smtAssertAxiom :: Context -> Triggered Expr -> IO ()
-smtAssertAxiom me p  = interact' me (AssertAx p)
+smtAssertAxiom :: Triggered Expr -> SmtM ()
+smtAssertAxiom p  = interact' (AssertAx p)
 
-smtDistinct :: Context -> [Expr] -> IO ()
-smtDistinct me az = interact' me (Distinct az)
+smtDistinct :: [Expr] -> SmtM ()
+smtDistinct az = interact' (Distinct az)
 
-smtCheckUnsat :: Context -> IO Bool
-smtCheckUnsat me  = respSat <$> command me CheckSat
+smtCheckUnsat :: SmtM Bool
+smtCheckUnsat = respSat <$> command CheckSat
 
-smtBracketAt :: SrcSpan -> Context -> String -> IO a -> IO a
-smtBracketAt sp x y z = smtBracket x y z `catch` dieAt sp
+smtBracketAt :: SrcSpan -> String -> SmtM a -> SmtM a
+smtBracketAt sp _msg a =
+  smtBracket _msg a `catchSMT` dieAt sp
 
-smtBracket :: Context -> String -> IO a -> IO a
-smtBracket me _msg a   = do
-  smtPush me
+smtBracket :: String -> SmtM a -> SmtM a
+smtBracket _msg a = do
+  smtPush
   r <- a
-  smtPop me
+  smtPop
   return r
 
 respSat :: Response -> Bool
@@ -447,8 +462,8 @@ respSat Sat     = False
 respSat Unknown = False
 respSat r       = die $ err dummySpan $ text ("crash: SMTLIB2 respSat = " ++ show r)
 
-interact' :: Context -> Command -> IO ()
-interact' me cmd  = void $ command me cmd
+interact' :: Command -> SmtM ()
+interact' cmd  = void $ command cmd
 
 
 makeTimeout :: Config -> [Builder]
@@ -464,29 +479,29 @@ makeMbqi cfg
 
 
 --------------------------------------------------------------------------------
-declare :: Context -> IO ()
+declare :: SmtM ()
 --------------------------------------------------------------------------------
-declare me = do
-  forM_ dss    $           smtDataDecl me
-  forM_ thyXTs $ uncurry $ smtDecl     me
-  forM_ qryXTs $ uncurry $ smtDecl     me
-  forM_ ats    $ uncurry $ smtFuncDecl me
-  forM_ defs   $           smtDefineEqn me
-  forM_ ess    $           smtDistinct me
-  forM_ axs    $           smtAssert   me
-  where
-    env        = ctxSymEnv me
-    dss        = dataDeclarations          env
-    lts        = F.toListSEnv . F.seLits $ env
-    ess        = distinctLiterals  lts
-    axs        = Thy.axiomLiterals lts
-    thyXTs     =             [ (x, t) | (x, t) <- xts, symKind env x == Just F.Uninterp ]
-    qryXTs     = fmap tx <$> [ (x, t) | (x, t) <- xts, symKind env x == Nothing ]
-    -- isKind n   = (n ==)  . symKind env . fst
-    xts        = symbolSorts (F.seSort env)
-    tx         = elaborate (ElabParam (ctxElabF me) "declare" env)
-    ats        = funcSortVars env
-    MkDefinedFuns defs = ctxDefines me
+declare = do
+  me <- ask
+  let env        = ctxSymEnv me
+  let xts        = symbolSorts (F.seSort env)
+  let tx         = elaborate (ElabParam (ctxElabF me) "declare" env)
+  let lts        = F.toListSEnv . F.seLits $ env
+  let dss        = dataDeclarations          env
+  let thyXTs     =             [ (x, t) | (x, t) <- xts, symKind env x == Just F.Uninterp ]
+  let qryXTs     = fmap tx <$> [ (x, t) | (x, t) <- xts, symKind env x == Nothing ]
+  let -- isKind n   = (n ==)  . symKind env . fst
+  let ats        = funcSortVars env
+  let MkDefinedFuns defs = ctxDefines me
+  let ess        = distinctLiterals  lts
+  let axs        = Thy.axiomLiterals lts
+  forM_ dss    $           smtDataDecl
+  forM_ thyXTs $ uncurry $ smtDecl
+  forM_ qryXTs $ uncurry $ smtDecl
+  forM_ ats    $ uncurry $ smtFuncDecl
+  forM_ defs   $           smtDefineEqn
+  forM_ ess    $           smtDistinct
+  forM_ axs    $           smtAssert
 
 symbolSorts :: F.SEnv F.Sort -> [(F.Symbol, F.Sort)]
 symbolSorts env = [(x, tx t) | (x, t) <- F.toListSEnv env ]
@@ -503,7 +518,7 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
                  ++ [(var lambdaName t       , lamSort t) | t <- ts]
                  ++ [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ]
   where
-    var n t       = evalState (F.symbolAtSmtName n () t) env
+    var n t       = runReader (F.symbolAtSmtName n () t) env
     ts            = M.keys (F.seAppls env)
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -73,7 +73,8 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
-import           Control.Monad.Reader
+-- import           Control.Monad.Reader
+import           Control.Monad.State
 import           Control.Exception
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BS
@@ -129,7 +130,7 @@ checkValidWithContext xts p q =
 checkValid :: Config -> FilePath -> [(Symbol, Sort)] -> Expr -> Expr -> IO Bool
 checkValid cfg f xts p q = do
   me <- makeContext cfg f
-  runReaderT (checkValid' xts p q) me
+  evalStateT (checkValid' xts p q) me
 
 checkValid' :: [(Symbol, Sort)] -> Expr -> Expr -> SmtM Bool
 checkValid' xts p q = do
@@ -144,7 +145,7 @@ checkValid' xts p q = do
 checkValids :: Config -> FilePath -> [(Symbol, Sort)] -> [Expr] -> IO [Bool]
 checkValids cfg f xts ps = do
   me <- makeContext cfg f
-  runReaderT (checkValids' xts ps) me
+  evalStateT (checkValids' xts ps) me
 
 checkValids' :: [(Symbol, Sort)] -> [Expr] -> SmtM [Bool]
 checkValids' xts ps = do
@@ -183,9 +184,9 @@ command              :: Command -> SmtM Response
 command !cmd       = do
   -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
   --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
-  ctxLog <- asks ctxLog
-  ctxSolver <- asks ctxSolver
-  ctxVerbose <- asks ctxVerbose
+  ctxLog <- gets ctxLog
+  ctxSolver <- gets ctxSolver
+  ctxVerbose <- gets ctxVerbose
   cmdBS <- hoistSMT $ runSmt2 cmd
   forM_ ctxLog $ \h -> lift $ do
     BS.hPutBuilder h cmdBS
@@ -270,7 +271,7 @@ makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do
   ctx     <- makeContext cfg f
   let ctx' = ctx {ctxSymEnv = env, ctxDefines = defns}
-  runReaderT declare ctx'
+  _ <- runStateT declare ctx'
   return ctx'
 
 makeContextNoLog :: Config -> IO Context
@@ -380,7 +381,7 @@ noString smt v cfg
 -- | SMT Commands -----------------------------------------------------------
 -----------------------------------------------------------------------------
 
-smtPush, smtPop   :: SmtM ()
+smtPush, smtPop :: SmtM ()
 smtPush = interact' Push
 smtPop  = interact' Pop
 
@@ -389,7 +390,7 @@ smtDecls = mapM_ $ uncurry smtDecl
 
 smtDecl :: Symbol -> Sort -> SmtM ()
 smtDecl x t = do
-  me <- ask
+  me <- get
   let env = seData (ctxSymEnv me)
   let ins' = sortSmtSort False env <$> ins
   let out' = sortSmtSort False env     out
@@ -425,7 +426,7 @@ smtDefineEqn Equ {..} = smtDefineFunc eqName eqArgs eqSort eqBody
 
 smtDefineFunc :: Symbol -> [(Symbol, F.Sort)] -> F.Sort -> Expr -> SmtM ()
 smtDefineFunc name symList rsort e =
-  do me <- ask
+  do me <- get
      let env = seData (ctxSymEnv me)
      interact' $
            DefineFunc
@@ -482,7 +483,7 @@ makeMbqi cfg
 declare :: SmtM ()
 --------------------------------------------------------------------------------
 declare = do
-  me <- ask
+  me <- get
   let env        = ctxSymEnv me
   let xts        = symbolSorts (F.seSort env)
   let tx         = elaborate (ElabParam (ctxElabF me) "declare" env)
@@ -518,7 +519,7 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
                  ++ [(var lambdaName t       , lamSort t) | t <- ts]
                  ++ [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ]
   where
-    var n t       = runReader (F.symbolAtSmtName n () t) env
+    var n t       = evalState (F.symbolAtSmtName n () t) env
     ts            = M.keys (F.seAppls env)
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -206,7 +206,7 @@ command !cmd       = do
   lift $ case cmd of
     CheckSat   -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
     GetValue _ -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
-    _          -> (SMTLIB.Backends.command_ ctxSolver cmdBS) >> return Ok
+    _          -> SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
 
 
 smtSetMbqi :: SmtM ()
@@ -495,7 +495,7 @@ interactDecl' cmd  = do
   ctx <- get
   let env = ctxSymEnv ctx
   let ats = funcSortVars (ctxLams ctx) env
-  forM_ ats $ uncurry $ smtFuncDecl
+  forM_ ats $ uncurry smtFuncDecl
   put (ctx {ctxSymEnv = env {seAppls = mergeTopAppls (seApplsCur env) (seAppls env), seApplsCur = M.empty} })
   void $ commandB cmdBS
 

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -38,9 +38,6 @@ module Language.Fixpoint.Smt.Interface (
 
     -- * Execute Queries
     , command
-
-    , command'
-
     , smtSetMbqi
 
     -- * Query API
@@ -48,17 +45,12 @@ module Language.Fixpoint.Smt.Interface (
     , smtDecls
     , smtDefineFunc
     , smtAssert
-
     , smtAssertDecl
-
     , smtFuncDecl
     , smtAssertAxiom
     , smtCheckUnsat
     , smtCheckSat
     , smtBracket, smtBracketAt
-
---    , smtBracketDecl
-
     , smtDistinct
     , smtPush, smtPop
 
@@ -79,12 +71,11 @@ import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
 import           Language.Fixpoint.Types         hiding (allowHO)
 import qualified Language.Fixpoint.Types         as F
-import Language.Fixpoint.Smt.Types
+import           Language.Fixpoint.Smt.Types
 import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Smt.Serialize ()
 import           Control.Applicative      ((<|>))
 import           Control.Monad
--- import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Exception
 import           Data.ByteString.Builder (Builder)
@@ -95,7 +86,6 @@ import           Data.Char
 import qualified Data.HashMap.Strict      as M
 import           Data.List                (uncons)
 import           Data.Maybe              (fromMaybe)
---import           Data.Functor.Identity   -- TODO remove
 import qualified Data.Text                as T
 import qualified Data.Text.Encoding       as TE
 import qualified Data.Text.IO
@@ -117,7 +107,6 @@ import qualified SMTLIB.Backends
 import qualified SMTLIB.Backends.Process as Process
 import qualified Language.Fixpoint.Conditional.Z3 as Conditional.Z3
 import Control.Concurrent.Async (async)
--- import Debug.Trace
 
 {-
 runFile f
@@ -190,25 +179,19 @@ commandRaw ctxLog ctxSolver ctxVerbose cmdBS = do
         Data.Text.IO.putStrLn textResponse
       return r
 
-command'              :: Builder -> SmtM Response
+commandB :: Builder -> SmtM Response
 --------------------------------------------------------------------------------
-command' cmdBS       = do
-  -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
-  --               LTIO.putStrLn ("CMD-RAW:" <> s <> ":CMD-RAW:DONE")
+commandB cmdBS       = do
   ctxLog <- gets ctxLog
   ctxSolver <- gets ctxSolver
-  -- ctxVerbose <- gets ctxVerbose
-  -- ctx <- gets ctxSymEnv
-  let cmdBS' = -- trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx))
-               cmdBS
   forM_ ctxLog $ \h -> lift $ do
-    BS.hPutBuilder h cmdBS'
+    BS.hPutBuilder h cmdBS
     LBS.hPutStr h "\n"
-  lift $ (SMTLIB.Backends.command_ ctxSolver cmdBS) >> return Ok
+  lift $ SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
 
 --------------------------------------------------------------------------------
 {-# SCC command #-}
-command              :: Command -> SmtM Response
+command  :: Command -> SmtM Response
 --------------------------------------------------------------------------------
 command !cmd       = do
   -- whenLoud $ do LTIO.appendFile debugFile (s <> "\n")
@@ -217,19 +200,13 @@ command !cmd       = do
   ctxSolver <- gets ctxSolver
   ctxVerbose <- gets ctxVerbose
   cmdBS <- liftSym $ runSmt2 cmd
-  -- ctx <- gets ctxSymEnv
-  let cmdBS' = -- trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx))
-               cmdBS
   forM_ ctxLog $ \h -> lift $ do
-    BS.hPutBuilder h cmdBS'
+    BS.hPutBuilder h cmdBS
     LBS.hPutStr h "\n"
   lift $ case cmd of
     CheckSat   -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
     GetValue _ -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
     _          -> (SMTLIB.Backends.command_ ctxSolver cmdBS) >> return Ok
---  where
---    cmdBS :: Builder
---    cmdBS = {-# SCC "Command-runSmt2" #-} evalState (runSmt2 cmd) ctxSymEnv
 
 
 smtSetMbqi :: SmtM ()
@@ -493,9 +470,7 @@ smtBracket _msg a = do
     let env = ctxSymEnv ctx in
     ctx { ctxSymEnv = env { seAppls = pushAppls (seAppls env) }
         , ctxIxs = seIx env : ctxIxs ctx}
---  hoistSMT $ modify $ \env -> env { seAppls = pushAppls (seAppls env) }
-  r <- -- trace ("BRACKET " ++ _msg)
-       a
+  r <- a
   smtPop
   modify $ \ctx ->
     let env = ctxSymEnv ctx
@@ -503,22 +478,7 @@ smtBracket _msg a = do
       in
     ctx { ctxSymEnv = env {seAppls = popAppls (seAppls env) , seIx = i}
         , ctxIxs = is}
---  hoistSMT $ modify $ \env -> env { seAppls = popAppls (seAppls env) }
   return r
-
-{-
-smtBracketDecl :: String -> SmtM a -> SmtM a
-smtBracketDecl _msg a = do
-  smtPush
-  ctx <- get
-  let env = ctxSymEnv ctx
-  let ats = funcSortVars env
-  forM_ ats $ uncurry $ smtFuncDecl
-  put (ctx {ctxSymEnv = env {seAppls = seAppls env <> seApplsNew env, seApplsNew = M.empty} })
-  r <- trace ("BRACKETDECL " ++ _msg) a
-  smtPop
-  return r
--}
 
 respSat :: Response -> Bool
 respSat Unsat   = True
@@ -533,12 +493,11 @@ interactDecl' :: Command -> SmtM ()
 interactDecl' cmd  = do
   cmdBS <- liftSym $ runSmt2 cmd
   ctx <- get
-  let env = -- trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
-                  (ctxSymEnv ctx)
+  let env = ctxSymEnv ctx
   let ats = funcSortVars (ctxLams ctx) env
   forM_ ats $ uncurry $ smtFuncDecl
   put (ctx {ctxSymEnv = env {seAppls = mergeTopAppls (seApplsCur env) (seAppls env), seApplsCur = M.empty} })
-  void $ command' cmdBS
+  void $ commandB cmdBS
 
 makeTimeout :: Config -> [Builder]
 makeTimeout cfg
@@ -564,18 +523,16 @@ declare = do
   let dss        = dataDeclarations          env
   let thyXTs     =             [ (x, t) | (x, t) <- xts, symKind env x == Just F.Uninterp ]
   let qryXTs     = fmap tx <$> [ (x, t) | (x, t) <- xts, symKind env x == Nothing ]
-  let -- isKind n   = (n ==)  . symKind env . fst
---  let ats        = funcSortVars env
+  -- let isKind n   = (n ==)  . symKind env . fst
   let MkDefinedFuns defs = ctxDefines me
   let ess        = distinctLiterals  lts
   let axs        = Thy.axiomLiterals lts
-  forM_ dss    $           smtDataDecl
-  forM_ thyXTs $ uncurry $ smtDecl
-  forM_ qryXTs $ uncurry $ smtDecl
---  forM_ ats    $ uncurry $ smtFuncDecl
-  forM_ defs   $           smtDefineEqn
-  forM_ ess    $           smtDistinct
-  forM_ axs    $           smtAssert
+  forM_ dss              smtDataDecl
+  forM_ thyXTs $ uncurry smtDecl
+  forM_ qryXTs $ uncurry smtDecl
+  forM_ defs             smtDefineEqn
+  forM_ ess              smtDistinct
+  forM_ axs              smtAssert
 
 symbolSorts :: F.SEnv F.Sort -> [(F.Symbol, F.Sort)]
 symbolSorts env = [(x, tx t) | (x, t) <- F.toListSEnv env ]
@@ -594,7 +551,7 @@ funcSortVars lams env =
   ++ if lams then [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ] else []
   where
     var :: F.Symbol -> F.FuncSort -> T.Text
-    var n t       = evalState (F.symbolAtSmtName n () t) env
+    var n t       = evalState (F.symbolAtSmtName n t) env
     ts            = M.keys $ F.seApplsCur env
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -553,13 +553,19 @@ dataDeclarations = orderDeclarations . map snd . F.toListSEnv . F.seData
 
 funcSortVars :: Bool -> F.SymEnv -> [(T.Text, ([F.SmtSort], F.SmtSort))]
 funcSortVars lams env =
+  -- TODO It would probably be even faster (if slightly) to convert `seApplsCur`
+  -- to a key-value list and iterate over it, at least this way we can get rid of
+  -- the unreachable `error` below.
                   [(var applyName  t       , appSort t) | t <- ts]
   ++              [(var coerceName t       , ([t1],t2)) | t@(t1, t2) <- ts]
   ++              [(var lambdaName t       , lamSort t) | t <- ts]
   ++ if lams then [(var (lamArgSymbol i) t , argSort t) | t@(_,F.SInt) <- ts, i <- [1..Thy.maxLamArg] ] else []
   where
     var :: F.Symbol -> F.FuncSort -> T.Text
-    var n t       = evalState (F.symbolAtSmtName n t) env
+    var n t       =
+      case M.lookup t (F.seApplsCur env) of
+        Just i  -> symbolAtSortIndex n i
+        Nothing -> error "funcSortVars: no index for sort in seApplsCur"
     ts            = M.keys $ F.seApplsCur env
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -179,16 +179,6 @@ commandRaw ctxLog ctxSolver ctxVerbose cmdBS = do
         Data.Text.IO.putStrLn textResponse
       return r
 
-commandB :: Builder -> SmtM Response
---------------------------------------------------------------------------------
-commandB cmdBS       = do
-  ctxLog <- gets ctxLog
-  ctxSolver <- gets ctxSolver
-  forM_ ctxLog $ \h -> lift $ do
-    BS.hPutBuilder h cmdBS
-    LBS.hPutStr h "\n"
-  lift $ SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
-
 --------------------------------------------------------------------------------
 {-# SCC command #-}
 command  :: Command -> SmtM Response
@@ -208,6 +198,16 @@ command !cmd       = do
     GetValue _ -> commandRaw ctxLog ctxSolver ctxVerbose cmdBS
     _          -> SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
 
+-- | A variant of `command` that accepts a pre-built command
+commandB :: Builder -> SmtM Response
+--------------------------------------------------------------------------------
+commandB cmdBS       = do
+  ctxLog <- gets ctxLog
+  ctxSolver <- gets ctxSolver
+  forM_ ctxLog $ \h -> lift $ do
+    BS.hPutBuilder h cmdBS
+    LBS.hPutStr h "\n"
+  lift $ SMTLIB.Backends.command_ ctxSolver cmdBS >> return Ok
 
 smtSetMbqi :: SmtM ()
 smtSetMbqi = interact' SetMbqi
@@ -278,9 +278,9 @@ makeContext cfg f
 
 makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do
-  ctx     <- makeContext cfg f
+  ctx      <- makeContext cfg f
   let ctx' = ctx {ctxSymEnv = env, ctxDefines = defns}
-  (_, ctx'') <- runStateT declare ctx'
+  ctx''    <- execStateT declare ctx'
   return ctx''
 
 makeContextNoLog :: Config -> IO Context
@@ -340,6 +340,9 @@ makeContext' cfg ctxLog
                   , ctxSymEnv    = mempty
                   , ctxIxs       = []
                   , ctxDefines   = mempty
+                  -- This is a heurstic to avoid generating large sequences of unused `lam_arg` symbols
+                  -- when there's no higher-order reasoning. It might require some tuning on larger codebases
+                  -- if `unknown function/constant lam_arg$XXX` errors are encountered.
                   , ctxLams      = allowHO cfg
                   }
 
@@ -432,6 +435,8 @@ smtCheckSat p
 smtAssert :: Expr -> SmtM ()
 smtAssert p = interact' (Assert Nothing p)
 
+-- the following three functions will emit additional `apply`,
+-- `coerce`, and `lambda` symbols for fresh function sorts as needed
 smtAssertDecl :: Expr -> SmtM ()
 smtAssertDecl p = interactDecl' (Assert Nothing p)
 
@@ -463,6 +468,8 @@ smtBracketAt :: SrcSpan -> String -> SmtM a -> SmtM a
 smtBracketAt sp _msg a =
   smtBracket _msg a `catchSMT` dieAt sp
 
+-- | `smtBracket` adds a new level to the apply stack and saves the last fresh index
+--   on the index stack before the action, and reverts these changes after the action.
 smtBracket :: String -> SmtM a -> SmtM a
 smtBracket _msg a = do
   smtPush
@@ -489,6 +496,8 @@ respSat r       = die $ err dummySpan $ text ("crash: SMTLIB2 respSat = " ++ sho
 interact' :: Command -> SmtM ()
 interact' cmd  = void $ command cmd
 
+-- | a variant of `interact'` which also emits fresh
+--   `apply`, `coerce`, and `lambda` symbols
 interactDecl' :: Command -> SmtM ()
 interactDecl' cmd  = do
   cmdBS <- liftSym $ runSmt2 cmd

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -117,7 +117,7 @@ import qualified SMTLIB.Backends
 import qualified SMTLIB.Backends.Process as Process
 import qualified Language.Fixpoint.Conditional.Z3 as Conditional.Z3
 import Control.Concurrent.Async (async)
-import Debug.Trace
+-- import Debug.Trace
 
 {-
 runFile f
@@ -198,8 +198,9 @@ command' cmdBS       = do
   ctxLog <- gets ctxLog
   ctxSolver <- gets ctxSolver
   -- ctxVerbose <- gets ctxVerbose
-  ctx <- gets ctxSymEnv
-  let cmdBS' = trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx)) cmdBS
+  -- ctx <- gets ctxSymEnv
+  let cmdBS' = -- trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx))
+               cmdBS
   forM_ ctxLog $ \h -> lift $ do
     BS.hPutBuilder h cmdBS'
     LBS.hPutStr h "\n"
@@ -216,8 +217,9 @@ command !cmd       = do
   ctxSolver <- gets ctxSolver
   ctxVerbose <- gets ctxVerbose
   cmdBS <- liftSym $ runSmt2 cmd
-  ctx <- gets ctxSymEnv
-  let cmdBS' = trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx)) cmdBS
+  -- ctx <- gets ctxSymEnv
+  let cmdBS' = -- trace ("command " ++ show (seAppls ctx) ++ " / " ++ show (seIx ctx))
+               cmdBS
   forM_ ctxLog $ \h -> lift $ do
     BS.hPutBuilder h cmdBS'
     LBS.hPutStr h "\n"
@@ -425,7 +427,7 @@ smtDecl x t = do
   let env = seData (ctxSymEnv me)
   let ins' = sortSmtSort False env <$> ins
   let out' = sortSmtSort False env     out
-  interact' (tracepp _msg $ Declare (symbolSafeText x) ins' out')
+  interact' (notracepp _msg $ Declare (symbolSafeText x) ins' out')
   where
     (ins, out) = deconSort t
     _msg       = "smtDecl: " ++ showpp (x, t, ins, out)
@@ -491,7 +493,8 @@ smtBracket _msg a = do
     ctx { ctxSymEnv = env { seAppls = pushAppls (seAppls env) }
         , ctxIxs = seIx env : ctxIxs ctx}
 --  hoistSMT $ modify $ \env -> env { seAppls = pushAppls (seAppls env) }
-  r <- trace ("BRACKET " ++ _msg) a
+  r <- -- trace ("BRACKET " ++ _msg)
+       a
   smtPop
   modify $ \ctx ->
     let env = ctxSymEnv ctx
@@ -529,7 +532,7 @@ interactDecl' :: Command -> SmtM ()
 interactDecl' cmd  = do
   cmdBS <- liftSym $ runSmt2 cmd
   ctx <- get
-  let env = trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
+  let env = -- trace ("interactDecl' [ " ++ show cmd ++ " ] " ++ show (seAppls $ ctxSymEnv ctx) ++ "; " ++ show (seApplsCur $ ctxSymEnv ctx))
                   (ctxSymEnv ctx)
   let ats = funcSortVars env
   forM_ ats $ uncurry $ smtFuncDecl
@@ -590,7 +593,8 @@ funcSortVars env  = [(var applyName  t       , appSort t) | t <- ts]
   where
     var n t       =
         let vr = evalState (F.symbolAtSmtName n () t) env
-        in trace ("var " ++ show vr) vr
+        in -- trace ("var " ++ show vr)
+           vr
     ts            = M.keys $ F.seApplsCur env
     appSort (s,t) = ([F.SInt, s], t)
     lamSort (s,t) = ([s, t], F.SInt)

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -169,6 +169,9 @@ instance SMTLIB2 Expr where
                              s1 <- smt2 e1
                              s2 <- smt2 e2
                              pure $ parenSeqs [so, s1, s2]
+  smt2 (ELet x e1 e2)   = do s1 <- smt2 (x, e1)
+                             s2 <- smt2 e2
+                             pure $ parenSeqs ["let", parens s1, s2]
   smt2 (EIte e1 e2 e3)  = do s1 <- smt2 e1
                              s2 <- smt2 e2
                              s3 <- smt2 e3

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -15,7 +15,7 @@
 
 module Language.Fixpoint.Smt.Serialize (smt2SortMono) where
 
-import           Control.Monad.State
+import           Control.Monad.Reader
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Types
@@ -46,33 +46,33 @@ instance SMTLIB2 (Symbol, Expr) where
 
 smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder
 -}
-smt2SortMono, smt2SortPoly :: (PPrint a) => a -> Sort -> State SymEnv Builder
+smt2SortMono, smt2SortPoly :: (PPrint a) => a -> Sort -> SymM Builder
 smt2SortMono = smt2Sort False
 smt2SortPoly = smt2Sort True
 
-smt2Sort :: (PPrint a) => Bool -> a -> Sort -> State SymEnv Builder
+smt2Sort :: (PPrint a) => Bool -> a -> Sort -> SymM Builder
 smt2Sort poly _ t =
-  do env <- get
+  do env <- ask
      smt2 (Thy.sortSmtSort poly (seData env) t)
 
-smt2data :: [DataDecl] -> State SymEnv Builder
+smt2data :: [DataDecl] -> SymM Builder
 smt2data = smt2data' . map padDataDecl
 
-smt2data' :: [DataDecl] -> State SymEnv Builder
+smt2data' :: [DataDecl] -> SymM Builder
 smt2data' ds =
   do n <- traverse smt2dataname ds
      d <- traverse smt2datactors ds
      pure $ seqs [ parens $ smt2many n , parens $ smt2many d ]
 
 
-smt2dataname :: DataDecl -> State SymEnv Builder
+smt2dataname :: DataDecl -> SymM Builder
 smt2dataname (DDecl tc as _) =
   do name <- smt2 (symbol tc)
      n    <- smt2 as
      pure $ parenSeqs [name, n]
 
 
-smt2datactors :: DataDecl -> State SymEnv Builder
+smt2datactors :: DataDecl -> SymM Builder
 smt2datactors (DDecl _ as cs) =
   do ds <- traverse (smt2ctor as) cs
      if as > 0
@@ -82,13 +82,13 @@ smt2datactors (DDecl _ as cs) =
   where
     smt2TV = smt2 . SVar
 
-smt2ctor :: Int -> DataCtor -> State SymEnv Builder
+smt2ctor :: Int -> DataCtor -> SymM Builder
 smt2ctor as (DCtor c fs) =
   do h <- smt2 c
      t <- traverse (smt2field as) fs
      pure $ parenSeqs (h : t)
 
-smt2field :: Int -> DataField -> State SymEnv Builder
+smt2field :: Int -> DataField -> SymM Builder
 smt2field as d@(DField x t) =
   do s <- smt2 x
      ss <- smt2SortPoly d $ mkPoly as t
@@ -120,7 +120,7 @@ declUsedVars = sortNub . Vis.foldDataDecl go []
     go is _        = is
 
 instance SMTLIB2 Symbol where
-  smt2 s = do env <- get
+  smt2 s = do env <- ask
               case Thy.smt2Symbol env s of
                 Just t  -> pure t
                 Nothing -> pure $ symbolBuilder s
@@ -139,7 +139,6 @@ instance SMTLIB2 Constant where
   smt2 (L t _) = pure $ fromText t
 
 instance SMTLIB2 Bop where
-  smt2 :: Bop -> State SymEnv Builder
   smt2 Plus   = pure "+"
   smt2 Minus  = pure "-"
   smt2 Times  = pure $ symbolBuilder mulFuncName
@@ -209,30 +208,30 @@ instance SMTLIB2 Expr where
 -- | smt2Cast uses the 'as x T' pattern needed for polymorphic ADT constructors
 --   like Nil, see `tests/pos/adt_list_1.fq`
 
-smt2Cast :: Expr -> Sort -> State SymEnv Builder
+smt2Cast :: Expr -> Sort -> SymM Builder
 smt2Cast (EVar x) t = smt2Var x t
 smt2Cast e        _ = smt2    e
 
-smt2Var :: Symbol -> Sort -> State SymEnv Builder
+smt2Var :: Symbol -> Sort -> SymM Builder
 smt2Var x t
   | isLamArgSymbol x = smtLamArg x t
-  | otherwise        = do env <- get
+  | otherwise        = do env <- ask
                           case symEnvSort x env of
                             Just s | isPolyInst s t -> smt2VarAs x t
                             _                       -> smt2 x
 
-smtLamArg :: Symbol -> Sort -> State SymEnv Builder
+smtLamArg :: Symbol -> Sort -> SymM Builder
 smtLamArg x t =
   do s <- symbolAtName x () (FFunc t FInt)
      pure $ Builder.fromText s
 
-smt2VarAs :: Symbol -> Sort -> State SymEnv Builder
+smt2VarAs :: Symbol -> Sort -> SymM Builder
 smt2VarAs x t =
   do s <- smt2 x
      s1 <- smt2SortMono x t
      pure $ parenSeqs ["as", s, s1]
 
-smt2Lam :: (Symbol, Sort) -> Expr -> State SymEnv Builder
+smt2Lam :: (Symbol, Sort) -> Expr -> SymM Builder
 smt2Lam (x, xT) full@(ECst _ eT) =
   do x' <- smtLamArg x xT
      lambda <- symbolAtName lambdaName () (FFunc xT eT)
@@ -241,7 +240,7 @@ smt2Lam (x, xT) full@(ECst _ eT) =
 smt2Lam _ e
   = panic ("smtlib2: Cannot serialize unsorted lambda: " ++ showpp e)
 
-smt2App :: Expr -> State SymEnv Builder
+smt2App :: Expr -> SymM Builder
 smt2App e@(EApp (EApp f e1) e2)
   | Just t <- unApplyAt f
   = do a <- symbolAtName applyName e t
@@ -257,7 +256,7 @@ smt2App e = do s0 <- traverse smt2 es
   where
     (f, es) = splitEApp' e
 
-smt2Coerc :: Sort -> Sort -> Expr -> State SymEnv Builder
+smt2Coerc :: Sort -> Sort -> Expr -> SymM Builder
 smt2Coerc t1 t2 e
   | t1 == t2  = smt2 e
   | otherwise = do coerceFn <- symbolAtName coerceName (ECoerc t1 t2 e) (FFunc t1 t2)
@@ -271,7 +270,7 @@ splitEApp'            = go []
   --   go acc (ECst e _) = go acc e
     go acc e          = (e, acc)
 
-mkRel :: Brel -> Expr -> Expr -> State SymEnv Builder
+mkRel :: Brel -> Expr -> Expr -> SymM Builder
 mkRel Ne  e1 e2 = mkNe e1 e2
 mkRel Une e1 e2 = mkNe e1 e2
 mkRel r   e1 e2 = do s <- smt2 r
@@ -279,7 +278,7 @@ mkRel r   e1 e2 = do s <- smt2 r
                      s2 <- smt2 e2
                      pure $ parenSeqs [s, s1, s2]
 
-mkNe :: Expr -> Expr -> State SymEnv Builder
+mkNe :: Expr -> Expr -> SymM Builder
 mkNe e1 e2 = do s1 <- smt2 e1
                 s2 <- smt2 e2
                 pure $ key "not" (parenSeqs ["=", s1, s2])
@@ -341,7 +340,7 @@ instance SMTLIB2 (Triggered Expr) where
   smt2 (TR _ e)               = smt2 e
 
 {-# INLINE smtTr #-}
-smtTr :: Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> State SymEnv Builder
+smtTr :: Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> SymM Builder
 smtTr q xs p t =
   do s <- smt2s xs
      s1 <- smt2 p
@@ -349,7 +348,7 @@ smtTr q xs p t =
      pure $ key q (parens s <+> key "!" (s1 <+> ":pattern" <> parens s2))
 
 {-# INLINE smt2s #-}
-smt2s :: SMTLIB2 a => [a] -> State SymEnv Builder
+smt2s :: SMTLIB2 a => [a] -> SymM Builder
 smt2s as = smt2many <$> traverse smt2 as
 
 {-# INLINE smt2many #-}

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -15,7 +15,6 @@
 
 module Language.Fixpoint.Smt.Serialize (smt2SortMono) where
 
---import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.SortCheck
@@ -27,7 +26,6 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 -- import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)
 import           Language.Fixpoint.Utils.Builder as Builder
--- import System.Process (CreateProcess())
 -- import Debug.Trace (trace)
 
 instance SMTLIB2 (Symbol, Sort) where
@@ -42,11 +40,7 @@ instance SMTLIB2 (Symbol, Expr) where
     do s <- smt2 sym
        ss <- smt2 e
        pure $ parenSeqs [s, ss]
-{-}
-  smt2 env (sym, e) =  parenSeqs [smt2 env sym, smt2 env e]
 
-smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder
--}
 smt2SortMono, smt2SortPoly :: (PPrint a) => a -> Sort -> SymM Builder
 smt2SortMono = smt2Sort False
 smt2SortPoly = smt2Sort True
@@ -223,7 +217,7 @@ smt2Var x t
 
 smtLamArg :: Symbol -> Sort -> SymM Builder
 smtLamArg x t =
-  do s <- symbolAtName x () (FFunc t FInt)
+  do s <- symbolAtName x (FFunc t FInt)
      pure $ Builder.fromText s
 
 smt2VarAs :: Symbol -> Sort -> SymM Builder
@@ -235,16 +229,16 @@ smt2VarAs x t =
 smt2Lam :: (Symbol, Sort) -> Expr -> SymM Builder
 smt2Lam (x, xT) full@(ECst _ eT) =
   do x' <- smtLamArg x xT
-     lambda <- symbolAtName lambdaName () (FFunc xT eT)
+     lambda <- symbolAtName lambdaName (FFunc xT eT)
      f <- smt2 full
      pure $ parenSeqs [Builder.fromText lambda, x', f]
 smt2Lam _ e
   = panic ("smtlib2: Cannot serialize unsorted lambda: " ++ showpp e)
 
 smt2App :: Expr -> SymM Builder
-smt2App e@(EApp (EApp f e1) e2)
+smt2App (EApp (EApp f e1) e2)
   | Just t <- unApplyAt f
-  = do a <- symbolAtName applyName e t
+  = do a <- symbolAtName applyName t
        s <- smt2s [e1, e2]
        pure $ parenSeqs [Builder.fromText a, s]
 smt2App e = do s0 <- traverse smt2 es
@@ -260,7 +254,7 @@ smt2App e = do s0 <- traverse smt2 es
 smt2Coerc :: Sort -> Sort -> Expr -> SymM Builder
 smt2Coerc t1 t2 e
   | t1 == t2  = smt2 e
-  | otherwise = do coerceFn <- symbolAtName coerceName (ECoerc t1 t2 e) (FFunc t1 t2)
+  | otherwise = do coerceFn <- symbolAtName coerceName (FFunc t1 t2)
                    s <- smt2 e
                    pure $ parenSeqs [Builder.fromText coerceFn , s]
 
@@ -299,17 +293,6 @@ instance SMTLIB2 Command where
        r <- smt2 rsort
        e' <- smt2 e
        pure $ parenSeqs ["define-fun", n, parenSeqs bParams, r, e']
-
-
-{-
-PAtom Eq
-      (ECst (EVar "y")
-            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt))
-      (ECst (EApp (ECst (EVar "acc") (FFunc (FApp (FApp (FTC (TC "Data" defined at: issue-738.smt2:1:12-1:16 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)
-                                            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)))
-                  (ECst (EVar "x")          (FApp (FApp (FTC (TC "Data" defined at: issue-738.smt2:4:15-4:19 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)))
-            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt))
--}
 
   smt2     (Assert Nothing p)  = {-# SCC "smt2-assert" #-}
                                   do s <- smt2 p

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -27,7 +27,7 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Misc (sortNub, errorstar)
 import           Language.Fixpoint.Utils.Builder as Builder
 -- import System.Process (CreateProcess())
-import Debug.Trace (trace)
+-- import Debug.Trace (trace)
 
 instance SMTLIB2 (Symbol, Sort) where
   smt2 c@(sym, t) =
@@ -295,8 +295,7 @@ instance SMTLIB2 Command where
                                           pure $ parenSeqs [s0 , s1]) paramxs
        r <- smt2 rsort
        e' <- smt2 e
-       let e'' = trace ("definefunc: " ++ show e) e'
-       pure $ parenSeqs ["define-fun", n, parenSeqs bParams, r, e'']
+       pure $ parenSeqs ["define-fun", n, parenSeqs bParams, r, e']
 
 
 {-

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -15,7 +15,8 @@
 
 module Language.Fixpoint.Smt.Serialize (smt2SortMono) where
 
-import           Control.Monad.Reader
+--import           Control.Monad.Reader
+import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Types
@@ -52,7 +53,7 @@ smt2SortPoly = smt2Sort True
 
 smt2Sort :: (PPrint a) => Bool -> a -> Sort -> SymM Builder
 smt2Sort poly _ t =
-  do env <- ask
+  do env <- get
      smt2 (Thy.sortSmtSort poly (seData env) t)
 
 smt2data :: [DataDecl] -> SymM Builder
@@ -120,7 +121,7 @@ declUsedVars = sortNub . Vis.foldDataDecl go []
     go is _        = is
 
 instance SMTLIB2 Symbol where
-  smt2 s = do env <- ask
+  smt2 s = do env <- get
               case Thy.smt2Symbol env s of
                 Just t  -> pure t
                 Nothing -> pure $ symbolBuilder s
@@ -215,7 +216,7 @@ smt2Cast e        _ = smt2    e
 smt2Var :: Symbol -> Sort -> SymM Builder
 smt2Var x t
   | isLamArgSymbol x = smtLamArg x t
-  | otherwise        = do env <- ask
+  | otherwise        = do env <- get
                           case symEnvSort x env of
                             Just s | isPolyInst s t -> smt2VarAs x t
                             _                       -> smt2 x

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -214,16 +214,19 @@ smt2Var x t
                             Just s | isPolyInst s t -> smt2VarAs x t
                             _                       -> smt2 x
 
-smtLamArg :: Symbol -> Sort -> SymM Builder
-smtLamArg x t =
-  do s <- symbolAtName x (FFunc t FInt)
-     pure $ Builder.fromText s
-
 smt2VarAs :: Symbol -> Sort -> SymM Builder
 smt2VarAs x t =
   do s <- smt2 x
      s1 <- smt2SortMono x t
      pure $ parenSeqs ["as", s, s1]
+
+-- the next four functions (ones containing a call to `symbolAtName`) can trigger
+-- an expansion of the "nursery" tag table ('seApplsCur' in 'SymEnv') when processing
+-- a fresh function sort
+smtLamArg :: Symbol -> Sort -> SymM Builder
+smtLamArg x t =
+  do s <- symbolAtName x (FFunc t FInt)
+     pure $ Builder.fromText s
 
 smt2Lam :: (Symbol, Sort) -> Expr -> SymM Builder
 smt2Lam (x, xT) full@(ECst _ eT) =

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DoAndIfThenElse      #-}
 
 {-# OPTIONS_GHC -Wno-orphans        #-}
+{-# LANGUAGE InstanceSigs #-}
 
 -- | This module contains the code for serializing Haskell values
 --   into SMTLIB2 format, that is, the instances for the @SMTLIB2@
@@ -14,6 +15,7 @@
 
 module Language.Fixpoint.Smt.Serialize (smt2SortMono) where
 
+import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.SortCheck
 import           Language.Fixpoint.Types
@@ -24,53 +26,73 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 -- import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)
 import           Language.Fixpoint.Utils.Builder as Builder
--- import Debug.Trace (trace)
+-- import System.Process (CreateProcess())
+import Debug.Trace (trace)
 
 instance SMTLIB2 (Symbol, Sort) where
-  smt2 env c@(sym, t) = -- build "({} {})" (smt2 env sym, smt2SortMono c env t)
-                        parenSeqs [smt2 env sym, smt2SortMono c env t]
+  smt2 c@(sym, t) =
+    -- build "({} {})" (smt2 env sym, smt2SortMono c env t)
+    do s <- smt2 sym
+       ss <- smt2SortMono c t
+       pure $ parenSeqs [s , ss]
 
 instance SMTLIB2 (Symbol, Expr) where
+  smt2 (sym, e) =
+    do s <- smt2 sym
+       ss <- smt2 e
+       pure $ parenSeqs [s, ss]
+{-}
   smt2 env (sym, e) =  parenSeqs [smt2 env sym, smt2 env e]
 
 smt2SortMono, smt2SortPoly :: (PPrint a) => a -> SymEnv -> Sort -> Builder
+-}
+smt2SortMono, smt2SortPoly :: (PPrint a) => a -> Sort -> State SymEnv Builder
 smt2SortMono = smt2Sort False
 smt2SortPoly = smt2Sort True
 
-smt2Sort :: (PPrint a) => Bool -> a -> SymEnv -> Sort -> Builder
-smt2Sort poly _ env t = smt2 env (Thy.sortSmtSort poly (seData env) t)
+smt2Sort :: (PPrint a) => Bool -> a -> Sort -> State SymEnv Builder
+smt2Sort poly _ t =
+  do env <- get
+     smt2 (Thy.sortSmtSort poly (seData env) t)
 
-smt2data :: SymEnv -> [DataDecl] -> Builder
-smt2data env = smt2data' env . map padDataDecl
+smt2data :: [DataDecl] -> State SymEnv Builder
+smt2data = smt2data' . map padDataDecl
 
-smt2data' :: SymEnv -> [DataDecl] -> Builder
-smt2data' env ds = seqs [ parens $ smt2many (smt2dataname env <$> ds)
-                        , parens $ smt2many (smt2datactors env <$> ds)
-                        ]
+smt2data' :: [DataDecl] -> State SymEnv Builder
+smt2data' ds =
+  do n <- traverse smt2dataname ds
+     d <- traverse smt2datactors ds
+     pure $ seqs [ parens $ smt2many n , parens $ smt2many d ]
 
 
-smt2dataname :: SymEnv -> DataDecl -> Builder
-smt2dataname env (DDecl tc as _) = parenSeqs [name, n]
+smt2dataname :: DataDecl -> State SymEnv Builder
+smt2dataname (DDecl tc as _) =
+  do name <- smt2 (symbol tc)
+     n    <- smt2 as
+     pure $ parenSeqs [name, n]
+
+
+smt2datactors :: DataDecl -> State SymEnv Builder
+smt2datactors (DDecl _ as cs) =
+  do ds <- traverse (smt2ctor as) cs
+     if as > 0
+      then do tvars <- traverse smt2TV [0..(as-1)]
+              pure $ parenSeqs ["par", parens (smt2many tvars), parens (smt2many ds)]
+      else pure $                                               parens (smt2many ds)
   where
-    name  = smt2 env (symbol tc)
-    n     = smt2 env as
+    smt2TV = smt2 . SVar
 
+smt2ctor :: Int -> DataCtor -> State SymEnv Builder
+smt2ctor as (DCtor c fs) =
+  do h <- smt2 c
+     t <- traverse (smt2field as) fs
+     pure $ parenSeqs (h : t)
 
-smt2datactors :: SymEnv -> DataDecl -> Builder
-smt2datactors env (DDecl _ as cs)
-  | as > 0       = parenSeqs ["par", parens tvars, parens ds]
-  | otherwise    =                                 parens ds
-  where
-    tvars        = smt2many (smt2TV <$> [0..(as-1)])
-    smt2TV       = smt2 env . SVar
-    ds           = smt2many (smt2ctor env as <$> cs)
-
-smt2ctor :: SymEnv -> Int -> DataCtor -> Builder
-
-smt2ctor env as (DCtor c fs)  = parenSeqs (smt2 env c : (smt2field env as <$> fs))
-
-smt2field :: SymEnv -> Int -> DataField -> Builder
-smt2field env as d@(DField x t) = parenSeqs [smt2 env x, smt2SortPoly d env $ mkPoly as t]
+smt2field :: Int -> DataField -> State SymEnv Builder
+smt2field as d@(DField x t) =
+  do s <- smt2 x
+     ss <- smt2SortPoly d $ mkPoly as t
+     pure $ parenSeqs [s , ss]
 
 -- | SMTLIB/Z3 don't like "unused" type variables; they get pruned away and
 --   cause wierd hassles. See tests/pos/adt_poly_dead.fq for an example.
@@ -98,121 +120,146 @@ declUsedVars = sortNub . Vis.foldDataDecl go []
     go is _        = is
 
 instance SMTLIB2 Symbol where
-  smt2 env s
-    | Just t <- Thy.smt2Symbol env s = t
-  smt2 _ s                           = symbolBuilder s
-
+  smt2 s = do env <- get
+              case Thy.smt2Symbol env s of
+                Just t  -> pure t
+                Nothing -> pure $ symbolBuilder s
 instance SMTLIB2 Int where
-  smt2 _ = Builder.fromString . show
+  smt2 i = pure $ Builder.fromString $ show i
 
 instance SMTLIB2 LocSymbol where
-  smt2 env = smt2 env . val
+  smt2 = smt2 . val
 
 instance SMTLIB2 SymConst where
-  smt2 env = smt2 env . symbol
+  smt2 = smt2 . symbol
 
 instance SMTLIB2 Constant where
-  smt2 _ (I n)   = bShow n
-  smt2 _ (R d)   = bFloat d
-  smt2 _ (L t _) = fromText t
+  smt2 (I n)   = pure $ bShow n
+  smt2 (R d)   = pure $ bFloat d
+  smt2 (L t _) = pure $ fromText t
 
 instance SMTLIB2 Bop where
-  smt2 _ Plus   = "+"
-  smt2 _ Minus  = "-"
-  smt2 _ Times  = symbolBuilder mulFuncName
-  smt2 _ Div    = symbolBuilder divFuncName
-  smt2 _ RTimes = "*"
-  smt2 _ RDiv   = "/"
-  smt2 _ Mod    = "mod"
+  smt2 :: Bop -> State SymEnv Builder
+  smt2 Plus   = pure "+"
+  smt2 Minus  = pure "-"
+  smt2 Times  = pure $ symbolBuilder mulFuncName
+  smt2 Div    = pure $ symbolBuilder divFuncName
+  smt2 RTimes = pure "*"
+  smt2 RDiv   = pure "/"
+  smt2 Mod    = pure "mod"
 
 instance SMTLIB2 Brel where
-  smt2 _ Eq    = "="
-  smt2 _ Ueq   = "="
-  smt2 _ Gt    = ">"
-  smt2 _ Ge    = ">="
-  smt2 _ Lt    = "<"
-  smt2 _ Le    = "<="
-  smt2 _ _     = errorstar "SMTLIB2 Brel"
+  smt2 Eq  = pure "="
+  smt2 Ueq = pure "="
+  smt2 Gt  = pure ">"
+  smt2 Ge  = pure ">="
+  smt2 Lt  = pure "<"
+  smt2 Le  = pure "<="
+  smt2 _   = errorstar "SMTLIB2 Brel"
 
 -- NV TODO: change the way EApp is printed
 instance SMTLIB2 Expr where
-  smt2 env (ESym z)         = smt2 env z
-  smt2 env (ECon c)         = smt2 env c
-  smt2 env (EVar x)         = smt2 env x
-  smt2 env e@(EApp _ _)     = smt2App env e
-  smt2 env (ENeg e)         = parenSeqs ["-", smt2 env e]
-  smt2 env (EBin o e1 e2)   = parenSeqs [smt2 env o, smt2 env e1, smt2 env e2]
-  smt2 env (ELet x e1 e2)   = parenSeqs ["let", parens (smt2 env (x, e1)), smt2 env e2]
-  smt2 env (EIte e1 e2 e3)  = parenSeqs ["ite", smt2 env e1, smt2 env e2, smt2 env e3]
-  smt2 env (ECst e t)       = smt2Cast env e t
-  smt2 _   PTrue            = "true"
-  smt2 _   PFalse           = "false"
-  smt2 _   (PAnd [])        = "true"
-  smt2 env (PAnd ps)        = parenSeqs ["and", smt2s env ps]
-  smt2 _   (POr [])         = "false"
-  smt2 env (POr ps)         = parenSeqs ["or", smt2s env ps]
-  smt2 env (PNot p)         = parenSeqs ["not", smt2 env p]
-  smt2 env (PImp p q)       = parenSeqs ["=>", smt2 env p, smt2 env q]
-  smt2 env (PIff p q)       = parenSeqs ["=", smt2 env p, smt2 env q]
-  smt2 env (PExist [] p)    = smt2 env p
-  smt2 env (PExist xs p)    = parenSeqs ["exists", parens (smt2s env xs), smt2 env p]
-  smt2 env (PAll   [] p)    = smt2 env p
-  smt2 env (PAll   xs p)    = parenSeqs ["forall", parens (smt2s env xs), smt2 env p]
-  smt2 env (PAtom r e1 e2)  = mkRel env r e1 e2
-  smt2 env (ELam b e)       = smt2Lam env b e
-  smt2 env (ECoerc t1 t2 e) = smt2Coerc env t1 t2 e
-  smt2 _   e                = panic ("smtlib2 Pred  " ++ show e)
-
-
+  smt2 (ESym z)         = smt2 z
+  smt2 (ECon c)         = smt2 c
+  smt2 (EVar x)         = smt2 x
+  smt2 e@(EApp _ _)     = smt2App e
+  smt2 (ENeg e)         = do s <- smt2 e
+                             pure $ parenSeqs ["-", s]
+  smt2 (EBin o e1 e2)   = do so <- smt2 o
+                             s1 <- smt2 e1
+                             s2 <- smt2 e2
+                             pure $ parenSeqs [so, s1, s2]
+  smt2 (EIte e1 e2 e3)  = do s1 <- smt2 e1
+                             s2 <- smt2 e2
+                             s3 <- smt2 e3
+                             pure $ parenSeqs ["ite", s1, s2, s3]
+  smt2 (ECst e t)       = smt2Cast e t
+  smt2 PTrue            = pure "true"
+  smt2 PFalse           = pure "false"
+  smt2 (PAnd [])        = pure "true"
+  smt2 (PAnd ps)        = do s <- smt2s ps
+                             pure $ parenSeqs ["and", s]
+  smt2 (POr [])         = pure "false"
+  smt2 (POr ps)         = do s <- smt2s ps
+                             pure $ parenSeqs ["or", s]
+  smt2 (PNot p)         = do s <- smt2 p
+                             pure $ parenSeqs ["not", s]
+  smt2 (PImp p q)       = do s1 <- smt2 p
+                             s2 <- smt2 q
+                             pure $ parenSeqs ["=>", s1, s2]
+  smt2 (PIff p q)       = do s1 <- smt2 p
+                             s2 <- smt2 q
+                             pure $ parenSeqs ["=", s1, s2]
+  smt2 (PExist [] p)    = smt2 p
+  smt2 (PExist xs p)    = do s <- smt2s xs
+                             s1 <- smt2 p
+                             pure $ parenSeqs ["exists", parens s, s1]
+  smt2 (PAll   [] p)    = smt2 p
+  smt2 (PAll   xs p)    = do s <- smt2s xs
+                             s1 <- smt2 p
+                             pure $ parenSeqs ["forall", parens s, s1]
+  smt2 (PAtom r e1 e2)  = mkRel r e1 e2
+  smt2 (ELam b e)       = smt2Lam b e
+  smt2 (ECoerc t1 t2 e) = smt2Coerc t1 t2 e
+  smt2 e                = panic ("smtlib2 Pred  " ++ show e)
 
 -- | smt2Cast uses the 'as x T' pattern needed for polymorphic ADT constructors
 --   like Nil, see `tests/pos/adt_list_1.fq`
 
-smt2Cast :: SymEnv -> Expr -> Sort -> Builder
-smt2Cast env (EVar x) t = smt2Var env x t
-smt2Cast env e        _ = smt2    env e
+smt2Cast :: Expr -> Sort -> State SymEnv Builder
+smt2Cast (EVar x) t = smt2Var x t
+smt2Cast e        _ = smt2    e
 
-smt2Var :: SymEnv -> Symbol -> Sort -> Builder
-smt2Var env x t
-  | isLamArgSymbol x            = smtLamArg env x t
-  | Just s <- symEnvSort x env
-  , isPolyInst s t              = smt2VarAs env x t
-  | otherwise                   = smt2 env x
+smt2Var :: Symbol -> Sort -> State SymEnv Builder
+smt2Var x t
+  | isLamArgSymbol x = smtLamArg x t
+  | otherwise        = do env <- get
+                          case symEnvSort x env of
+                            Just s | isPolyInst s t -> smt2VarAs x t
+                            _                       -> smt2 x
 
-smtLamArg :: SymEnv -> Symbol -> Sort -> Builder
-smtLamArg env x t = Builder.fromText $ symbolAtName x env () (FFunc t FInt)
+smtLamArg :: Symbol -> Sort -> State SymEnv Builder
+smtLamArg x t =
+  do s <- symbolAtName x () (FFunc t FInt)
+     pure $ Builder.fromText s
 
-smt2VarAs :: SymEnv -> Symbol -> Sort -> Builder
-smt2VarAs env x t = parenSeqs ["as", smt2 env x, smt2SortMono x env t]
+smt2VarAs :: Symbol -> Sort -> State SymEnv Builder
+smt2VarAs x t =
+  do s <- smt2 x
+     s1 <- smt2SortMono x t
+     pure $ parenSeqs ["as", s, s1]
 
-smt2Lam :: SymEnv -> (Symbol, Sort) -> Expr -> Builder
-smt2Lam env (x, xT) full@(ECst _ eT) = parenSeqs [Builder.fromText lambda, x', smt2 env full]
-  where
-    x'     = smtLamArg env x xT
-    lambda = symbolAtName lambdaName env () (FFunc xT eT)
-
-smt2Lam _ _ e
+smt2Lam :: (Symbol, Sort) -> Expr -> State SymEnv Builder
+smt2Lam (x, xT) full@(ECst _ eT) =
+  do x' <- smtLamArg x xT
+     lambda <- symbolAtName lambdaName () (FFunc xT eT)
+     f <- smt2 full
+     pure $ parenSeqs [Builder.fromText lambda, x', f]
+smt2Lam _ e
   = panic ("smtlib2: Cannot serialize unsorted lambda: " ++ showpp e)
 
-smt2App :: SymEnv -> Expr -> Builder
-smt2App env e@(EApp (EApp f e1) e2)
+smt2App :: Expr -> State SymEnv Builder
+smt2App e@(EApp (EApp f e1) e2)
   | Just t <- unApplyAt f
-  = parenSeqs [Builder.fromText (symbolAtName applyName env e t), smt2s env [e1, e2]]
-smt2App env e
-  | Just b <- Thy.smt2App smt2VarAs env f (smt2 env <$> es)
-  = b
-  | otherwise
-  = parenSeqs [smt2 env f, smt2s env es]
+  = do a <- symbolAtName applyName e t
+       s <- smt2s [e1, e2]
+       pure $ parenSeqs [Builder.fromText a, s]
+smt2App e = do s0 <- traverse smt2 es
+               s1 <- Thy.smt2App smt2VarAs f s0
+               case s1 of
+                 Just b -> pure b
+                 Nothing -> do s2 <- smt2 f
+                               s3 <- smt2s es
+                               pure $ parenSeqs [s2, s3]
   where
-    (f, es)   = splitEApp' e
+    (f, es) = splitEApp' e
 
-smt2Coerc :: SymEnv -> Sort -> Sort -> Expr -> Builder
-smt2Coerc env t1 t2 e
-  | t1 == t2  = smt2 env e
-  | otherwise = parenSeqs [Builder.fromText coerceFn , smt2 env e]
-  where
-    coerceFn  = symbolAtName coerceName env (ECoerc t1 t2 e) t
-    t         = FFunc t1 t2
+smt2Coerc :: Sort -> Sort -> Expr -> State SymEnv Builder
+smt2Coerc t1 t2 e
+  | t1 == t2  = smt2 e
+  | otherwise = do coerceFn <- symbolAtName coerceName (ECoerc t1 t2 e) (FFunc t1 t2)
+                   s <- smt2 e
+                   pure $ parenSeqs [Builder.fromText coerceFn , s]
 
 splitEApp' :: Expr -> (Expr, [Expr])
 splitEApp'            = go []
@@ -221,50 +268,87 @@ splitEApp'            = go []
   --   go acc (ECst e _) = go acc e
     go acc e          = (e, acc)
 
-mkRel :: SymEnv -> Brel -> Expr -> Expr -> Builder
-mkRel env Ne  e1 e2 = mkNe env e1 e2
-mkRel env Une e1 e2 = mkNe env e1 e2
-mkRel env r   e1 e2 = parenSeqs [smt2 env r, smt2 env e1, smt2 env e2]
+mkRel :: Brel -> Expr -> Expr -> State SymEnv Builder
+mkRel Ne  e1 e2 = mkNe e1 e2
+mkRel Une e1 e2 = mkNe e1 e2
+mkRel r   e1 e2 = do s <- smt2 r
+                     s1 <- smt2 e1
+                     s2 <- smt2 e2
+                     pure $ parenSeqs [s, s1, s2]
 
-mkNe :: SymEnv -> Expr -> Expr -> Builder
-mkNe env e1 e2      = key "not" (parenSeqs ["=",  smt2 env e1, smt2 env e2])
-
+mkNe :: Expr -> Expr -> State SymEnv Builder
+mkNe e1 e2 = do s1 <- smt2 e1
+                s2 <- smt2 e2
+                pure $ key "not" (parenSeqs ["=", s1, s2])
 instance SMTLIB2 Command where
-  smt2 env (DeclData ds)       = key "declare-datatypes" (smt2data env ds)
-  smt2 env (Declare x ts t)    = parenSeqs ["declare-fun", Builder.fromText x, parens (smt2many (smt2 env <$> ts)), smt2 env t]
-  smt2 env c@(Define t)        = key "declare-sort" (smt2SortMono c env t)
-  smt2 env (DefineFunc name paramxs rsort e) =
-    let bParams = [ parenSeqs [smt2 env s, smt2 env t] | (s, t) <- paramxs]
-     in parenSeqs ["define-fun", smt2 env name, parenSeqs bParams, smt2 env rsort, smt2 env e]
-  smt2 env (Assert Nothing p)  = {-# SCC "smt2-assert" #-} key "assert" (smt2 env p)
-  smt2 env (Assert (Just i) p) = {-# SCC "smt2-assert" #-} key "assert" (parens ("!"<+> smt2 env p <+> ":named p-" <> bShow i))
-  smt2 env (Distinct az)
-    | length az < 2            = ""
-    | otherwise                = key "assert" (key "distinct" (smt2s env az))
-  smt2 env (AssertAx t)        = key "assert" (smt2 env t)
-  smt2 _   Push                = "(push 1)"
-  smt2 _   Pop                 = "(pop 1)"
-  smt2 _   CheckSat            = "(check-sat)"
-  smt2 env (GetValue xs)       = key "key-value" (parens (smt2s env xs))
-  smt2 env (CMany cmds)        = smt2many (smt2 env <$> cmds)
-  smt2 _   Exit                = "(exit)"
-  smt2 _   SetMbqi             = "(set-option :smt.mbqi true)"
+  smt2     (DeclData ds)       = do s <- smt2data ds
+                                    pure $ key "declare-datatypes" s
+  smt2     (Declare x ts t)    = do s <- smt2s ts
+                                    s1 <- smt2 t
+                                    pure $ parenSeqs ["declare-fun", Builder.fromText x, parens s, s1]
+  smt2     c@(Define t)        = do s <- smt2SortMono c t
+                                    pure $ key "declare-sort" s
+  smt2     (DefineFunc name paramxs rsort e) =
+    do n <- smt2 name
+       bParams <- traverse (\(s, t) -> do s0 <- smt2 s
+                                          s1 <- smt2 t
+                                          pure $ parenSeqs [s0 , s1]) paramxs
+       r <- smt2 rsort
+       e' <- smt2 e
+       let e'' = trace ("definefunc: " ++ show e) e'
+       pure $ parenSeqs ["define-fun", n, parenSeqs bParams, r, e'']
+
+
+{-
+PAtom Eq
+      (ECst (EVar "y")
+            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt))
+      (ECst (EApp (ECst (EVar "acc") (FFunc (FApp (FApp (FTC (TC "Data" defined at: issue-738.smt2:1:12-1:16 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)
+                                            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)))
+                  (ECst (EVar "x")          (FApp (FApp (FTC (TC "Data" defined at: issue-738.smt2:4:15-4:19 (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt)))
+            (FApp (FApp (FTC (TC "Array_t" (dummyLoc) (TCInfo {tc_isNum = False, tc_isReal = False, tc_isString = False}))) FInt) FInt))
+-}
+
+  smt2     (Assert Nothing p)  = {-# SCC "smt2-assert" #-}
+                                  do s <- smt2 p
+                                     pure $ key "assert" s
+  smt2     (Assert (Just i) p) = {-# SCC "smt2-assert" #-}
+                                  do s <- smt2 p
+                                     pure $ key "assert" (parens ("!"<+> s <+> ":named p-" <> bShow i))
+  smt2     (Distinct az)
+    | length az < 2            = pure ""
+    | otherwise                = do s <- smt2s az
+                                    pure $ key "assert" $ key "distinct" s
+  smt2     (AssertAx t)        = do s <- smt2 t
+                                    pure $ key "assert" s
+  smt2     Push                = pure "(push 1)"
+  smt2     Pop                 = pure "(pop 1)"
+  smt2     CheckSat            = pure "(check-sat)"
+  smt2     (GetValue xs)       = do s <- smt2s xs
+                                    pure $ key "key-value" (parens s)
+  smt2     (CMany cmds)        = smt2s cmds
+  smt2     Exit                = pure "(exit)"
+  smt2     SetMbqi             = pure "(set-option :smt.mbqi true)"
 
 instance SMTLIB2 (Triggered Expr) where
-  smt2 env (TR NoTrigger e)       = smt2 env e
-  smt2 env (TR _ (PExist [] p))   = smt2 env p
-  smt2 env t@(TR _ (PExist xs p)) = smtTr env "exists" xs p t
-  smt2 env (TR _ (PAll   [] p))   = smt2 env p
-  smt2 env t@(TR _ (PAll   xs p)) = smtTr env "forall" xs p t
-  smt2 env (TR _ e)               = smt2 env e
+  smt2 (TR NoTrigger e)       = smt2 e
+  smt2 (TR _ (PExist [] p))   = smt2 p
+  smt2 t@(TR _ (PExist xs p)) = smtTr "exists" xs p t
+  smt2 (TR _ (PAll   [] p))   = smt2 p
+  smt2 t@(TR _ (PAll   xs p)) = smtTr "forall" xs p t
+  smt2 (TR _ e)               = smt2 e
 
 {-# INLINE smtTr #-}
-smtTr :: SymEnv -> Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> Builder
-smtTr env q xs p t = key q (parens (smt2s env xs) <+> key "!" (smt2 env p <+> ":pattern" <> parens (smt2s env (makeTriggers t))))
+smtTr :: Builder -> [(Symbol, Sort)] -> Expr -> Triggered Expr -> State SymEnv Builder
+smtTr q xs p t =
+  do s <- smt2s xs
+     s1 <- smt2 p
+     s2 <- smt2s (makeTriggers t)
+     pure $ key q (parens s <+> key "!" (s1 <+> ":pattern" <> parens s2))
 
 {-# INLINE smt2s #-}
-smt2s    :: SMTLIB2 a => SymEnv -> [a] -> Builder
-smt2s env as = smt2many (smt2 env <$> as)
+smt2s :: SMTLIB2 a => [a] -> State SymEnv Builder
+smt2s as = smt2many <$> traverse smt2 as
 
 {-# INLINE smt2many #-}
 smt2many :: [Builder] -> Builder

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE DoAndIfThenElse      #-}
 
 {-# OPTIONS_GHC -Wno-orphans        #-}
-{-# LANGUAGE InstanceSigs #-}
 
 -- | This module contains the code for serializing Haskell values
 --   into SMTLIB2 format, that is, the instances for the @SMTLIB2@

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -654,12 +654,12 @@ bvConcatSort = FAbs 0 $ FAbs 1 $ FAbs 2 $
 interpSym :: Symbol -> Raw -> Sort -> (Symbol, TheorySymbol)
 interpSym x n t = (x, Thy x n t Theory)
 
--- This variable is uded to generate the lambda names `lam_arg$n` in
+-- This variable is used to generate the lambda names `lam_arg$n` in
 -- `Interface.hs` that will be used during defunctionalization in
--- `Defunctionalize.hs`, is a pretty gross hack as if the user typees in the
--- program or ple generates a term that has more than `maxLamArg` lambda binders
--- one inside the other, the smt will crash complaining that
--- `lam_arg${maxLamArg}` was not declared.
+-- `Defunctionalize.hs`, is a pretty gross hack as if the user types in the
+-- program or PLE generates a term that has more than `maxLamArg` lambda binders
+-- one inside the other, the SMT will crash complaining that
+-- `lam_arg${maxLamArg + k}` was not declared.
 maxLamArg :: Int
 maxLamArg = 20
 

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE UndecidableInstances      #-}
-{-# LANGUAGE PatternGuards             #-}
+-- {-# LANGUAGE PatternGuards             #-}
 {-# LANGUAGE ViewPatterns              #-}
 
 {-# OPTIONS_GHC -Wno-orphans           #-}
@@ -56,6 +56,7 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
+import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Config
@@ -298,7 +299,7 @@ smt2Symbol :: SymEnv -> Symbol -> Maybe Builder
 smt2Symbol env x = fromText . tsRaw <$> symEnvTheory x env
 
 instance SMTLIB2 SmtSort where
-  smt2 _ = smt2SmtSort
+  smt2 s = pure $ smt2SmtSort s
 
 smt2SmtSort :: SmtSort -> Builder
 smt2SmtSort SInt         = "Int"
@@ -318,37 +319,46 @@ smt2SmtSort (SData c ts) = parenSeqs [symbolBuilder c, smt2SmtSorts ts]
 smt2SmtSorts :: [SmtSort] -> Builder
 smt2SmtSorts = seqs . fmap smt2SmtSort
 
-type VarAs = SymEnv -> Symbol -> Sort -> Builder
+type VarAs = Symbol -> Sort -> State SymEnv Builder
 --------------------------------------------------------------------------------
-smt2App :: VarAs -> SymEnv -> Expr -> [Builder] -> Maybe Builder
+smt2App :: VarAs -> Expr -> [Builder] -> State SymEnv (Maybe Builder)
 --------------------------------------------------------------------------------
-smt2App _ env ex@(dropECst -> EVar f) [d]
-  | f == arrConstS = Just (key (key "as const" (getTarget ex)) d)
-  | f == arrConstB = Just (key (key "as const" (getTarget ex)) d)
-  | f == arrConstM = Just (key (key "as const" (getTarget ex)) d)
-  | f == setEmpty  = Just (key "as set.empty" (getTarget ex))
-  | f == bagEmpty  = Just (key "as bag.empty" (getTarget ex))
+smt2App _ ex@(dropECst -> EVar f) [d] = gets (smt2AppVar ex f d)
+smt2App k ex (builder:builders) =
+  do a <- smt2AppArg k ex
+     pure $ (\fb -> key fb (builder <> mconcat [ " " <> d | d <- builders])) <$> a
+smt2App _ _ [] = pure Nothing
+
+smt2AppVar :: Expr -> Symbol -> Builder -> SymEnv -> Maybe Builder
+smt2AppVar ex f d env
+  | f == arrConstS = Just $ key (key "as const" (getTarget ex)) d
+  | f == arrConstB = Just $ key (key "as const" (getTarget ex)) d
+  | f == arrConstM = Just $ key (key "as const" (getTarget ex)) d
+  | f == setEmpty  = Just $ key "as set.empty" (getTarget ex)
+  | f == bagEmpty  = Just $ key "as bag.empty" (getTarget ex)
+  | otherwise = Nothing
   where
     getTarget :: Expr -> Builder
     -- const is a function, but SMT expects only the output sort
     getTarget (ECst _ t) = smt2SmtSort $ sortSmtSort True (seData env) (ffuncOut t)
     getTarget e = bShow e
 
-smt2App k env ex (builder:builders)
-  | Just fb <- smt2AppArg k env ex
-  = Just $ key fb (builder <> mconcat [ " " <> d | d <- builders])
-
-smt2App _ _ _ _    = Nothing
-
-smt2AppArg :: VarAs -> SymEnv -> Expr -> Maybe Builder
-smt2AppArg k env (ECst (dropECst -> EVar f) t)
+smt2AppArg :: VarAs -> Expr -> State SymEnv (Maybe Builder)
+smt2AppArg k (ECst (dropECst -> EVar f) t)
+  = do env <- get
+       case symEnvTheory f env of
+         Just fThy -> if isPolyCtor fThy t
+                           then Just <$> k f (ffuncOut t)
+                           else pure $ Just $ fromText (tsRaw fThy)
+         Nothing   -> pure Nothing
+         {-
   | Just fThy <- symEnvTheory f env
   = Just $ if isPolyCtor fThy t
             then k env f (ffuncOut t)
             else fromText (tsRaw fThy)
-
-smt2AppArg _ _ _
-  = Nothing
+-}
+smt2AppArg _ _
+  = pure Nothing
 
 isPolyCtor :: TheorySymbol -> Sort -> Bool
 isPolyCtor fThy t = isPolyInst (tsSort fThy) t && tsInterp fThy == Ctor
@@ -383,6 +393,19 @@ sortAppInfo t = case bkFFunc t of
 instance TheorySymbols SMTSolver where
   theorySymbols :: SMTSolver -> SEnv TheorySymbol
   theorySymbols = fromListSEnv . interpSymbols
+
+{-
+-- | `theorySymbols` contains the list of ALL SMT symbols with interpretations,
+--   i.e. which are given via `define-fun` (as opposed to `declare-fun`)
+theorySymbols :: SMTSolver -> [DataDecl] -> SEnv TheorySymbol -- M.HashMap Symbol TheorySymbol
+theorySymbols cfg ds = fromListSEnv $  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols
+                                    -- SHIFTLAM uninterpSymbols
+                                    -- SHIFTLAM uninterpSymbols
+                                    -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols
+                                    -- SHIFTLAM uninterpSymbols
+                                  interpSymbols cfg
+                               ++ concatMap dataDeclSymbols ds
+-}
 
 instance TheorySymbols [DataDecl] where
   theorySymbols :: [DataDecl] -> SEnv TheorySymbol

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -323,25 +323,27 @@ type VarAs = Symbol -> Sort -> State SymEnv Builder
 --------------------------------------------------------------------------------
 smt2App :: VarAs -> Expr -> [Builder] -> State SymEnv (Maybe Builder)
 --------------------------------------------------------------------------------
-smt2App _ ex@(dropECst -> EVar f) [d] = gets (smt2AppVar ex f d)
+smt2App _ ex@(dropECst -> EVar f) [d]
+  | f == arrConstS = do env <- get
+                        pure $ Just $ key (key "as const" (getTarget env ex)) d
+  | f == arrConstB = do env <- get
+                        pure $ Just $ key (key "as const" (getTarget env ex)) d
+  | f == arrConstM = do env <- get
+                        pure $ Just $ key (key "as const" (getTarget env ex)) d
+  | f == setEmpty  = do env <- get
+                        pure $ Just $ key "as set.empty" (getTarget env ex)
+  | f == bagEmpty  = do env <- get
+                        pure $ Just $ key "as bag.empty" (getTarget env ex)
+  where
+    getTarget :: SymEnv -> Expr -> Builder
+    -- const is a function, but SMT expects only the output sort
+    getTarget env (ECst _ t) = smt2SmtSort $ sortSmtSort True (seData env) (ffuncOut t)
+    getTarget _ e = bShow e
+
 smt2App k ex (builder:builders) =
   do a <- smt2AppArg k ex
      pure $ (\fb -> key fb (builder <> mconcat [ " " <> d | d <- builders])) <$> a
 smt2App _ _ [] = pure Nothing
-
-smt2AppVar :: Expr -> Symbol -> Builder -> SymEnv -> Maybe Builder
-smt2AppVar ex f d env
-  | f == arrConstS = Just $ key (key "as const" (getTarget ex)) d
-  | f == arrConstB = Just $ key (key "as const" (getTarget ex)) d
-  | f == arrConstM = Just $ key (key "as const" (getTarget ex)) d
-  | f == setEmpty  = Just $ key "as set.empty" (getTarget ex)
-  | f == bagEmpty  = Just $ key "as bag.empty" (getTarget ex)
-  | otherwise = Nothing
-  where
-    getTarget :: Expr -> Builder
-    -- const is a function, but SMT expects only the output sort
-    getTarget (ECst _ t) = smt2SmtSort $ sortSmtSort True (seData env) (ffuncOut t)
-    getTarget e = bShow e
 
 smt2AppArg :: VarAs -> Expr -> State SymEnv (Maybe Builder)
 smt2AppArg k (ECst (dropECst -> EVar f) t)
@@ -351,12 +353,6 @@ smt2AppArg k (ECst (dropECst -> EVar f) t)
                            then Just <$> k f (ffuncOut t)
                            else pure $ Just $ fromText (tsRaw fThy)
          Nothing   -> pure Nothing
-         {-
-  | Just fThy <- symEnvTheory f env
-  = Just $ if isPolyCtor fThy t
-            then k env f (ffuncOut t)
-            else fromText (tsRaw fThy)
--}
 smt2AppArg _ _
   = pure Nothing
 

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -323,16 +323,15 @@ type VarAs = Symbol -> Sort -> SymM Builder
 smt2App :: VarAs -> Expr -> [Builder] -> SymM (Maybe Builder)
 --------------------------------------------------------------------------------
 smt2App _ ex@(dropECst -> EVar f) [d]
-  | f == arrConstS = do env <- get
-                        pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstB = do env <- get
-                        pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstM = do env <- get
-                        pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == setEmpty  = do env <- get
-                        pure $ Just $ key "as set.empty" (getTarget env ex)
-  | f == bagEmpty  = do env <- get
-                        pure $ Just $ key "as bag.empty" (getTarget env ex)
+  | f == arrConstS || f == arrConstB || f == arrConstM =
+      do env <- get
+         pure $ Just $ key (key "as const" (getTarget env ex)) d
+  | f == setEmpty  =
+      do env <- get
+         pure $ Just $ key "as set.empty" (getTarget env ex)
+  | f == bagEmpty  =
+      do env <- get
+         pure $ Just $ key "as bag.empty" (getTarget env ex)
   where
     getTarget :: SymEnv -> Expr -> Builder
     -- const is a function, but SMT expects only the output sort

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE UndecidableInstances      #-}
--- {-# LANGUAGE PatternGuards             #-}
 {-# LANGUAGE ViewPatterns              #-}
 
 {-# OPTIONS_GHC -Wno-orphans           #-}
@@ -56,7 +55,6 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
--- import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types.Sorts
@@ -390,19 +388,6 @@ sortAppInfo t = case bkFFunc t of
 instance TheorySymbols SMTSolver where
   theorySymbols :: SMTSolver -> SEnv TheorySymbol
   theorySymbols = fromListSEnv . interpSymbols
-
-{-
--- | `theorySymbols` contains the list of ALL SMT symbols with interpretations,
---   i.e. which are given via `define-fun` (as opposed to `declare-fun`)
-theorySymbols :: SMTSolver -> [DataDecl] -> SEnv TheorySymbol -- M.HashMap Symbol TheorySymbol
-theorySymbols cfg ds = fromListSEnv $  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols
-                                    -- SHIFTLAM uninterpSymbols
-                                    -- SHIFTLAM uninterpSymbols
-                                    -- SHIFTLAM uninterpSymbols  -- SHIFTLAM uninterpSymbols
-                                    -- SHIFTLAM uninterpSymbols
-                                  interpSymbols cfg
-                               ++ concatMap dataDeclSymbols ds
--}
 
 instance TheorySymbols [DataDecl] where
   theorySymbols :: [DataDecl] -> SEnv TheorySymbol

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -56,7 +56,7 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
-import           Control.Monad.State
+import           Control.Monad.Reader
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Config
@@ -319,20 +319,20 @@ smt2SmtSort (SData c ts) = parenSeqs [symbolBuilder c, smt2SmtSorts ts]
 smt2SmtSorts :: [SmtSort] -> Builder
 smt2SmtSorts = seqs . fmap smt2SmtSort
 
-type VarAs = Symbol -> Sort -> State SymEnv Builder
+type VarAs = Symbol -> Sort -> SymM Builder
 --------------------------------------------------------------------------------
-smt2App :: VarAs -> Expr -> [Builder] -> State SymEnv (Maybe Builder)
+smt2App :: VarAs -> Expr -> [Builder] -> SymM (Maybe Builder)
 --------------------------------------------------------------------------------
 smt2App _ ex@(dropECst -> EVar f) [d]
-  | f == arrConstS = do env <- get
+  | f == arrConstS = do env <- ask
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstB = do env <- get
+  | f == arrConstB = do env <- ask
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstM = do env <- get
+  | f == arrConstM = do env <- ask
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == setEmpty  = do env <- get
+  | f == setEmpty  = do env <- ask
                         pure $ Just $ key "as set.empty" (getTarget env ex)
-  | f == bagEmpty  = do env <- get
+  | f == bagEmpty  = do env <- ask
                         pure $ Just $ key "as bag.empty" (getTarget env ex)
   where
     getTarget :: SymEnv -> Expr -> Builder
@@ -345,9 +345,9 @@ smt2App k ex (builder:builders) =
      pure $ (\fb -> key fb (builder <> mconcat [ " " <> d | d <- builders])) <$> a
 smt2App _ _ [] = pure Nothing
 
-smt2AppArg :: VarAs -> Expr -> State SymEnv (Maybe Builder)
+smt2AppArg :: VarAs -> Expr -> SymM (Maybe Builder)
 smt2AppArg k (ECst (dropECst -> EVar f) t)
-  = do env <- get
+  = do env <- ask
        case symEnvTheory f env of
          Just fThy -> if isPolyCtor fThy t
                            then Just <$> k f (ffuncOut t)

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -56,7 +56,8 @@ module Language.Fixpoint.Smt.Theories
      ) where
 
 import           Prelude hiding (map)
-import           Control.Monad.Reader
+-- import           Control.Monad.Reader
+import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Config
@@ -324,15 +325,15 @@ type VarAs = Symbol -> Sort -> SymM Builder
 smt2App :: VarAs -> Expr -> [Builder] -> SymM (Maybe Builder)
 --------------------------------------------------------------------------------
 smt2App _ ex@(dropECst -> EVar f) [d]
-  | f == arrConstS = do env <- ask
+  | f == arrConstS = do env <- get
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstB = do env <- ask
+  | f == arrConstB = do env <- get
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == arrConstM = do env <- ask
+  | f == arrConstM = do env <- get
                         pure $ Just $ key (key "as const" (getTarget env ex)) d
-  | f == setEmpty  = do env <- ask
+  | f == setEmpty  = do env <- get
                         pure $ Just $ key "as set.empty" (getTarget env ex)
-  | f == bagEmpty  = do env <- ask
+  | f == bagEmpty  = do env <- get
                         pure $ Just $ key "as bag.empty" (getTarget env ex)
   where
     getTarget :: SymEnv -> Expr -> Builder
@@ -347,7 +348,7 @@ smt2App _ _ [] = pure Nothing
 
 smt2AppArg :: VarAs -> Expr -> SymM (Maybe Builder)
 smt2AppArg k (ECst (dropECst -> EVar f) t)
-  = do env <- ask
+  = do env <- get
        case symEnvTheory f env of
          Just fThy -> if isPolyCtor fThy t
                            then Just <$> k f (ffuncOut t)

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -12,8 +12,11 @@ module Language.Fixpoint.Smt.Types (
     -- * Serialized Representation
     --    symbolBuilder
 
+    -- * SMT monad
+      SmtST
+
     -- * Commands
-      Command  (..)
+    , Command  (..)
 
     -- * Responses
     , Response (..)
@@ -27,6 +30,7 @@ module Language.Fixpoint.Smt.Types (
 
     ) where
 
+import           Control.Monad.State
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Types.Config (ElabFlags)
@@ -43,6 +47,9 @@ import           System.IO                (Handle)
 
 -- symbolBuilder :: Symbol -> LT.Builder
 -- symbolBuilder = LT.fromText . symbolSafeText
+
+-- | SMT monad
+type SmtST a = StateT SymEnv IO a
 
 -- | Commands issued to SMT engine
 data Command      = Push
@@ -110,7 +117,7 @@ data Context = Ctx
 --------------------------------------------------------------------------------
 
 class SMTLIB2 a where
-  smt2 :: SymEnv -> a -> Builder
+  smt2 :: a -> State SymEnv Builder
 
-runSmt2 :: (SMTLIB2 a) => SymEnv -> a -> Builder
+runSmt2 :: (SMTLIB2 a) => a -> State SymEnv Builder
 runSmt2 = smt2

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances         #-}
+{-# LANGUAGE TupleSections             #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings         #-}
@@ -12,11 +13,8 @@ module Language.Fixpoint.Smt.Types (
     -- * Serialized Representation
     --    symbolBuilder
 
-    -- * SMT monad
-      SmtST
-
     -- * Commands
-    , Command  (..)
+      Command  (..)
 
     -- * Responses
     , Response (..)
@@ -28,9 +26,16 @@ module Language.Fixpoint.Smt.Types (
     -- * SMTLIB2 Process Context
     , Context (..)
 
-    ) where
+    -- * SMT monad
+    , SmtM
+    , hoistSMT
+    , catchSMT
+    , bracketSMT
 
-import           Control.Monad.State
+    ) where
+import           Control.Exception
+-- import           Control.Monad.State
+import           Control.Monad.Reader
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Types.Config (ElabFlags)
@@ -47,9 +52,6 @@ import           System.IO                (Handle)
 
 -- symbolBuilder :: Symbol -> LT.Builder
 -- symbolBuilder = LT.fromText . symbolSafeText
-
--- | SMT monad
-type SmtST a = StateT SymEnv IO a
 
 -- | Commands issued to SMT engine
 data Command      = Push
@@ -112,12 +114,57 @@ data Context = Ctx
   , ctxDefines :: DefinedFuns
   }
 
+-- | SMT monad
+
+-- type SmtM a = StateT SymEnv IO a
+type SmtM = ReaderT Context IO
+
+hoistSMT :: SymM a -> SmtM a
+hoistSMT s =
+  do env <- asks ctxSymEnv
+     let a = runReader s env
+--     put env'
+     pure a
+
+catchSMT :: Exception e => SmtM a -> (e -> IO a) -> SmtM a
+catchSMT action handler =
+  ReaderT $ \ctx -> catch (runReaderT action ctx) handler
+
+   -- StateT $ \s -> catch (runStateT action s) (\e -> (,s) <$> handler e)
+
+bracketSMT :: SmtM a -> (a -> IO b) -> (a -> SmtM c) -> SmtM c
+bracketSMT acquire release use = ReaderT $ \s ->
+  bracket
+    (runReaderT acquire s)
+    release
+    (\resource -> runReaderT (use resource) s)
+
+{-
+-- TODO hacky?
+hoistSMT :: SymM a -> SmtM a
+hoistSMT s =
+  do env <- get
+     let (a, env') = runState s env
+     put env'
+     pure a
+
+catchSMT :: Exception e => SmtM a -> (e -> IO a) -> SmtM a
+catchSMT action handler = StateT $ \s -> catch (runStateT action s) (\e -> (,s) <$> handler e)
+
+bracketSMT :: SmtM a -> (a -> IO b) -> (a -> SmtM c) -> SmtM c
+bracketSMT acquire release use = StateT $ \s ->
+  bracket
+    (runStateT acquire s)
+    (\(resource, _) -> release resource)
+    (\(resource, intermediateState) -> runStateT (use resource) intermediateState)
+-}
+
 --------------------------------------------------------------------------------
 -- | AST Conversion: Types that can be serialized ------------------------------
 --------------------------------------------------------------------------------
 
 class SMTLIB2 a where
-  smt2 :: a -> State SymEnv Builder
+  smt2 :: a -> SymM Builder
 
-runSmt2 :: (SMTLIB2 a) => a -> State SymEnv Builder
+runSmt2 :: (SMTLIB2 a) => a -> SymM Builder
 runSmt2 = smt2

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -111,6 +111,7 @@ data Context = Ctx
   , ctxLog     :: !(Maybe Handle)
   , ctxVerbose :: !Bool
   , ctxSymEnv  :: !SymEnv
+  , ctxIxs     :: ![Int]
   , ctxDefines :: DefinedFuns
   }
 

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -34,8 +34,8 @@ module Language.Fixpoint.Smt.Types (
 
     ) where
 import           Control.Exception
--- import           Control.Monad.State
-import           Control.Monad.Reader
+import           Control.Monad.State
+--import           Control.Monad.Reader
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Types.Config (ElabFlags)
@@ -116,7 +116,7 @@ data Context = Ctx
 
 -- | SMT monad
 
--- type SmtM a = StateT SymEnv IO a
+{-
 type SmtM = ReaderT Context IO
 
 hoistSMT :: SymM a -> SmtM a
@@ -138,14 +138,16 @@ bracketSMT acquire release use = ReaderT $ \s ->
     (runReaderT acquire s)
     release
     (\resource -> runReaderT (use resource) s)
+-}
 
-{-
+type SmtM a = StateT Context IO a
+
 -- TODO hacky?
 hoistSMT :: SymM a -> SmtM a
 hoistSMT s =
-  do env <- get
-     let (a, env') = runState s env
-     put env'
+  do ctx <- get
+     let (a, env') = runState s (ctxSymEnv ctx)
+     put (ctx {ctxSymEnv = env'})
      pure a
 
 catchSMT :: Exception e => SmtM a -> (e -> IO a) -> SmtM a
@@ -157,7 +159,6 @@ bracketSMT acquire release use = StateT $ \s ->
     (runStateT acquire s)
     (\(resource, _) -> release resource)
     (\(resource, intermediateState) -> runStateT (use resource) intermediateState)
--}
 
 --------------------------------------------------------------------------------
 -- | AST Conversion: Types that can be serialized ------------------------------

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -35,7 +35,6 @@ module Language.Fixpoint.Smt.Types (
     ) where
 import           Control.Exception
 import           Control.Monad.State
---import           Control.Monad.Reader
 import           Data.ByteString.Builder (Builder)
 import           Language.Fixpoint.Types
 import           Language.Fixpoint.Types.Config (ElabFlags)
@@ -118,33 +117,8 @@ data Context = Ctx
 
 -- | SMT monad
 
-{-
-type SmtM = ReaderT Context IO
-
-hoistSMT :: SymM a -> SmtM a
-hoistSMT s =
-  do env <- asks ctxSymEnv
-     let a = runReader s env
---     put env'
-     pure a
-
-catchSMT :: Exception e => SmtM a -> (e -> IO a) -> SmtM a
-catchSMT action handler =
-  ReaderT $ \ctx -> catch (runReaderT action ctx) handler
-
-   -- StateT $ \s -> catch (runStateT action s) (\e -> (,s) <$> handler e)
-
-bracketSMT :: SmtM a -> (a -> IO b) -> (a -> SmtM c) -> SmtM c
-bracketSMT acquire release use = ReaderT $ \s ->
-  bracket
-    (runReaderT acquire s)
-    release
-    (\resource -> runReaderT (use resource) s)
--}
-
 type SmtM = StateT Context IO
 
--- TODO hacky?
 liftSym :: SymM a -> SmtM a
 liftSym s =
   do ctx <- get

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -113,6 +113,7 @@ data Context = Ctx
   , ctxSymEnv  :: !SymEnv
   , ctxIxs     :: ![Int]
   , ctxDefines :: DefinedFuns
+  , ctxLams    :: !Bool
   }
 
 -- | SMT monad

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -110,13 +110,17 @@ data Context = Ctx
   , ctxLog     :: !(Maybe Handle)
   , ctxVerbose :: !Bool
   , ctxSymEnv  :: !SymEnv
+  -- | The stack of sort indexes which were fresh at the corresponding level of push/pop stack.
   , ctxIxs     :: ![Int]
   , ctxDefines :: DefinedFuns
+  -- | Flag which controls the generation SMT placeholders for lambda arguments
+  --   See also `L.F.Smt.Theories.maxLamArg`
   , ctxLams    :: !Bool
   }
 
--- | SMT monad
-
+-- | SMT monad, used to communicate with the SMT solver backend.
+--   The `SymM` monad embeds into it, as the symbolic state has to be threaded
+--   through for gnerating `apply`s and other function sort symbols.
 type SmtM = StateT Context IO
 
 liftSym :: SymM a -> SmtM a

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -28,7 +28,7 @@ module Language.Fixpoint.Smt.Types (
 
     -- * SMT monad
     , SmtM
-    , hoistSMT
+    , liftSym
     , catchSMT
     , bracketSMT
 
@@ -141,11 +141,11 @@ bracketSMT acquire release use = ReaderT $ \s ->
     (\resource -> runReaderT (use resource) s)
 -}
 
-type SmtM a = StateT Context IO a
+type SmtM = StateT Context IO
 
 -- TODO hacky?
-hoistSMT :: SymM a -> SmtM a
-hoistSMT s =
+liftSym :: SymM a -> SmtM a
+liftSym s =
   do ctx <- get
      let (a, env') = runState s (ctxSymEnv ctx)
      put (ctx {ctxSymEnv = env'})

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -127,7 +127,7 @@ liftSym s =
      pure a
 
 catchSMT :: Exception e => SmtM a -> (e -> IO a) -> SmtM a
-catchSMT action handler = StateT $ \s -> catch (runStateT action s) (\e -> (,s) <$> handler e)
+catchSMT action handler = StateT $ \s -> catch (runStateT action s) (fmap (, s) . handler)
 
 bracketSMT :: SmtM a -> (a -> IO b) -> (a -> SmtM c) -> SmtM c
 bracketSMT acquire release use = StateT $ \s ->

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -2,7 +2,6 @@
 
 module Language.Fixpoint.Solver.Common (askSMT, toSMT) where
 
---import Control.Monad.Reader
 import Control.Monad.State
 import Language.Fixpoint.Types.Config (Config, solver, solverFlags)
 import Language.Fixpoint.Smt.Interface (Context(..), checkValidWithContext)
@@ -11,7 +10,6 @@ import Language.Fixpoint.Types
 import Language.Fixpoint.Types.Visitor (kvarsExpr)
 import Language.Fixpoint.Defunctionalize (defuncAny)
 import Language.Fixpoint.SortCheck (ElabParam(..), elaborate)
--- import Debug.Trace
 
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
@@ -23,9 +21,7 @@ askSMT cfg xs e
   | null (kvarsExpr e) =
       do ctx <- get
          let e' = toSMT "askSMT" cfg ctx xs e
-         let e'' = -- trace ("askSMT e': " ++ showpp e')
-                      e'
-         checkValidWithContext xs PTrue e''
+         checkValidWithContext xs PTrue e'
   | otherwise          = return False
 
 toSMT :: String -> Config -> Context -> [(Symbol, Sort)] -> Expr -> Pred

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -2,7 +2,8 @@
 
 module Language.Fixpoint.Solver.Common (askSMT, toSMT) where
 
-import Control.Monad.Reader
+--import Control.Monad.Reader
+import Control.Monad.State
 import Language.Fixpoint.Types.Config (Config, solver, solverFlags)
 import Language.Fixpoint.Smt.Interface (Context(..), checkValidWithContext)
 import Language.Fixpoint.Smt.Types (SmtM)
@@ -19,7 +20,7 @@ askSMT cfg xs e
 --   | isContraPred e  = return False
   | isTautoPred  e     = return True
   | null (kvarsExpr e) =
-      do ctx <- ask
+      do ctx <- get
          let e' = toSMT "askSMT" cfg ctx xs e
          checkValidWithContext xs PTrue e'
   | otherwise          = return False

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -11,9 +11,10 @@ import Language.Fixpoint.Types
 import Language.Fixpoint.Types.Visitor (kvarsExpr)
 import Language.Fixpoint.Defunctionalize (defuncAny)
 import Language.Fixpoint.SortCheck (ElabParam(..), elaborate)
+import Debug.Trace
 
 mytracepp :: (PPrint a) => String -> a -> a
-mytracepp = notracepp
+mytracepp = tracepp
 
 askSMT :: Config -> [(Symbol, Sort)] -> Expr -> SmtM Bool
 askSMT cfg xs e
@@ -22,14 +23,15 @@ askSMT cfg xs e
   | null (kvarsExpr e) =
       do ctx <- get
          let e' = toSMT "askSMT" cfg ctx xs e
-         checkValidWithContext xs PTrue e'
+         let e'' = trace ("askSMT e': " ++ showpp e') e'
+         checkValidWithContext xs PTrue e''
   | otherwise          = return False
 
 toSMT :: String -> Config -> Context -> [(Symbol, Sort)] -> Expr -> Pred
 toSMT msg cfg ctx xs e =
     defuncAny cfg symenv .
         elaborate (ElabParam (solverFlags $ solver cfg) (dummyLoc msg) (elabEnv xs)) .
-            mytracepp ("toSMT from " ++ msg ++ showpp e) $
+            mytracepp ("toSMT from " ++ msg ++ " > " ++ showpp e) $
                 e
   where
     elabEnv = insertsSymEnv symenv

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -11,10 +11,10 @@ import Language.Fixpoint.Types
 import Language.Fixpoint.Types.Visitor (kvarsExpr)
 import Language.Fixpoint.Defunctionalize (defuncAny)
 import Language.Fixpoint.SortCheck (ElabParam(..), elaborate)
-import Debug.Trace
+-- import Debug.Trace
 
 mytracepp :: (PPrint a) => String -> a -> a
-mytracepp = tracepp
+mytracepp = notracepp
 
 askSMT :: Config -> [(Symbol, Sort)] -> Expr -> SmtM Bool
 askSMT cfg xs e
@@ -23,7 +23,8 @@ askSMT cfg xs e
   | null (kvarsExpr e) =
       do ctx <- get
          let e' = toSMT "askSMT" cfg ctx xs e
-         let e'' = trace ("askSMT e': " ++ showpp e') e'
+         let e'' = -- trace ("askSMT e': " ++ showpp e')
+                      e'
          checkValidWithContext xs PTrue e''
   | otherwise          = return False
 

--- a/src/Language/Fixpoint/Solver/Common.hs
+++ b/src/Language/Fixpoint/Solver/Common.hs
@@ -2,8 +2,10 @@
 
 module Language.Fixpoint.Solver.Common (askSMT, toSMT) where
 
+import Control.Monad.Reader
 import Language.Fixpoint.Types.Config (Config, solver, solverFlags)
 import Language.Fixpoint.Smt.Interface (Context(..), checkValidWithContext)
+import Language.Fixpoint.Smt.Types (SmtM)
 import Language.Fixpoint.Types
 import Language.Fixpoint.Types.Visitor (kvarsExpr)
 import Language.Fixpoint.Defunctionalize (defuncAny)
@@ -12,14 +14,15 @@ import Language.Fixpoint.SortCheck (ElabParam(..), elaborate)
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
 
-askSMT :: Config -> Context -> [(Symbol, Sort)] -> Expr -> IO Bool
-askSMT cfg ctx xs e
+askSMT :: Config -> [(Symbol, Sort)] -> Expr -> SmtM Bool
+askSMT cfg xs e
 --   | isContraPred e  = return False
   | isTautoPred  e     = return True
-  | null (kvarsExpr e) = checkValidWithContext ctx xs PTrue e'
+  | null (kvarsExpr e) =
+      do ctx <- ask
+         let e' = toSMT "askSMT" cfg ctx xs e
+         checkValidWithContext xs PTrue e'
   | otherwise          = return False
-  where
-    e' = toSMT "askSMT" cfg ctx xs e
 
 toSMT :: String -> Config -> Context -> [(Symbol, Sort)] -> Expr -> Pred
 toSMT msg cfg ctx xs e =

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -142,7 +142,7 @@ withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> Sm
 withAssms env ctx delta cidMb act = do
   let ctx'  = updCtx env ctx delta cidMb
   let assms = mytracepp  ("ple1-assms: " ++ show (cidMb, delta)) (icAssms ctx')
-  SMT.smtBracket "PLE.evaluate" $ do
+  SMT.smtBracket "Instantiate.withAssms" $ do
     forM_ assms SMT.smtAssert
     act ctx'
 
@@ -167,7 +167,7 @@ evalCandsLoop cfg γ s0 = go []
   where
     go acc []    = return acc
     go acc cands = do ctx <- get
-                      eqss <- SMT.smtBracket "PLE.evaluate" $ do
+                      eqss <- SMT.smtBracket "Instantiate.evalCandsLoop" $ do
                                 SMT.smtAssert (unfoldPred cfg ctx acc)
                                 mapM (liftIO . evalOne γ s0) cands
                       let us  = zip (Just <$> cands) eqss
@@ -365,7 +365,7 @@ _evalLoop cfg γ s0 ctxEqs = loop 0 []
     loop _ acc []    = return acc
     loop i acc cands = do ctx <- get
                           let eqp = toSMT cfg ctx [] $ pAnd $ equalitiesPred acc
-                          eqss <- SMT.smtBracket "PLE.evaluate" $ do
+                          eqss <- SMT.smtBracket "Instantiate._evalLoop" $ do
                                     forM_ (eqp : ctxEqs) SMT.smtAssert
                                     mapM (liftIO . evalOne γ s0) cands
                           case concat eqss of

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -34,6 +34,7 @@ import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import qualified Language.Fixpoint.Solver.PLE as PLE      (instantiate)
 import qualified Language.Fixpoint.Solver.Common as Common (toSMT)
 import           Language.Fixpoint.Solver.Common          (askSMT)
+import           Control.Exception.Base (bracket)
 import           Control.Monad ((>=>), foldM, forM, forM_, join)
 import           Control.Monad.State
 -- import           Control.Monad.Reader
@@ -809,12 +810,12 @@ assertSelectors γ expr' = do
 --------------------------------------------------------------------------------
 
 withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
-withCtx cfg file env defns k = do
-  ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
-  _   <- evalStateT SMT.smtPush ctx
-  res <- evalStateT k ctx
-  liftIO $ SMT.cleanupContext ctx
-  return res
+withCtx cfg file env defns k =
+  bracket acquire release $
+    evalStateT $ SMT.smtPush >> k   -- TODO why is there no pop?
+  where
+    acquire = SMT.makeContextWithSEnv cfg file env defns
+    release = SMT.cleanupContext
 
 infixl 9 ~>
 (~>) :: (Expr, String) -> Expr -> EvalST Expr

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -24,6 +24,7 @@ import           Language.Fixpoint.Types.Config  as FC
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import qualified Language.Fixpoint.Misc          as Misc -- (mapFst)
 import qualified Language.Fixpoint.Smt.Interface as SMT
+import           Language.Fixpoint.Smt.Types (SmtM)
 import           Language.Fixpoint.Defunctionalize
 import qualified Language.Fixpoint.Utils.Trie    as T
 import           Language.Fixpoint.Utils.Progress -- as T
@@ -35,6 +36,7 @@ import qualified Language.Fixpoint.Solver.Common as Common (toSMT)
 import           Language.Fixpoint.Solver.Common          (askSMT)
 import           Control.Monad ((>=>), foldM, forM, forM_, join)
 import           Control.Monad.State
+import           Control.Monad.Reader
 import           Data.Bifunctor (first, second)
 import qualified Data.Text            as T
 import qualified Data.HashMap.Strict  as M
@@ -82,8 +84,10 @@ incrInstantiate' cfg info subcIds = do
                       ,  maybe True (i `L.elem`) subcIds ]
     let t  = mkCTrie cs                                               -- 1. BUILD the Trie
     res   <- withProgress (1 + length cs) $
-               withCtx cfg file sEnv (defns info) (pleTrie t . instEnv cfg info cs)  -- 2. TRAVERSE Trie to compute InstRes
-    return $ resSInfo cfg sEnv info res                                 -- 3. STRENGTHEN SInfo using InstRes
+               withCtx cfg file sEnv (defns info) $
+                 do ctx <- ask
+                    pleTrie t $ instEnv cfg info cs ctx               -- 2. TRAVERSE Trie to compute InstRes
+    return $ resSInfo cfg sEnv info res                               -- 3. STRENGTHEN SInfo using InstRes
   where
     file   = srcFile cfg ++ ".evals"
     sEnv   = symbolEnv cfg info
@@ -96,10 +100,10 @@ incrInstantiate' cfg info subcIds = do
 instEnv :: (Loc a) => Config -> SInfo a -> [(SubcId, SimpC a)] -> SMT.Context -> InstEnv a
 instEnv cfg info cs ctx = InstEnv cfg ctx bEnv aEnv (M.fromList cs) γ s0
   where
-    bEnv              = bs info
-    aEnv              = ae info
-    γ                 = knowledge cfg ctx aEnv
-    s0                = EvalEnv 0 [] aEnv (SMT.ctxSymEnv ctx) cfg
+    bEnv = bs info
+    aEnv = ae info
+    γ    = knowledge cfg ctx aEnv
+    s0   = EvalEnv 0 [] aEnv (SMT.ctxSymEnv ctx) cfg
 
 ----------------------------------------------------------------------------------------------
 -- | Step 1b: @mkCTrie@ builds the @Trie@ of constraints indexed by their environments
@@ -110,7 +114,7 @@ mkCTrie ics  = mytracepp  "TRIE" $ T.fromList [ (cBinds c, i) | (i, c) <- ics ]
 
 ----------------------------------------------------------------------------------------------
 -- | Step 2: @pleTrie@ walks over the @CTrie@ to actually do the incremental-PLE
-pleTrie :: CTrie -> InstEnv a -> IO InstRes
+pleTrie :: CTrie -> InstEnv a -> SmtM InstRes
 pleTrie t env = loopT env ctx0 diff0 Nothing res0 t
   where
     diff0        = []
@@ -118,7 +122,7 @@ pleTrie t env = loopT env ctx0 diff0 Nothing res0 t
     ctx0         = initCtx es0
     es0          = eqBody <$> L.filter (null . eqArgs) (aenvEqs . ieAenv $ env)
 
-loopT :: InstEnv a -> ICtx -> Diff -> Maybe BindId -> InstRes -> CTrie -> IO InstRes
+loopT :: InstEnv a -> ICtx -> Diff -> Maybe BindId -> InstRes -> CTrie -> SmtM InstRes
 loopT env ctx delta i res t = case t of
   T.Node []  -> return res
   T.Node [b] -> loopB env ctx delta i res b
@@ -126,28 +130,28 @@ loopT env ctx delta i res t = case t of
                   (ctx'', res') <- ple1 env ctx' i Nothing res
                   foldM (loopB env ctx'' [] i) res' bs
 
-loopB :: InstEnv a -> ICtx -> Diff -> Maybe BindId -> InstRes -> CBranch -> IO InstRes
+loopB :: InstEnv a -> ICtx -> Diff -> Maybe BindId -> InstRes -> CBranch -> SmtM InstRes
 loopB env ctx delta iMb res b = case b of
   T.Bind i t -> loopT env ctx (i:delta) (Just i) res t
   T.Val cid  -> withAssms env ctx delta (Just cid) $ \ctx' -> do
-                  progressTick
+                  lift progressTick
                   snd <$> ple1 env ctx' iMb (Just cid) res
 
 
-withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> IO b) -> IO b
-withAssms env@InstEnv{..} ctx delta cidMb act = do
+withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> SmtM b
+withAssms env ctx delta cidMb act = do
   let ctx'  = updCtx env ctx delta cidMb
   let assms = mytracepp  ("ple1-assms: " ++ show (cidMb, delta)) (icAssms ctx')
-  SMT.smtBracket ieSMT  "PLE.evaluate" $ do
-    forM_ assms (SMT.smtAssert ieSMT)
+  SMT.smtBracket "PLE.evaluate" $ do
+    forM_ assms SMT.smtAssert
     act ctx'
 
 -- | @ple1@ performs the PLE at a single "node" in the Trie
-ple1 :: InstEnv a -> ICtx -> Maybe BindId -> Maybe SubcId -> InstRes -> IO (ICtx, InstRes)
+ple1 :: InstEnv a -> ICtx -> Maybe BindId -> Maybe SubcId -> InstRes -> SmtM (ICtx, InstRes)
 ple1 env@InstEnv{..} ctx i cidMb res = do
-  let cands = mytracepp  ("ple1-cands: "  ++ show cidMb) $ S.toList (icCands ctx)
+  let cands = mytracepp ("ple1-cands: " ++ show cidMb) $ S.toList (icCands ctx)
   -- unfolds  <- evalCands ieKnowl ieEvEnv cands
-  unfolds  <- evalCandsLoop ieCfg ieSMT ieKnowl ieEvEnv cands
+  unfolds  <- evalCandsLoop ieCfg ieKnowl ieEvEnv cands
   return    $ updCtxRes env ctx res i cidMb (mytracepp  ("ple1-cands-unfolds: " ++ show cidMb) unfolds)
 
 _evalCands :: Knowledge -> EvalEnv -> [Expr] -> IO [Unfold]
@@ -158,13 +162,14 @@ _evalCands γ s0 cands = do eqs <- mapM (evalOne γ s0) cands
 unfoldPred :: Config -> SMT.Context -> [Unfold] -> Pred
 unfoldPred cfg ctx = toSMT cfg ctx [] . pAnd . concatMap snd
 
-evalCandsLoop :: Config -> SMT.Context -> Knowledge -> EvalEnv -> [Expr] -> IO [Unfold]
-evalCandsLoop cfg ctx γ s0 = go []
+evalCandsLoop :: Config -> Knowledge -> EvalEnv -> [Expr] -> SmtM [Unfold]
+evalCandsLoop cfg γ s0 = go []
   where
     go acc []    = return acc
-    go acc cands = do eqss   <- SMT.smtBracket ctx "PLE.evaluate" $ do
-                                  SMT.smtAssert ctx (unfoldPred cfg ctx acc)
-                                  mapM (evalOne γ s0) cands
+    go acc cands = do ctx <- ask
+                      eqss <- SMT.smtBracket "PLE.evaluate" $ do
+                                SMT.smtAssert (unfoldPred cfg ctx acc)
+                                mapM (liftIO . evalOne γ s0) cands
                       let us  = zip (Just <$> cands) eqss
                       case mkUnfolds us of
                         []  -> return acc
@@ -298,8 +303,8 @@ getCstr env cid = Misc.safeLookup "Instantiate.getCstr" cid env
 instantiate' :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
 instantiate' cfg info subcIds = sInfo cfg env info <$> withCtx cfg file env (defns info) act
   where
-    act ctx         = forM cstrs $ \(i, c) ->
-                        ((i,srcSpan c),) . mytracepp  ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg ctx (bs info) aenv i c
+    act             = forM cstrs $ \(i, c) ->
+                        ((i,srcSpan c),) . mytracepp  ("INSTANTIATE i = " ++ show i) <$> instSimpC cfg (bs info) aenv i c
     cstrs           = [ (i, c) | (i, c) <- M.toList (cm info) , isPleCstr aenv i c
                                ,  maybe True (i `L.elem`) subcIds ]
     file            = srcFile cfg ++ ".evals"
@@ -313,12 +318,12 @@ sInfo cfg env info ips = strengthenHyp info (mytracepp  "ELAB-INST:  " $ zip (fs
     ps'              = defuncAny cfg env ps
     ps''             = zipWith (\(i, sp) -> elaborate (ElabParam (solverFlags $ solver cfg) (atLoc sp ("PLE1 " ++ show i)) env)) is ps'
 
-instSimpC :: Config -> SMT.Context -> BindEnv a -> AxiomEnv -> SubcId -> SimpC a -> IO Expr
-instSimpC cfg ctx bds aenv subId sub
+instSimpC :: Config -> BindEnv a -> AxiomEnv -> SubcId -> SimpC a -> SmtM Expr
+instSimpC cfg bds aenv subId sub
   | isPleCstr aenv subId sub = do
     let is0       = mytracepp  "INITIAL-STUFF" $ eqBody <$> L.filter (null . eqArgs) (aenvEqs aenv)
     let (bs, es0) = cstrExprs bds sub
-    equalities   <- evaluate cfg ctx aenv bs es0 subId
+    equalities   <- evaluate cfg aenv bs es0 subId
     let evalEqs   = [ EEq e1 e2 | (e1, e2) <- equalities, e1 /= e2 ]
     return        $ pAnd (is0 ++ evalEqs)
   | otherwise     = return PTrue
@@ -335,32 +340,34 @@ cstrExprs bds sub = (second unElabSortedReft <$> binds, unElab <$> es)
 --------------------------------------------------------------------------------
 -- | Symbolic Evaluation with SMT
 --------------------------------------------------------------------------------
-evaluate :: Config -> SMT.Context -> AxiomEnv -- ^ Definitions
+evaluate :: Config -> AxiomEnv -- ^ Definitions
          -> [(Symbol, SortedReft)]            -- ^ Environment of "true" facts
          -> [Expr]                            -- ^ Candidates for unfolding
          -> SubcId                            -- ^ Constraint Id
-         -> IO [(Expr, Expr)]                 -- ^ Newly unfolded equalities
+         -> SmtM [(Expr, Expr)]              -- ^ Newly unfolded equalities
 --------------------------------------------------------------------------------
-evaluate cfg ctx aenv facts es subId = do
+evaluate cfg aenv facts es subId = do
+  ctx <- ask
   let eqs      = initEqualities ctx aenv facts
   let γ        = knowledge cfg ctx aenv
-  let cands    = mytracepp  ("evaluate-cands " ++ showpp subId) $ Misc.setNub (concatMap topApps es)
+  let cands    = mytracepp ("evaluate-cands " ++ showpp subId) $ Misc.setNub (concatMap topApps es)
   let s0       = EvalEnv 0 [] aenv (SMT.ctxSymEnv ctx) cfg
   let ctxEqs   = [ toSMT cfg ctx [] (EEq e1 e2) | (e1, e2)  <- eqs ]
               ++ [ toSMT cfg ctx [] (expr xr)   | xr@(_, r) <- facts, null (Vis.kvarsExpr $ reftPred $ sr_reft r) ]
-  eqss        <- _evalLoop cfg ctx γ s0 ctxEqs cands
+  eqss        <- _evalLoop cfg γ s0 ctxEqs cands
   return       $ eqs ++ eqss
 
 
 
-_evalLoop :: Config -> SMT.Context -> Knowledge -> EvalEnv -> [Pred] -> [Expr] -> IO [(Expr, Expr)]
-_evalLoop cfg ctx γ s0 ctxEqs = loop 0 []
+_evalLoop :: Config -> Knowledge -> EvalEnv -> [Pred] -> [Expr] -> SmtM [(Expr, Expr)]
+_evalLoop cfg γ s0 ctxEqs = loop 0 []
   where
     loop _ acc []    = return acc
-    loop i acc cands = do let eqp = toSMT cfg ctx [] $ pAnd $ equalitiesPred acc
-                          eqss <- SMT.smtBracket ctx "PLE.evaluate" $ do
-                                    forM_ (eqp : ctxEqs) (SMT.smtAssert ctx)
-                                    mapM (evalOne γ s0) cands
+    loop i acc cands = do ctx <- ask
+                          let eqp = toSMT cfg ctx [] $ pAnd $ equalitiesPred acc
+                          eqss <- SMT.smtBracket "PLE.evaluate" $ do
+                                    forM_ (eqp : ctxEqs) SMT.smtAssert
+                                    mapM (liftIO . evalOne γ s0) cands
                           case concat eqss of
                             []   -> return acc
                             eqs' -> do let acc'   = acc ++ eqs'
@@ -668,13 +675,13 @@ data Knowledge = KN
   { knSims    :: ![Rewrite]           -- ^ Measure info, asserted for each new Ctor ('assertSelectors')
   , knAms     :: ![Equation]          -- ^ (Recursive) function definitions, used for PLE
   , knContext :: SMT.Context
-  , knPreds   :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
+  , knPreds   :: [(Symbol, Sort)] -> Expr -> SmtM Bool
   , knLams    :: [(Symbol, Sort)]
   }
 
 isValid :: Knowledge -> Expr -> IO Bool
 isValid γ e = mytracepp ("isValid: " ++ showpp e) <$>
-                knPreds γ (knContext γ) (knLams γ) e
+                runReaderT (knPreds γ (knLams γ) e) (knContext γ)
 
 isProof :: (a, SortedReft) -> Bool
 isProof (_, RR s _) = showpp s == "Tuple"
@@ -801,12 +808,12 @@ assertSelectors γ expr' = do
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> (SMT.Context -> IO a) -> IO a
+withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k = do
-  ctx <- SMT.makeContextWithSEnv cfg file env defns
-  _   <- SMT.smtPush ctx
-  res <- k ctx
-  SMT.cleanupContext ctx
+  ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
+  _   <- runReaderT SMT.smtPush ctx
+  res <- runReaderT k ctx
+  liftIO $ SMT.cleanupContext ctx
   return res
 
 infixl 9 ~>

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -36,7 +36,7 @@ import qualified Language.Fixpoint.Solver.Common as Common (toSMT)
 import           Language.Fixpoint.Solver.Common          (askSMT)
 import           Control.Monad ((>=>), foldM, forM, forM_, join)
 import           Control.Monad.State
-import           Control.Monad.Reader
+-- import           Control.Monad.Reader
 import           Data.Bifunctor (first, second)
 import qualified Data.Text            as T
 import qualified Data.HashMap.Strict  as M
@@ -85,7 +85,7 @@ incrInstantiate' cfg info subcIds = do
     let t  = mkCTrie cs                                               -- 1. BUILD the Trie
     res   <- withProgress (1 + length cs) $
                withCtx cfg file sEnv (defns info) $
-                 do ctx <- ask
+                 do ctx <- get
                     pleTrie t $ instEnv cfg info cs ctx               -- 2. TRAVERSE Trie to compute InstRes
     return $ resSInfo cfg sEnv info res                               -- 3. STRENGTHEN SInfo using InstRes
   where
@@ -166,7 +166,7 @@ evalCandsLoop :: Config -> Knowledge -> EvalEnv -> [Expr] -> SmtM [Unfold]
 evalCandsLoop cfg γ s0 = go []
   where
     go acc []    = return acc
-    go acc cands = do ctx <- ask
+    go acc cands = do ctx <- get
                       eqss <- SMT.smtBracket "PLE.evaluate" $ do
                                 SMT.smtAssert (unfoldPred cfg ctx acc)
                                 mapM (liftIO . evalOne γ s0) cands
@@ -347,7 +347,7 @@ evaluate :: Config -> AxiomEnv -- ^ Definitions
          -> SmtM [(Expr, Expr)]              -- ^ Newly unfolded equalities
 --------------------------------------------------------------------------------
 evaluate cfg aenv facts es subId = do
-  ctx <- ask
+  ctx <- get
   let eqs      = initEqualities ctx aenv facts
   let γ        = knowledge cfg ctx aenv
   let cands    = mytracepp ("evaluate-cands " ++ showpp subId) $ Misc.setNub (concatMap topApps es)
@@ -363,7 +363,7 @@ _evalLoop :: Config -> Knowledge -> EvalEnv -> [Pred] -> [Expr] -> SmtM [(Expr, 
 _evalLoop cfg γ s0 ctxEqs = loop 0 []
   where
     loop _ acc []    = return acc
-    loop i acc cands = do ctx <- ask
+    loop i acc cands = do ctx <- get
                           let eqp = toSMT cfg ctx [] $ pAnd $ equalitiesPred acc
                           eqss <- SMT.smtBracket "PLE.evaluate" $ do
                                     forM_ (eqp : ctxEqs) SMT.smtAssert
@@ -681,7 +681,7 @@ data Knowledge = KN
 
 isValid :: Knowledge -> Expr -> IO Bool
 isValid γ e = mytracepp ("isValid: " ++ showpp e) <$>
-                runReaderT (knPreds γ (knLams γ) e) (knContext γ)
+                evalStateT (knPreds γ (knLams γ) e) (knContext γ)
 
 isProof :: (a, SortedReft) -> Bool
 isProof (_, RR s _) = showpp s == "Tuple"
@@ -811,8 +811,8 @@ assertSelectors γ expr' = do
 withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k = do
   ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
-  _   <- runReaderT SMT.smtPush ctx
-  res <- runReaderT k ctx
+  _   <- evalStateT SMT.smtPush ctx
+  res <- evalStateT k ctx
   liftIO $ SMT.cleanupContext ctx
   return res
 

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -37,7 +37,6 @@ import           Language.Fixpoint.Solver.Common          (askSMT)
 import           Control.Exception.Base (bracket)
 import           Control.Monad ((>=>), foldM, forM, forM_, join)
 import           Control.Monad.State
--- import           Control.Monad.Reader
 import           Data.Bifunctor (first, second)
 import qualified Data.Text            as T
 import qualified Data.HashMap.Strict  as M

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -60,6 +60,8 @@ import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes)
 import           Control.Exception.Base (bracket)
 
+--import Debug.Trace
+
 --------------------------------------------------------------------------------
 -- | Solver Monadic API --------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -120,7 +122,12 @@ incChck n = modifyStats $ \s -> s {numChck = n + numChck s}
 incVald n = modifyStats $ \s -> s {numVald = n + numVald s}
 
 liftSMT :: SmtM a -> SolveM ann a
-liftSMT k = (lift . ST.evalStateT k) =<< getContext
+liftSMT k =
+  do es <- get
+     let ctx = ssCtx es
+     (a, ctx') <- lift $ ST.runStateT k ctx
+     put (es {ssCtx = ctx'})
+     pure a
 
 getContext :: SolveM ann Context
 getContext = ssCtx <$> get
@@ -148,12 +155,14 @@ sendConcreteBindingsToSMT known act = do
         , not (F.memberIBindEnv i known)
         ]
   st <- get
-  (a, st') <- liftSMT $
-    smtBracket "" $ do
+  (a, st'') <- liftSMT $
+    smtBracket "sendConcreteBindingsToSMT" $ do
       forM_ concretePreds $ \(i, e) ->
         smtDefineFunc (F.bindSymbol (fromIntegral i)) [] F.boolSort e
-      liftIO $ flip runStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
-  put st'
+      ctx <- get
+      let st' = st { ssCtx = ctx }
+      liftIO $ flip runStateT st' $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
+  put st''
   return a
   where
     isShortExpr F.PTrue = True
@@ -186,10 +195,10 @@ filterValid sp p qs = do
 {-# SCC filterValid_ #-}
 filterValid_ :: F.SrcSpan -> F.Expr -> F.Cand a -> SmtM [a]
 filterValid_ sp p qs = catMaybes <$> do
-  smtAssert p
+  smtAssertDecl p
   forM qs $ \(q, x) ->
     smtBracketAt sp "filterValidRHS" $ do
-      smtAssert (F.PNot q)
+      smtAssertDecl (F.PNot q)
       valid <- smtCheckUnsat
       return $ if valid then Just x else Nothing
 

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -28,6 +28,9 @@ module Language.Fixpoint.Solver.Monad
        , stats
        , numIter
        , SolverState(..)
+
+       , modifyContext
+       , clearApplys
        )
        where
 
@@ -135,6 +138,12 @@ getContext = ssCtx <$> get
 modifyStats :: (Stats -> Stats) -> SolveM ann ()
 modifyStats f = modify $ \s -> s { ssStats = f (ssStats s) }
 
+modifyContext :: (Context -> Context) -> SolveM ann ()
+modifyContext f = modify $ \s -> s { ssCtx = f (ssCtx s) }
+
+clearApplys :: SolveM ann ()
+clearApplys = modifyContext $ \c -> c { ctxSymEnv = (ctxSymEnv c) { F.seAppls = mempty , F.seApplsCur = mempty , F.seIx = 0 } }
+
 --------------------------------------------------------------------------------
 -- | SMT Interface -------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -186,6 +195,7 @@ filterValid sp p qs = do
   qs' <- liftSMT $
            smtBracket "filterValidLHS" $
              filterValid_ sp p qs
+--  clearApplys
   -- stats
   incBrkt
   incChck (length qs)

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -53,8 +53,9 @@ import           Language.Fixpoint.Graph.Types (SolverInfo (..))
 -- import           Data.Maybe           (catMaybes)
 import           Data.List            (partition)
 -- import           Data.Char            (isUpper)
+import qualified Control.Monad.State as ST
 import           Control.Monad.State.Strict
-import           Control.Monad.Reader
+--import           Control.Monad.Reader
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes)
 import           Control.Exception.Base (bracket)
@@ -119,7 +120,7 @@ incChck n = modifyStats $ \s -> s {numChck = n + numChck s}
 incVald n = modifyStats $ \s -> s {numVald = n + numVald s}
 
 liftSMT :: SmtM a -> SolveM ann a
-liftSMT k = (lift . runReaderT k) =<< getContext
+liftSMT k = (lift . ST.evalStateT k) =<< getContext
 
 getContext :: SolveM ann Context
 getContext = ssCtx <$> get

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -58,12 +58,9 @@ import           Data.List            (partition)
 -- import           Data.Char            (isUpper)
 import qualified Control.Monad.State as ST
 import           Control.Monad.State.Strict
---import           Control.Monad.Reader
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes)
 import           Control.Exception.Base (bracket)
-
---import Debug.Trace
 
 --------------------------------------------------------------------------------
 -- | Solver Monadic API --------------------------------------------------------
@@ -195,7 +192,6 @@ filterValid sp p qs = do
   qs' <- liftSMT $
            smtBracket "filterValidLHS" $
              filterValid_ sp p qs
---  clearApplys
   -- stats
   incBrkt
   incChck (length qs)

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -5,6 +5,7 @@
 module Language.Fixpoint.Solver.Monad
        ( -- * Type
          SolveM
+       , liftSMT
 
          -- * Execution
        , runSolverM
@@ -43,6 +44,7 @@ import qualified Language.Fixpoint.Types.Visitor as F
 import           Language.Fixpoint.Smt.Serialize ()
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Smt.Interface
+import           Language.Fixpoint.Smt.Types (SmtM)
 -- import qualified Language.Fixpoint.Smt.Theories as Thy
 import           Language.Fixpoint.Solver.Sanitize
 import           Language.Fixpoint.Solver.Stats
@@ -52,6 +54,7 @@ import           Language.Fixpoint.Graph.Types (SolverInfo (..))
 import           Data.List            (partition)
 -- import           Data.Char            (isUpper)
 import           Control.Monad.State.Strict
+import           Control.Monad.Reader
 import qualified Data.HashMap.Strict as M
 import           Data.Maybe (catMaybes)
 import           Control.Exception.Base (bracket)
@@ -115,8 +118,8 @@ incChck, incVald :: Int -> SolveM ann ()
 incChck n = modifyStats $ \s -> s {numChck = n + numChck s}
 incVald n = modifyStats $ \s -> s {numVald = n + numVald s}
 
-withContext :: (Context -> IO a) -> SolveM ann a
-withContext k = (lift . k) =<< getContext
+liftSMT :: SmtM a -> SolveM ann a
+liftSMT k = (lift . runReaderT k) =<< getContext
 
 getContext :: SolveM ann Context
 getContext = ssCtx <$> get
@@ -144,11 +147,11 @@ sendConcreteBindingsToSMT known act = do
         , not (F.memberIBindEnv i known)
         ]
   st <- get
-  (a, st') <- withContext $ \me -> do
-    smtBracket me "" $ do
+  (a, st') <- liftSMT $
+    smtBracket "" $ do
       forM_ concretePreds $ \(i, e) ->
-        smtDefineFunc me (F.bindSymbol (fromIntegral i)) [] F.boolSort e
-      flip runStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
+        smtDefineFunc (F.bindSymbol (fromIntegral i)) [] F.boolSort e
+      liftIO $ flip runStateT st $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
   put st'
   return a
   where
@@ -170,9 +173,9 @@ filterRequired = error "TBD:filterRequired"
 filterValid :: F.SrcSpan -> F.Expr -> F.Cand a -> SolveM ann [a]
 --------------------------------------------------------------------------------
 filterValid sp p qs = do
-  qs' <- withContext $ \me ->
-           smtBracket me "filterValidLHS" $
-             filterValid_ sp p qs me
+  qs' <- liftSMT $
+           smtBracket "filterValidLHS" $
+             filterValid_ sp p qs
   -- stats
   incBrkt
   incChck (length qs)
@@ -180,13 +183,13 @@ filterValid sp p qs = do
   return qs'
 
 {-# SCC filterValid_ #-}
-filterValid_ :: F.SrcSpan -> F.Expr -> F.Cand a -> Context -> IO [a]
-filterValid_ sp p qs me = catMaybes <$> do
-  smtAssert me p
+filterValid_ :: F.SrcSpan -> F.Expr -> F.Cand a -> SmtM [a]
+filterValid_ sp p qs = catMaybes <$> do
+  smtAssert p
   forM qs $ \(q, x) ->
-    smtBracketAt sp me "filterValidRHS" $ do
-      smtAssert me (F.PNot q)
-      valid <- smtCheckUnsat me
+    smtBracketAt sp "filterValidRHS" $ do
+      smtAssert (F.PNot q)
+      valid <- smtCheckUnsat
       return $ if valid then Just x else Nothing
 
 --------------------------------------------------------------------------------
@@ -196,50 +199,50 @@ filterValid_ sp p qs me = catMaybes <$> do
 filterValidGradual :: [F.Expr] -> F.Cand a -> SolveM ann [a]
 --------------------------------------------------------------------------------
 filterValidGradual p qs = do
-  qs' <- withContext $ \me ->
-           smtBracket me "filterValidGradualLHS" $
-             filterValidGradual_ p qs me
+  qs' <- liftSMT $
+           smtBracket "filterValidGradualLHS" $
+             filterValidGradual_ p qs
   -- stats
   incBrkt
   incChck (length qs)
   incVald (length qs')
   return qs'
 
-filterValidGradual_ :: [F.Expr] -> F.Cand a -> Context -> IO [a]
-filterValidGradual_ ps qs me
+filterValidGradual_ :: [F.Expr] -> F.Cand a -> SmtM [a]
+filterValidGradual_ ps qs
   = map snd . fst <$> foldM partitionCandidates ([], qs) ps
   where
-    partitionCandidates :: (F.Cand a, F.Cand a) -> F.Expr -> IO (F.Cand a, F.Cand a)
+    partitionCandidates :: (F.Cand a, F.Cand a) -> F.Expr -> SmtM (F.Cand a, F.Cand a)
     partitionCandidates (ok, candidates) p = do
-      (valids', invalids')  <- partition snd <$> filterValidOne_ p candidates me
+      (valids', invalids')  <- partition snd <$> filterValidOne_ p candidates
       let (valids, invalids) = (fst <$> valids', fst <$> invalids')
       return (ok ++ valids, invalids)
 
-filterValidOne_ :: F.Expr -> F.Cand a -> Context -> IO [((F.Expr, a), Bool)]
-filterValidOne_ p qs me = do
-  smtAssert me p
+filterValidOne_ :: F.Expr -> F.Cand a -> SmtM [((F.Expr, a), Bool)]
+filterValidOne_ p qs = do
+  smtAssert p
   forM qs $ \(q, x) ->
-    smtBracket me "filterValidRHS" $ do
-      smtAssert me (F.PNot q)
-      valid <- smtCheckUnsat me
+    smtBracket "filterValidRHS" $ do
+      smtAssert (F.PNot q)
+      valid <- smtCheckUnsat
       return ((q, x), valid)
 
 smtEnablembqi :: SolveM ann ()
 smtEnablembqi
-  = withContext smtSetMbqi
+  = liftSMT smtSetMbqi
 
 --------------------------------------------------------------------------------
 checkSat :: F.Expr -> SolveM ann Bool
 --------------------------------------------------------------------------------
 checkSat p
-  = withContext $ \me ->
-      smtBracket me "checkSat" $
-        smtCheckSat me p
+  = liftSMT $
+      smtBracket "checkSat" $
+        smtCheckSat p
 
 --------------------------------------------------------------------------------
 assumesAxioms :: [F.Triggered F.Expr] -> SolveM ann ()
 --------------------------------------------------------------------------------
-assumesAxioms es = withContext $ \me -> forM_  es $ smtAssertAxiom me
+assumesAxioms es = liftSMT $ forM_ es smtAssertAxiom
 
 
 ---------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -52,6 +52,7 @@ import Language.REST.ExploredTerms as ExploredTerms
 import Language.REST.RuntimeTerm as RT
 import Language.REST.SMT (withZ3, SolverHandle)
 
+import           Control.Exception.Base (bracket)
 import           Control.Monad (filterM, foldM, forM_, when, replicateM)
 import           Control.Monad.Reader
 import           Control.Monad.State
@@ -280,7 +281,7 @@ withAssms env ctx delta cidMb act = do
   let ctx' = updCtx env ctx delta cidMb
   let assms = icAssms ctx'
 
-  SMT.smtBracket "PLE.evaluate" $ do
+  SMT.smtBracket "PLE.withAssms" $ do
     forM_ assms SMT.smtAssert
     act ctx' { icAssms = mempty }
 
@@ -1344,13 +1345,15 @@ partitionUserDataConstructorSelectors dds rws = L.partition isSelector rws
 --------------------------------------------------------------------------------
 
 withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
-withCtx cfg file env defns k = do
-  ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
-  _   <- evalStateT SMT.smtPush ctx
-  res <- evalStateT k ctx
-  liftIO $ SMT.cleanupContext ctx
-  return res
-
+withCtx cfg file env defns k =
+  bracket acquire release $ \ctx ->
+  do _   <- evalStateT SMT.smtPush ctx
+     res <- evalStateT k ctx
+     SMT.cleanupContext ctx
+     return res
+  where
+    acquire = SMT.makeContextWithSEnv cfg file env defns
+    release  = SMT.cleanupContext
 
 -- (sel_i, D, i), meaning sel_i (D x1 .. xn) = xi,
 -- i.e., sel_i selects the ith value for the data constructor D

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -162,7 +162,7 @@ instEnv cfg info cs restSolver = do
               }
     return $ InstEnv
        { ieCfg = cfg
-       , ieSMT = ctx
+--       , ieSMT = ctx
        , ieBEnv = coerceBindEnv ef (bs info)
        , ieAenv = ae info
        , ieCstrs = cs
@@ -278,7 +278,8 @@ loopB env ctx delta iMb res b = case b of
 --
 withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> SmtM b
 withAssms env ctx delta cidMb act = do
-  let ctx' = updCtx env ctx delta cidMb
+  sctx <- get
+  let ctx' = updCtx env sctx ctx delta cidMb
   let assms = icAssms ctx'
 
   SMT.smtBracket "PLE.withAssms" $ do
@@ -292,6 +293,7 @@ withAssms env ctx delta cidMb act = do
 -- @ieKnowl@.
 ple1 :: InstEnv a -> ICtx -> Maybe BindId -> InstRes -> SmtM (ICtx, InstEnv a, InstRes)
 ple1 ie@InstEnv{..} ctx i res = do
+  ieSMT <- get
   (ctx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ctx ieSMT ieKnowl) ieEvEnv
   let pendings = collectPendingUnfoldings env (icSubcId ctx)
       newEqs = pendings ++ S.toList (S.difference (icEquals ctx') (icEquals ctx))
@@ -322,14 +324,15 @@ evalToSMT msg cfg ctx (e1,e2) = toSMT ("evalToSMT:" ++ msg) cfg ctx [] (EEq e1 e
 -- >       or the environment becomes inconsistent
 --
 evalCandsLoop :: Config -> ICtx -> SMT.Context -> Knowledge -> EvalST ICtx
-evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
+evalCandsLoop cfg ictx0 ctx0 γ = go ictx0 ctx0 0
   where
-    go ictx _ | S.null (icCands ictx) = return ictx
-    go ictx i = do
+    go :: ICtx -> SMT.Context -> Int -> EvalST ICtx
+    go ictx _   _ | S.null (icCands ictx) = return ictx
+    go ictx ctx i = do
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do liftIO $ evalStateT (SMT.smtAssert (pAndNoDedup (S.toList $ icAssms ictx))) ctx
+        else do (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx
                 let ictx' = ictx { icAssms = mempty }
                     cands = S.toList $ icCands ictx
                 candss <- mapM (evalOne γ ictx' i) cands
@@ -342,7 +345,7 @@ evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
                       else do let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx `S.map` unknownEqs
                               let ictx'' = ictx' { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
-                              go (ictx'' { icCands = S.fromList (concat candss) }) (i + 1)
+                              go (ictx'' { icCands = S.fromList (concat candss) }) ctx' (i + 1)
 
     testForInconsistentEnvironment =
       liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) (knContext γ)
@@ -368,7 +371,7 @@ resSInfo cfg env info res = strengthenBinds info res'
 
 data InstEnv a = InstEnv
   { ieCfg   :: !Config
-  , ieSMT   :: !SMT.Context
+--  , ieSMT   :: !SMT.Context
   , ieBEnv  :: !(BindEnv a)
   , ieAenv  :: !AxiomEnv
   , ieCstrs :: !(CMap (SimpC a))
@@ -429,8 +432,8 @@ updRes res  Nothing _ = res
 --   to the context.
 ----------------------------------------------------------------------------------------------
 
-updCtx :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> ICtx
-updCtx InstEnv{..} ctx delta cidMb
+updCtx :: InstEnv a -> SMT.Context -> ICtx -> Diff -> Maybe SubcId -> ICtx
+updCtx InstEnv{..} ieSMT ctx delta cidMb
             = ctx { icAssms  = S.fromList (filter (not . isTautoPred) ctxEqs)
                   , icCands  = S.fromList deANFedCands <> icCands  ctx
                   , icSimpl  = icSimpl ctx <> econsts
@@ -1348,12 +1351,10 @@ withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k =
   bracket acquire release $ \ctx ->
   do _   <- evalStateT SMT.smtPush ctx
-     res <- evalStateT k ctx
-     SMT.cleanupContext ctx
-     return res
+     evalStateT k ctx
   where
     acquire = SMT.makeContextWithSEnv cfg file env defns
-    release  = SMT.cleanupContext
+    release = SMT.cleanupContext
 
 -- (sel_i, D, i), meaning sel_i (D x1 .. xn) = xi,
 -- i.e., sel_i selects the ith value for the data constructor D

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -69,7 +69,7 @@ import qualified Data.Maybe           as Mb
 import qualified Data.Set as Set
 import           Text.PrettyPrint.HughesPJ.Compat
 
-import Debug.Trace (trace)
+--import Debug.Trace (trace)
 
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
@@ -152,6 +152,7 @@ instEnv cfg info cs restSolver = do
         s0 = EvalEnv
               { evEnv = SMT.ctxSymEnv ctx
               , evElabF = ef
+              , evKCtx = ctx
               , evPendingUnfoldings = mempty
               , evNewEqualities = mempty
               , evSMTCache = mempty
@@ -168,7 +169,7 @@ instEnv cfg info cs restSolver = do
        , ieBEnv = coerceBindEnv ef (bs info)
        , ieAenv = ae info
        , ieCstrs = cs
-       , ieKnowl = knowledge cfg ctx info
+       , ieKnowl = knowledge cfg {- ctx -} info
        , ieEvEnv = s0
        , ieLRWs  = lrws info
        }
@@ -246,12 +247,12 @@ loopT
   -> InstRes
   -> CTrie
   -> SmtM InstRes
-loopT env ctx delta i res t = case t of
+loopT env ictx delta i res t = case t of
   T.Node []  -> return res
-  T.Node [b] -> loopB env ctx delta i res b
-  T.Node bs  -> withAssms env ctx delta Nothing $ \ctx' -> do
-                  (ctx'', env'', res') <- ple1 env ctx' i res
-                  foldM (loopB env'' ctx'' [] i) res' bs
+  T.Node [b] -> loopB env ictx delta i res b
+  T.Node bs  -> withAssms env ictx delta Nothing $ \ictx' -> do
+                  (ictx'', env'', res') <- ple1 env ictx' i res
+                  foldM (loopB env'' ictx'' [] i) res' bs
 
 loopB
   :: InstEnv a
@@ -262,11 +263,11 @@ loopB
   -> InstRes
   -> CBranch
   -> SmtM InstRes
-loopB env ctx delta iMb res b = case b of
-  T.Bind i t -> loopT env ctx (i:delta) (Just i) res t
-  T.Val cid  -> withAssms env ctx delta (Just cid) $ \ctx' -> do
+loopB env ictx delta iMb res b = case b of
+  T.Bind i t -> loopT env ictx (i:delta) (Just i) res t
+  T.Val cid  -> withAssms env ictx delta (Just cid) $ \ictx' -> do
                   liftIO progressTick
-                  (\(_, _, r) -> r) <$> ple1 env ctx' iMb res
+                  (\(_, _, r) -> r) <$> ple1 env ictx' iMb res
 
 -- | Adds to @ctx@ candidate expressions to unfold from the bindings in @delta@
 -- and the rhs of @cidMb@.
@@ -281,12 +282,12 @@ loopB env ctx delta iMb res b = case b of
 withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> SmtM b
 withAssms env ctx delta cidMb act = do
   sctx <- get
-  let ctx' = updCtx env sctx ctx delta cidMb
-  let assms = icAssms ctx'
+  let ictx' = updCtx env sctx ctx delta cidMb
+  let assms = icAssms ictx'
 
   SMT.smtBracket "PLE.withAssms" $ do
     forM_ assms SMT.smtAssertDecl
-    act ctx' { icAssms = mempty }
+    act $ ictx' { icAssms = mempty }
 
 -- | @ple1@ performs the PLE at a single "node" in the Trie
 --
@@ -294,12 +295,13 @@ withAssms env ctx delta cidMb act = do
 -- in @ctx@ for which definitions are known. The function definitions are in
 -- @ieKnowl@.
 ple1 :: InstEnv a -> ICtx -> Maybe BindId -> InstRes -> SmtM (ICtx, InstEnv a, InstRes)
-ple1 ie@InstEnv{..} ctx i res = do
-  ieSMT <- get
-  (ctx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ctx ieSMT ieKnowl) ieEvEnv
-  let pendings = collectPendingUnfoldings env (icSubcId ctx)
-      newEqs = pendings ++ S.toList (S.difference (icEquals ctx') (icEquals ctx))
-  return (ctx', ie { ieEvEnv = env }, updCtxRes res i newEqs)
+ple1 ie@InstEnv{..} ictx i res = do
+  ctx <- get
+  -- ieSMT <- get
+  (ictx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ictx {- ieSMT -} ieKnowl) (ieEvEnv { evKCtx = ctx })
+  let pendings = collectPendingUnfoldings env (icSubcId ictx)
+      newEqs = pendings ++ S.toList (S.difference (icEquals ictx') (icEquals ictx))
+  return (ictx', ie { ieEvEnv = env }, updCtxRes res i newEqs)
   where
     -- Pending unfoldings (i.e. with undecided guards) are collected only
     -- when we reach a leaf in the Trie, and only if the user asked for them.
@@ -325,21 +327,24 @@ evalToSMT msg cfg ctx (e1,e2) = toSMT ("evalToSMT:" ++ msg) cfg ctx [] (EEq e1 e
 -- > until no new equalities are discovered
 -- >       or the environment becomes inconsistent
 --
-evalCandsLoop :: Config -> ICtx -> SMT.Context -> Knowledge -> EvalST ICtx
-evalCandsLoop cfg ictx0 ctx0 γ = go ictx0 ctx0 0
+evalCandsLoop :: Config -> ICtx -> {- SMT.Context -> -} Knowledge -> EvalST ICtx
+evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
   where
-    go :: ICtx -> SMT.Context -> Int -> EvalST ICtx
-    go ictx _   _ | S.null (icCands ictx) = return ictx
-    go ictx ctx i = do
+    go :: ICtx -> {- SMT.Context -> -} Int -> EvalST ICtx
+    go ictx {- _ -}  _ | S.null (icCands ictx) = return ictx
+    go ictx {- ctx -} i = do
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do let ctx1 = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ctx
-                (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
-                let ictx' = trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $ ictx { icAssms = mempty }
-                    cands = S.toList $ icCands ictx
-                let i' = trace ("before candss " ++ show (seAppls $ SMT.ctxSymEnv $ knContext γ)) i
-                candss <- mapM (evalOne γ ictx' i') cands
+        else do ctx <- gets evKCtx
+                -- let ictx' = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ictx
+                liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
+                -- (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
+                -- let ictx' = trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $ ictx { icAssms = mempty }
+                let cands = S.toList $ icCands ictx
+--                k <- gets evKCtx
+--                let i' = trace ("before candss " ++ show (seAppls $ SMT.ctxSymEnv $ k)) i
+                candss <- mapM (evalOne γ ictx i) cands
                 us <- gets evNewEqualities
                 modify $ \st -> st { evNewEqualities = mempty }
                 let noCandidateChanged = and (zipWith eqCand candss cands)
@@ -347,15 +352,17 @@ evalCandsLoop cfg ictx0 ctx0 γ = go ictx0 ctx0 0
                 if S.null unknownEqs && noCandidateChanged
                       then return ictx
                       else do let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx `S.map` unknownEqs
-                              let ictx'' = ictx' { icEquals = icEquals ictx <> unknownEqs
+                              let ictx'' = ictx { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
-                              go (ictx'' { icCands = S.fromList (concat candss) }) ctx' (i' + 1)
+                              go (ictx'' { icCands = S.fromList (concat candss) }) {- ctx' -} (i + 1)
 
     testForInconsistentEnvironment :: EvalST Bool
     testForInconsistentEnvironment =
-      let k = knContext γ
-          k' = trace ("before testForInconsistentEnvironment " ++ show (seAppls $ SMT.ctxSymEnv k)) k in
-      liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) k'
+      liftSMT $ knPreds γ (knLams γ) PFalse
+      --do
+      --k <- gets evKCtx
+      --let k' = trace ("before testForInconsistentEnvironment " ++ show (seAppls $ SMT.ctxSymEnv k)) k
+      --liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) k'
 
     eqCand [e0] e1 = e0 == e1
     eqCand _ _ = False
@@ -440,17 +447,17 @@ updRes res  Nothing _ = res
 ----------------------------------------------------------------------------------------------
 
 updCtx :: InstEnv a -> SMT.Context -> ICtx -> Diff -> Maybe SubcId -> ICtx
-updCtx InstEnv{..} ieSMT ctx delta cidMb
-            = ctx { icAssms  = S.fromList (filter (not . isTautoPred) ctxEqs)
-                  , icCands  = S.fromList deANFedCands <> icCands  ctx
-                  , icSimpl  = icSimpl ctx <> econsts
-                  , icSubcId = cidMb
-                  , icANFs   = anfBinds
-                  , icLRWs   = mconcat $ icLRWs ctx : newLRWs
-                  }
+updCtx InstEnv{..} ieSMT ictx delta cidMb =
+  ictx { icAssms  = S.fromList (filter (not . isTautoPred) ctxEqs)
+       , icCands  = S.fromList deANFedCands <> icCands ictx
+       , icSimpl  = icSimpl ictx <> econsts
+       , icSubcId = cidMb
+       , icANFs   = anfBinds
+       , icLRWs   = mconcat $ icLRWs ictx : newLRWs
+       }
   where
     cands     = rhs:es
-    anfBinds  = bs : icANFs ctx
+    anfBinds  = bs : icANFs ictx
     econsts   = M.fromList $ findConstants ieKnowl es
     ctxEqs    = toSMT "updCtx" ieCfg ieSMT [] <$> L.nub
                   [ c | xr <- bs, c <- conjuncts (expr xr), null (Vis.kvarsExpr c) ]
@@ -465,8 +472,8 @@ updCtx InstEnv{..} ieSMT ctx delta cidMb
     deANFedCands =
       -- We only call 'deANF' if necessary.
       if not (null (getAutoRws ieKnowl cidMb))
-         || icExtensionalityFlag ctx
-         || icEtaBetaFlag ctx then
+         || icExtensionalityFlag ictx
+         || icEtaBetaFlag ictx then
         deANF anfBinds cands
       else
         cands
@@ -496,6 +503,7 @@ type EvEqualities = S.HashSet (Expr, Expr)
 data EvalEnv = EvalEnv
   { evEnv      :: !SymEnv
   , evElabF    :: ElabFlags
+  , evKCtx     :: SMT.Context
     -- | Equalities where we couldn't evaluate the guards
   , evPendingUnfoldings :: M.HashMap Expr Expr
   , evNewEqualities :: EvEqualities -- ^ Equalities discovered during a traversal of
@@ -523,6 +531,15 @@ defFuelCount :: Config -> FuelCount
 defFuelCount cfg = FC mempty (fuel cfg)
 
 type EvalST a = StateT EvalEnv IO a
+
+liftSMT :: SmtM a -> EvalST a
+liftSMT k =
+  do es <- get
+     let ctx = evKCtx es
+     (a, ctx') <- lift $ runStateT k ctx
+     put (es {evKCtx = ctx'})
+     pure a
+
 --------------------------------------------------------------------------------
 
 getAutoRws :: Knowledge -> Maybe SubcId -> [AutoRewrite]
@@ -819,7 +836,7 @@ evalRESTWithCache cacheRef γ ctx acc rp =
       Just exploredTerms -> do
         se <- liftIO (shouldExploreTerm exploredTerms exprs)
         if se then do
-          possibleRWs <- getRWs
+          possibleRWs <- liftSMT getRWs
           rws <- notVisitedFirst exploredTerms <$> filterM (liftIO . allowed) possibleRWs
           oldEqualities <- gets evNewEqualities
           modify $ \st -> st { evNewEqualities = mempty }
@@ -912,7 +929,7 @@ evalRESTWithCache cacheRef γ ctx acc rp =
           then
             do
               let getRW e ar = Rewrite.getRewrite (oc rp) rwArgs (c rp) e ar
-              let getRWs' s  = Mb.catMaybes <$> mapM (liftIO . runMaybeT . getRW s) autorws
+              let getRWs' s  = Mb.catMaybes <$> mapM (runMaybeT . getRW s) autorws
               concat <$> mapM getRWs' (subExprs exprs)
           else return []
 
@@ -1199,14 +1216,19 @@ isValidCached γ e = do
   case M.lookup e (evSMTCache env) of
     Nothing -> do
       let isFreeInE (s, _) = not (S.member s (exprSymbolsSet e))
-      b <- liftIO $ evalStateT (knPreds γ (knLams γ) e) (knContext γ)
+      --k <- gets evKCtx
+      --let k' = trace ("before isValidCached1 " ++ show (seAppls $ SMT.ctxSymEnv k)) k
+      -- b <- liftIO $ evalStateT (knPreds γ (knLams γ) e) k'
+      b <- liftSMT (knPreds γ (knLams γ) e)
       if b
         then do
           when (all isFreeInE (knLams γ)) $
             put (env { evSMTCache = M.insert e True (evSMTCache env) })
           return (Just True)
         else do
-          b2 <- liftIO $ evalStateT (knPreds γ (knLams γ) (PNot e)) (knContext γ)
+          -- let e' = trace ("before isValidCached2 " ++ show (seAppls $ SMT.ctxSymEnv k)) e
+          -- b2 <- liftIO $ evalStateT (knPreds γ (knLams γ) (PNot e')) k'
+          b2 <- liftSMT (knPreds γ (knLams γ) (PNot e))
           if b2
             then do
               when (all isFreeInE (knLams γ)) $
@@ -1228,7 +1250,6 @@ data Knowledge = KN
     -- user data declaration.
     knSims              :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
   , knAms               :: Map Symbol Equation -- ^ All function definitions
-  , knContext           :: SMT.Context
   , knPreds             :: [(Symbol, Sort)] -> Expr -> SmtM Bool
   , knLams              :: ![(Symbol, Sort)]
   , knSummary           :: ![(Symbol, Int)]     -- ^ summary of functions to be evaluates (knSims and knAsms) with their arity
@@ -1245,24 +1266,25 @@ data Knowledge = KN
 data IsUserDataSMeasure = NoUserDataSMeasure | UserDataSMeasure
   deriving (Eq, Show)
 
-isValid :: IORef (M.HashMap Expr Bool) -> Knowledge -> Expr -> IO Bool
+isValid :: IORef (M.HashMap Expr Bool) -> Knowledge -> Expr -> SmtM Bool
 isValid cacheRef γ e = do
     smtCache <- liftIO $ readIORef cacheRef
     case M.lookup e smtCache of
       Nothing -> do
-        b <- evalStateT (knPreds γ (knLams γ) e) (knContext γ)
+        -- k <- gets evKCtx
+        -- let k' = trace ("before isValid " ++ show (seAppls $ SMT.ctxSymEnv k)) ctx
+        b <- knPreds γ (knLams γ) e --) k'
         when b $
           liftIO $ writeIORef cacheRef (M.insert e True smtCache)
         return b
       Just b -> return b
 
-knowledge :: Config -> SMT.Context -> SInfo a -> Knowledge
-knowledge cfg ctx si = KN
+knowledge :: Config -> {- SMT.Context -> -} SInfo a -> Knowledge
+knowledge cfg {- ctx -} si = KN
   { knSims                     = Map.fromListWith (++) $
                                    [ (smDC rw, [(rw, NoUserDataSMeasure)]) | rw <- sims ] ++
                                    [ (smDC rw, [(rw, UserDataSMeasure)]) | rw <- dataSims ]
   , knAms                      = Map.fromList [(eqName eq, eq) | eq <- aenvEqs aenv]
-  , knContext                  = ctx
   , knPreds                    = askSMT cfg
   , knLams                     = []
   , knSummary                  =    ((\s -> (smName s, 1)) <$> sims)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -299,6 +299,7 @@ ple1 ie@InstEnv{..} ictx i res = do
   ctx <- get
   -- ieSMT <- get
   (ictx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ictx {- ieSMT -} ieKnowl) (ieEvEnv { evKCtx = ctx })
+  put $ evKCtx env
   let pendings = collectPendingUnfoldings env (icSubcId ictx)
       newEqs = pendings ++ S.toList (S.difference (icEquals ictx') (icEquals ictx))
   return (ictx', ie { ieEvEnv = env }, updCtxRes res i newEqs)
@@ -336,7 +337,7 @@ evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do ctx <- gets evKCtx
+        else do -- ctx <- gets evKCtx
                 -- let ictx' = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ictx
                 liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
                 -- (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
@@ -352,7 +353,8 @@ evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
                     unknownEqs = us `S.difference` icEquals ictx
                 if S.null unknownEqs && noCandidateChanged
                       then return ictx
-                      else do let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx `S.map` unknownEqs
+                      else do ctx' <- gets evKCtx
+                              let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx' `S.map` unknownEqs
                               let ictx'' = ictx { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
                               go (ictx'' { icCands = S.fromList (concat candss) }) {- ctx' -} (i + 1)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -340,11 +340,12 @@ evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
                 -- let ictx' = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ictx
                 liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
                 -- (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
-                -- let ictx' = trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $ ictx { icAssms = mempty }
+                let ictx' = -- trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $
+                            ictx { icAssms = mempty }
                 let cands = S.toList $ icCands ictx
 --                k <- gets evKCtx
 --                let i' = trace ("before candss " ++ show (seAppls $ SMT.ctxSymEnv $ k)) i
-                candss <- mapM (evalOne γ ictx i) cands
+                candss <- mapM (evalOne γ ictx' i) cands
                 us <- gets evNewEqualities
                 modify $ \st -> st { evNewEqualities = mempty }
                 let noCandidateChanged = and (zipWith eqCand candss cands)

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -659,7 +659,7 @@ eval γ ctx et = go
       let (xs', fe) = feSeq xs
       return (f xs', fe)
 
--- | 'evalELamb' produces equations that preserve the context of a rewrite
+-- | 'evalELam' produces equations that preserve the context of a rewrite
 -- so equations include any necessary lambda bindings.
 evalELam :: Knowledge -> ICtx -> EvalType -> (Symbol, Sort) -> Expr -> EvalST (Expr, FinalExpand)
 evalELam γ ctx et (x, s) e

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -69,6 +69,8 @@ import qualified Data.Maybe           as Mb
 import qualified Data.Set as Set
 import           Text.PrettyPrint.HughesPJ.Compat
 
+import Debug.Trace (trace)
+
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
 
@@ -283,7 +285,7 @@ withAssms env ctx delta cidMb act = do
   let assms = icAssms ctx'
 
   SMT.smtBracket "PLE.withAssms" $ do
-    forM_ assms SMT.smtAssert
+    forM_ assms SMT.smtAssertDecl
     act ctx' { icAssms = mempty }
 
 -- | @ple1@ performs the PLE at a single "node" in the Trie
@@ -332,10 +334,12 @@ evalCandsLoop cfg ictx0 ctx0 γ = go ictx0 ctx0 0
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx
-                let ictx' = ictx { icAssms = mempty }
+        else do let ctx1 = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ctx
+                (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
+                let ictx' = trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $ ictx { icAssms = mempty }
                     cands = S.toList $ icCands ictx
-                candss <- mapM (evalOne γ ictx' i) cands
+                let i' = trace ("before candss " ++ show (seAppls $ SMT.ctxSymEnv $ knContext γ)) i
+                candss <- mapM (evalOne γ ictx' i') cands
                 us <- gets evNewEqualities
                 modify $ \st -> st { evNewEqualities = mempty }
                 let noCandidateChanged = and (zipWith eqCand candss cands)
@@ -345,10 +349,13 @@ evalCandsLoop cfg ictx0 ctx0 γ = go ictx0 ctx0 0
                       else do let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx `S.map` unknownEqs
                               let ictx'' = ictx' { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
-                              go (ictx'' { icCands = S.fromList (concat candss) }) ctx' (i + 1)
+                              go (ictx'' { icCands = S.fromList (concat candss) }) ctx' (i' + 1)
 
+    testForInconsistentEnvironment :: EvalST Bool
     testForInconsistentEnvironment =
-      liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) (knContext γ)
+      let k = knContext γ
+          k' = trace ("before testForInconsistentEnvironment " ++ show (seAppls $ SMT.ctxSymEnv k)) k in
+      liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) k'
 
     eqCand [e0] e1 = e0 == e1
     eqCand _ _ = False
@@ -1247,7 +1254,7 @@ isValid cacheRef γ e = do
         when b $
           liftIO $ writeIORef cacheRef (M.insert e True smtCache)
         return b
-      mb -> return (mb == Just True)
+      Just b -> return b
 
 knowledge :: Config -> SMT.Context -> SInfo a -> Knowledge
 knowledge cfg ctx si = KN
@@ -1349,9 +1356,8 @@ partitionUserDataConstructorSelectors dds rws = L.partition isSelector rws
 
 withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k =
-  bracket acquire release $ \ctx ->
-  do _   <- evalStateT SMT.smtPush ctx
-     evalStateT k ctx
+  bracket acquire release $
+    evalStateT $ SMT.smtPush >> k   -- TODO why is there no pop?
   where
     acquire = SMT.makeContextWithSEnv cfg file env defns
     release = SMT.cleanupContext

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -34,6 +34,7 @@ import           Language.Fixpoint.Types.Solutions (CMap)
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import qualified Language.Fixpoint.Misc          as Misc
 import qualified Language.Fixpoint.Smt.Interface as SMT
+import           Language.Fixpoint.Smt.Types (SmtM)
 import           Language.Fixpoint.Defunctionalize
 import           Language.Fixpoint.Solver.EnvironmentReduction (inlineInExpr, undoANF)
 import qualified Language.Fixpoint.Utils.Files   as Files
@@ -52,6 +53,7 @@ import Language.REST.RuntimeTerm as RT
 import Language.REST.SMT (withZ3, SolverHandle)
 
 import           Control.Monad (filterM, foldM, forM_, when, replicateM)
+import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (second)
@@ -79,11 +81,12 @@ instantiate cfg fi' subcIds = do
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
                (cm info)
     let t  = mkCTrie (M.toList cs)                                          -- 1. BUILD the Trie
-    res   <- withRESTSolver $ \solver -> withProgress (1 + M.size cs) $
-               withCtx cfg file sEnv (defns fi') $ \ctx -> do
-                  env <- instEnv cfg info cs solver ctx
+    res   <- withRESTSolver $ \solver ->
+               withProgress (1 + M.size cs) $
+               withCtx cfg file sEnv (defns fi') $
+               do env <- instEnv cfg info cs solver
                   pleTrie t env                                             -- 2. TRAVERSE Trie to compute InstRes
-    savePLEEqualities cfg info sEnv res
+    liftIO $ savePLEEqualities cfg info sEnv res
     return $ resSInfo cfg sEnv info res                                     -- 3. STRENGTHEN SInfo using InstRes
   where
     withRESTSolver :: (Maybe SolverHandle -> IO a) -> IO a
@@ -122,10 +125,11 @@ savePLEEqualities cfg info sEnv res = when (save cfg) $ do
 
 -------------------------------------------------------------------------------
 -- | Step 1a: @instEnv@ sets up the incremental-PLE environment
-instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SMT.Context -> IO (InstEnv a)
-instEnv cfg info cs restSolver ctx = do
-    refRESTCache <- newIORef mempty
-    refRESTSatCache <- newIORef mempty
+instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SmtM (InstEnv a)
+instEnv cfg info cs restSolver = do
+    ctx <- ask
+    refRESTCache <- liftIO $ newIORef mempty
+    refRESTSatCache <- liftIO $ newIORef mempty
     let
         restOrd = FC.restOC cfg
         oc0 = ordConstraints restOrd $ Mb.fromJust restSolver
@@ -212,7 +216,7 @@ mkCTrie ics  = T.fromList [ (cBinds c, i) | (i, c) <- ics ]
 
 ----------------------------------------------------------------------------------------------
 -- | Step 2: @pleTrie@ walks over the @CTrie@ to actually do the incremental-PLE
-pleTrie :: CTrie -> InstEnv a -> IO InstRes
+pleTrie :: CTrie -> InstEnv a -> SmtM InstRes
 pleTrie t env = loopT env ctx0 diff0 Nothing res0 t
   where
     diff0        = []
@@ -238,7 +242,7 @@ loopT
                   --   'Nothing' when this is the top-level trie.
   -> InstRes
   -> CTrie
-  -> IO InstRes
+  -> SmtM InstRes
 loopT env ctx delta i res t = case t of
   T.Node []  -> return res
   T.Node [b] -> loopB env ctx delta i res b
@@ -254,11 +258,11 @@ loopB
                   --   'Nothing' when this is a branch of the top-level trie.
   -> InstRes
   -> CBranch
-  -> IO InstRes
+  -> SmtM InstRes
 loopB env ctx delta iMb res b = case b of
   T.Bind i t -> loopT env ctx (i:delta) (Just i) res t
   T.Val cid  -> withAssms env ctx delta (Just cid) $ \ctx' -> do
-                  progressTick
+                  liftIO progressTick
                   (\(_, _, r) -> r) <$> ple1 env ctx' iMb res
 
 -- | Adds to @ctx@ candidate expressions to unfold from the bindings in @delta@
@@ -271,13 +275,13 @@ loopB env ctx delta iMb res b = case b of
 -- Pushes assumptions from the modified context to the SMT solver, runs @act@,
 -- and then pops the assumptions.
 --
-withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> IO b) -> IO b
-withAssms env@InstEnv{..} ctx delta cidMb act = do
+withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> SmtM b
+withAssms env ctx delta cidMb act = do
   let ctx' = updCtx env ctx delta cidMb
   let assms = icAssms ctx'
 
-  SMT.smtBracket ieSMT "PLE.evaluate" $ do
-    forM_ assms (SMT.smtAssert ieSMT)
+  SMT.smtBracket "PLE.evaluate" $ do
+    forM_ assms SMT.smtAssert
     act ctx' { icAssms = mempty }
 
 -- | @ple1@ performs the PLE at a single "node" in the Trie
@@ -285,9 +289,9 @@ withAssms env@InstEnv{..} ctx delta cidMb act = do
 -- It will generate equalities for all function invocations in the candidates
 -- in @ctx@ for which definitions are known. The function definitions are in
 -- @ieKnowl@.
-ple1 :: InstEnv a -> ICtx -> Maybe BindId -> InstRes -> IO (ICtx, InstEnv a, InstRes)
+ple1 :: InstEnv a -> ICtx -> Maybe BindId -> InstRes -> SmtM (ICtx, InstEnv a, InstRes)
 ple1 ie@InstEnv{..} ctx i res = do
-  (ctx', env) <- runStateT (evalCandsLoop ieCfg ctx ieSMT ieKnowl) ieEvEnv
+  (ctx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ctx ieSMT ieKnowl) ieEvEnv
   let pendings = collectPendingUnfoldings env (icSubcId ctx)
       newEqs = pendings ++ S.toList (S.difference (icEquals ctx') (icEquals ctx))
   return (ctx', ie { ieEvEnv = env }, updCtxRes res i newEqs)
@@ -324,7 +328,7 @@ evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do liftIO $ SMT.smtAssert ctx (pAndNoDedup (S.toList $ icAssms ictx))
+        else do liftIO $ runReaderT (SMT.smtAssert (pAndNoDedup (S.toList $ icAssms ictx))) ctx
                 let ictx' = ictx { icAssms = mempty }
                     cands = S.toList $ icCands ictx
                 candss <- mapM (evalOne γ ictx' i) cands
@@ -340,7 +344,7 @@ evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
                               go (ictx'' { icCands = S.fromList (concat candss) }) (i + 1)
 
     testForInconsistentEnvironment =
-      liftIO $ knPreds γ (knContext γ) (knLams γ) PFalse
+      liftIO $ runReaderT (knPreds γ (knLams γ) PFalse) (knContext γ)
 
     eqCand [e0] e1 = e0 == e1
     eqCand _ _ = False
@@ -1184,14 +1188,14 @@ isValidCached γ e = do
   case M.lookup e (evSMTCache env) of
     Nothing -> do
       let isFreeInE (s, _) = not (S.member s (exprSymbolsSet e))
-      b <- liftIO $ knPreds γ (knContext γ) (knLams γ) e
+      b <- liftIO $ runReaderT (knPreds γ (knLams γ) e) (knContext γ)
       if b
         then do
           when (all isFreeInE (knLams γ)) $
             put (env { evSMTCache = M.insert e True (evSMTCache env) })
           return (Just True)
         else do
-          b2 <- liftIO $ knPreds γ (knContext γ) (knLams γ) (PNot e)
+          b2 <- liftIO $ runReaderT (knPreds γ (knLams γ) (PNot e)) (knContext γ)
           if b2
             then do
               when (all isFreeInE (knLams γ)) $
@@ -1214,7 +1218,7 @@ data Knowledge = KN
     knSims              :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
   , knAms               :: Map Symbol Equation -- ^ All function definitions
   , knContext           :: SMT.Context
-  , knPreds             :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
+  , knPreds             :: [(Symbol, Sort)] -> Expr -> SmtM Bool
   , knLams              :: ![(Symbol, Sort)]
   , knSummary           :: ![(Symbol, Int)]     -- ^ summary of functions to be evaluates (knSims and knAsms) with their arity
   , knDCs               :: !(S.HashSet Symbol)  -- ^ data constructors drawn from Rewrite
@@ -1232,12 +1236,12 @@ data IsUserDataSMeasure = NoUserDataSMeasure | UserDataSMeasure
 
 isValid :: IORef (M.HashMap Expr Bool) -> Knowledge -> Expr -> IO Bool
 isValid cacheRef γ e = do
-    smtCache <- readIORef cacheRef
+    smtCache <- liftIO $ readIORef cacheRef
     case M.lookup e smtCache of
       Nothing -> do
-        b <- knPreds γ (knContext γ) (knLams γ) e
+        b <- runReaderT (knPreds γ (knLams γ) e) (knContext γ)
         when b $
-          writeIORef cacheRef (M.insert e True smtCache)
+          liftIO $ writeIORef cacheRef (M.insert e True smtCache)
         return b
       mb -> return (mb == Just True)
 
@@ -1248,7 +1252,7 @@ knowledge cfg ctx si = KN
                                    [ (smDC rw, [(rw, UserDataSMeasure)]) | rw <- dataSims ]
   , knAms                      = Map.fromList [(eqName eq, eq) | eq <- aenvEqs aenv]
   , knContext                  = ctx
-  , knPreds                    = askSMT  cfg
+  , knPreds                    = askSMT cfg
   , knLams                     = []
   , knSummary                  =    ((\s -> (smName s, 1)) <$> sims)
                                  ++ ((\s -> (eqName s, length (eqArgs s))) <$> aenvEqs aenv)
@@ -1339,12 +1343,12 @@ partitionUserDataConstructorSelectors dds rws = L.partition isSelector rws
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> (SMT.Context -> IO a) -> IO a
+withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k = do
-  ctx <- SMT.makeContextWithSEnv cfg file env defns
-  _   <- SMT.smtPush ctx
-  res <- k ctx
-  SMT.cleanupContext ctx
+  ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
+  _   <- runReaderT SMT.smtPush ctx
+  res <- runReaderT k ctx
+  liftIO $ SMT.cleanupContext ctx
   return res
 
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -127,7 +127,7 @@ savePLEEqualities cfg info sEnv res = when (save cfg) $ do
 -- | Step 1a: @instEnv@ sets up the incremental-PLE environment
 instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SmtM (InstEnv a)
 instEnv cfg info cs restSolver = do
-    ctx <- ask
+    ctx <- get
     refRESTCache <- liftIO $ newIORef mempty
     refRESTSatCache <- liftIO $ newIORef mempty
     let
@@ -328,7 +328,7 @@ evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do liftIO $ runReaderT (SMT.smtAssert (pAndNoDedup (S.toList $ icAssms ictx))) ctx
+        else do liftIO $ evalStateT (SMT.smtAssert (pAndNoDedup (S.toList $ icAssms ictx))) ctx
                 let ictx' = ictx { icAssms = mempty }
                     cands = S.toList $ icCands ictx
                 candss <- mapM (evalOne γ ictx' i) cands
@@ -344,7 +344,7 @@ evalCandsLoop cfg ictx0 ctx γ = go ictx0 0
                               go (ictx'' { icCands = S.fromList (concat candss) }) (i + 1)
 
     testForInconsistentEnvironment =
-      liftIO $ runReaderT (knPreds γ (knLams γ) PFalse) (knContext γ)
+      liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) (knContext γ)
 
     eqCand [e0] e1 = e0 == e1
     eqCand _ _ = False
@@ -1188,14 +1188,14 @@ isValidCached γ e = do
   case M.lookup e (evSMTCache env) of
     Nothing -> do
       let isFreeInE (s, _) = not (S.member s (exprSymbolsSet e))
-      b <- liftIO $ runReaderT (knPreds γ (knLams γ) e) (knContext γ)
+      b <- liftIO $ evalStateT (knPreds γ (knLams γ) e) (knContext γ)
       if b
         then do
           when (all isFreeInE (knLams γ)) $
             put (env { evSMTCache = M.insert e True (evSMTCache env) })
           return (Just True)
         else do
-          b2 <- liftIO $ runReaderT (knPreds γ (knLams γ) (PNot e)) (knContext γ)
+          b2 <- liftIO $ evalStateT (knPreds γ (knLams γ) (PNot e)) (knContext γ)
           if b2
             then do
               when (all isFreeInE (knLams γ)) $
@@ -1239,7 +1239,7 @@ isValid cacheRef γ e = do
     smtCache <- liftIO $ readIORef cacheRef
     case M.lookup e smtCache of
       Nothing -> do
-        b <- runReaderT (knPreds γ (knLams γ) e) (knContext γ)
+        b <- evalStateT (knPreds γ (knLams γ) e) (knContext γ)
         when b $
           liftIO $ writeIORef cacheRef (M.insert e True smtCache)
         return b
@@ -1346,8 +1346,8 @@ partitionUserDataConstructorSelectors dds rws = L.partition isSelector rws
 withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
 withCtx cfg file env defns k = do
   ctx <- liftIO $ SMT.makeContextWithSEnv cfg file env defns
-  _   <- runReaderT SMT.smtPush ctx
-  res <- runReaderT k ctx
+  _   <- evalStateT SMT.smtPush ctx
+  res <- evalStateT k ctx
   liftIO $ SMT.cleanupContext ctx
   return res
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -54,7 +54,6 @@ import Language.REST.SMT (withZ3, SolverHandle)
 
 import           Control.Exception.Base (bracket)
 import           Control.Monad (filterM, foldM, forM_, when, replicateM)
-import           Control.Monad.Reader
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (second)
@@ -68,8 +67,6 @@ import qualified Data.Map as Map
 import qualified Data.Maybe           as Mb
 import qualified Data.Set as Set
 import           Text.PrettyPrint.HughesPJ.Compat
-
---import Debug.Trace (trace)
 
 mytracepp :: (PPrint a) => String -> a -> a
 mytracepp = notracepp
@@ -165,11 +162,10 @@ instEnv cfg info cs restSolver = do
               }
     return $ InstEnv
        { ieCfg = cfg
---       , ieSMT = ctx
        , ieBEnv = coerceBindEnv ef (bs info)
        , ieAenv = ae info
        , ieCstrs = cs
-       , ieKnowl = knowledge cfg {- ctx -} info
+       , ieKnowl = knowledge cfg info
        , ieEvEnv = s0
        , ieLRWs  = lrws info
        }
@@ -297,8 +293,7 @@ withAssms env ctx delta cidMb act = do
 ple1 :: InstEnv a -> ICtx -> Maybe BindId -> InstRes -> SmtM (ICtx, InstEnv a, InstRes)
 ple1 ie@InstEnv{..} ictx i res = do
   ctx <- get
-  -- ieSMT <- get
-  (ictx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ictx {- ieSMT -} ieKnowl) (ieEvEnv { evKCtx = ctx })
+  (ictx', env) <- liftIO $ runStateT (evalCandsLoop ieCfg ictx ieKnowl) (ieEvEnv { evKCtx = ctx })
   put $ evKCtx env
   let pendings = collectPendingUnfoldings env (icSubcId ictx)
       newEqs = pendings ++ S.toList (S.difference (icEquals ictx') (icEquals ictx))
@@ -328,24 +323,18 @@ evalToSMT msg cfg ctx (e1,e2) = toSMT ("evalToSMT:" ++ msg) cfg ctx [] (EEq e1 e
 -- > until no new equalities are discovered
 -- >       or the environment becomes inconsistent
 --
-evalCandsLoop :: Config -> ICtx -> {- SMT.Context -> -} Knowledge -> EvalST ICtx
-evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
+evalCandsLoop :: Config -> ICtx -> Knowledge -> EvalST ICtx
+evalCandsLoop cfg ictx0 γ = go ictx0 0
   where
-    go :: ICtx -> {- SMT.Context -> -} Int -> EvalST ICtx
-    go ictx {- _ -}  _ | S.null (icCands ictx) = return ictx
-    go ictx {- ctx -} i = do
+    go :: ICtx -> Int -> EvalST ICtx
+    go ictx _ | S.null (icCands ictx) = return ictx
+    go ictx i = do
       inconsistentEnv <- testForInconsistentEnvironment
       if inconsistentEnv
         then return ictx
-        else do -- ctx <- gets evKCtx
-                -- let ictx' = trace ("before pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx)) ictx
-                liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
-                -- (_, ctx') <- liftIO $ runStateT (SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))) ctx1
-                let ictx' = -- trace ("after pandnoded " ++ show (seAppls $ SMT.ctxSymEnv ctx')) $
-                            ictx { icAssms = mempty }
+        else do liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
+                let ictx' = ictx { icAssms = mempty }
                 let cands = S.toList $ icCands ictx
---                k <- gets evKCtx
---                let i' = trace ("before candss " ++ show (seAppls $ SMT.ctxSymEnv $ k)) i
                 candss <- mapM (evalOne γ ictx' i) cands
                 us <- gets evNewEqualities
                 modify $ \st -> st { evNewEqualities = mempty }
@@ -357,15 +346,11 @@ evalCandsLoop cfg ictx0 {- ctx0 -} γ = go ictx0 {- ctx0 -} 0
                               let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx' `S.map` unknownEqs
                               let ictx'' = ictx { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
-                              go (ictx'' { icCands = S.fromList (concat candss) }) {- ctx' -} (i + 1)
+                              go (ictx'' { icCands = S.fromList (concat candss) }) (i + 1)
 
     testForInconsistentEnvironment :: EvalST Bool
     testForInconsistentEnvironment =
       liftSMT $ knPreds γ (knLams γ) PFalse
-      --do
-      --k <- gets evKCtx
-      --let k' = trace ("before testForInconsistentEnvironment " ++ show (seAppls $ SMT.ctxSymEnv k)) k
-      --liftIO $ evalStateT (knPreds γ (knLams γ) PFalse) k'
 
     eqCand [e0] e1 = e0 == e1
     eqCand _ _ = False
@@ -388,7 +373,6 @@ resSInfo cfg env info res = strengthenBinds info res'
 
 data InstEnv a = InstEnv
   { ieCfg   :: !Config
---  , ieSMT   :: !SMT.Context
   , ieBEnv  :: !(BindEnv a)
   , ieAenv  :: !AxiomEnv
   , ieCstrs :: !(CMap (SimpC a))
@@ -1219,9 +1203,6 @@ isValidCached γ e = do
   case M.lookup e (evSMTCache env) of
     Nothing -> do
       let isFreeInE (s, _) = not (S.member s (exprSymbolsSet e))
-      --k <- gets evKCtx
-      --let k' = trace ("before isValidCached1 " ++ show (seAppls $ SMT.ctxSymEnv k)) k
-      -- b <- liftIO $ evalStateT (knPreds γ (knLams γ) e) k'
       b <- liftSMT (knPreds γ (knLams γ) e)
       if b
         then do
@@ -1229,8 +1210,6 @@ isValidCached γ e = do
             put (env { evSMTCache = M.insert e True (evSMTCache env) })
           return (Just True)
         else do
-          -- let e' = trace ("before isValidCached2 " ++ show (seAppls $ SMT.ctxSymEnv k)) e
-          -- b2 <- liftIO $ evalStateT (knPreds γ (knLams γ) (PNot e')) k'
           b2 <- liftSMT (knPreds γ (knLams γ) (PNot e))
           if b2
             then do
@@ -1274,16 +1253,14 @@ isValid cacheRef γ e = do
     smtCache <- liftIO $ readIORef cacheRef
     case M.lookup e smtCache of
       Nothing -> do
-        -- k <- gets evKCtx
-        -- let k' = trace ("before isValid " ++ show (seAppls $ SMT.ctxSymEnv k)) ctx
-        b <- knPreds γ (knLams γ) e --) k'
+        b <- knPreds γ (knLams γ) e
         when b $
           liftIO $ writeIORef cacheRef (M.insert e True smtCache)
         return b
       Just b -> return b
 
-knowledge :: Config -> {- SMT.Context -> -} SInfo a -> Knowledge
-knowledge cfg {- ctx -} si = KN
+knowledge :: Config -> SInfo a -> Knowledge
+knowledge cfg si = KN
   { knSims                     = Map.fromListWith (++) $
                                    [ (smDC rw, [(rw, NoUserDataSMeasure)]) | rw <- sims ] ++
                                    [ (smDC rw, [(rw, UserDataSMeasure)]) | rw <- dataSims ]

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -334,7 +334,7 @@ evalCandsLoop cfg ictx0 γ = go ictx0 0
         then return ictx
         else do liftSMT $ SMT.smtAssertDecl (pAndNoDedup (S.toList $ icAssms ictx))
                 let ictx' = ictx { icAssms = mempty }
-                let cands = S.toList $ icCands ictx
+                    cands = S.toList $ icCands ictx
                 candss <- mapM (evalOne γ ictx' i) cands
                 us <- gets evNewEqualities
                 modify $ \st -> st { evNewEqualities = mempty }
@@ -344,7 +344,7 @@ evalCandsLoop cfg ictx0 γ = go ictx0 0
                       then return ictx
                       else do ctx' <- gets evKCtx
                               let eqsSMT = evalToSMT "evalCandsLoop" cfg ctx' `S.map` unknownEqs
-                              let ictx'' = ictx { icEquals = icEquals ictx <> unknownEqs
+                                  ictx'' = ictx { icEquals = icEquals ictx <> unknownEqs
                                                  , icAssms  = S.filter (not . isTautoPred) eqsSMT }
                               go (ictx'' { icCands = S.fromList (concat candss) }) (i + 1)
 
@@ -1203,14 +1203,14 @@ isValidCached γ e = do
   case M.lookup e (evSMTCache env) of
     Nothing -> do
       let isFreeInE (s, _) = not (S.member s (exprSymbolsSet e))
-      b <- liftSMT (knPreds γ (knLams γ) e)
+      b <- liftSMT $ knPreds γ (knLams γ) e
       if b
         then do
           when (all isFreeInE (knLams γ)) $
             put (env { evSMTCache = M.insert e True (evSMTCache env) })
           return (Just True)
         else do
-          b2 <- liftSMT (knPreds γ (knLams γ) (PNot e))
+          b2 <- liftSMT $ knPreds γ (knLams γ) (PNot e)
           if b2
             then do
               when (all isFreeInE (knLams γ)) $

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -21,8 +21,6 @@ module Language.Fixpoint.Solver.Rewrite
 
 import           Control.Monad (guard)
 import           Control.Monad.Trans.Maybe
--- import           Control.Monad.State hiding (lift)
-
 import           Data.Hashable
 import qualified Data.HashMap.Strict  as M
 import qualified Data.List            as L
@@ -32,8 +30,7 @@ import           GHC.Generics
 import           Text.PrettyPrint (text)
 import           Language.Fixpoint.Types.Config (RESTOrdering(..))
 import           Language.Fixpoint.Types hiding (simplify)
-import           Language.Fixpoint.Smt.Types (SmtM {-, Context-})
-
+import           Language.Fixpoint.Smt.Types (SmtM)
 import           Language.REST
 import           Language.REST.KBO (kbo)
 import           Language.REST.LPO (lpo)

--- a/src/Language/Fixpoint/Solver/Rewrite.hs
+++ b/src/Language/Fixpoint/Solver/Rewrite.hs
@@ -21,6 +21,8 @@ module Language.Fixpoint.Solver.Rewrite
 
 import           Control.Monad (guard)
 import           Control.Monad.Trans.Maybe
+-- import           Control.Monad.State hiding (lift)
+
 import           Data.Hashable
 import qualified Data.HashMap.Strict  as M
 import qualified Data.List            as L
@@ -30,6 +32,8 @@ import           GHC.Generics
 import           Text.PrettyPrint (text)
 import           Language.Fixpoint.Types.Config (RESTOrdering(..))
 import           Language.Fixpoint.Types hiding (simplify)
+import           Language.Fixpoint.Smt.Types (SmtM {-, Context-})
+
 import           Language.REST
 import           Language.REST.KBO (kbo)
 import           Language.REST.LPO (lpo)
@@ -54,7 +58,7 @@ data RWTerminationOpts =
   | RWTerminationCheckDisabled
 
 data RewriteArgs = RWArgs
- { isRWValid          :: Expr -> IO Bool
+ { isRWValid          :: Expr -> SmtM Bool
  , rwTerminationOpts  :: RWTerminationOpts
  }
 
@@ -128,7 +132,7 @@ getRewrite ::
   -> oc
   -> SubExpr
   -> AutoRewrite
-  -> MaybeT IO ((Expr, Expr), Expr, oc)
+  -> MaybeT SmtM ((Expr, Expr), Expr, oc)
 getRewrite aoc rwArgs c (subE, toE) (AutoRewrite args lhs rhs) =
   do
     su <- MaybeT $ return $ unify freeVars lhs subE
@@ -145,7 +149,7 @@ getRewrite aoc rwArgs c (subE, toE) (AutoRewrite args lhs rhs) =
           (eqn, expr', c')
       RWTerminationCheckDisabled -> (eqn, expr', c)
   where
-    check :: Expr -> MaybeT IO ()
+    check :: Expr -> MaybeT SmtM ()
     check e = do
       valid <- MaybeT $ Just <$> isRWValid rwArgs e
       guard valid

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -134,6 +134,11 @@ solve_ cfg fi s0 ks wkl = do
   (fi1, s4, res1) <- case resStatus res0 of  {- first run the interpreter -}
     Unsafe _ bads | not (noLazyPLE cfg) && rewriteAxioms cfg && interpreter cfg -> do
       fi1 <- doInterpret cfg fi (map fst $ mytrace ("before the Interpreter " ++ show (length bads) ++ " constraints remain") bads)
+      -- TODO the `clearApplys` is a workaround needed because `sendConcreteBindingsToSMT`
+      -- seems to not remove the tags introduced in its bracket from the tag stack,
+      -- meanwhile the SMT solver pops the corresponding definition. The result is
+      -- that when the same definition needs to re-emitted in the interpreter/PLE,
+      -- LH thinks it's still in the context, which causes the SMT solver to crash.
       clearApplys
       (s4, res1) <- sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s4    <- {- SCC "sol-refine" -} refine bindingsInSmt s3 wkl

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -40,10 +40,12 @@ import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
 import qualified Language.Fixpoint.Types.Config as C
 import Language.Fixpoint.Solver.Interpreter (instInterpreter)
 import Language.Fixpoint.Solver.Instantiate (instantiate)
-import Debug.Trace                      (trace)
+-- import Debug.Trace                      (trace)
 
 mytrace :: String -> a -> a
-mytrace s x = trace s x
+mytrace
+  {- s x = trace s x -}
+  _ x = x
 
 --------------------------------------------------------------------------------
 solve :: (NFData a, F.Fixpoint a, Show a, F.Loc a) => Config -> F.SInfo a -> IO (F.Result (Integer, a))

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -134,7 +134,8 @@ solve_ cfg fi s0 ks wkl = do
   (fi1, s4, res1) <- case resStatus res0 of  {- first run the interpreter -}
     Unsafe _ bads | not (noLazyPLE cfg) && rewriteAxioms cfg && interpreter cfg -> do
       fi1 <- doInterpret cfg fi (map fst $ mytrace ("before the Interpreter " ++ show (length bads) ++ " constraints remain") bads)
-      (s4, res1) <-  sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
+      clearApplys
+      (s4, res1) <- sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s4    <- {- SCC "sol-refine" -} refine bindingsInSmt s3 wkl
         res1  <- {- SCC "sol-result" -} result bindingsInSmt cfg wkl s4
         return (s4, res1)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -40,10 +40,10 @@ import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
 import qualified Language.Fixpoint.Types.Config as C
 import Language.Fixpoint.Solver.Interpreter (instInterpreter)
 import Language.Fixpoint.Solver.Instantiate (instantiate)
---import Debug.Trace                      (trace)
+import Debug.Trace                      (trace)
 
 mytrace :: String -> a -> a
-mytrace _ x = {- trace s -} x
+mytrace s x = trace s x
 
 --------------------------------------------------------------------------------
 solve :: (NFData a, F.Fixpoint a, Show a, F.Loc a) => Config -> F.SInfo a -> IO (F.Result (Integer, a))
@@ -141,7 +141,9 @@ solve_ cfg fi s0 ks wkl = do
 
   res2  <- case resStatus res1 of  {- then run normal PLE on remaining unsolved constraints -}
     Unsafe _ bads2 | not (noLazyPLE cfg) && rewriteAxioms cfg -> do
-      doPLE cfg fi1 (map fst $ mytrace ("before z3 PLE " ++ show (length bads2) ++ " constraints remain") bads2)
+      doPLE cfg fi1 (map fst $ mytrace ("before PLE " ++ show (length bads2) ++ " constraints remain") bads2)
+      -- TODO reset the ix stack too?
+      clearApplys
       sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s5    <- {- SCC "sol-refine" -} refine bindingsInSmt s4 wkl
         result bindingsInSmt cfg wkl s5

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -44,7 +44,7 @@ import Language.Fixpoint.Solver.Instantiate (instantiate)
 
 mytrace :: String -> a -> a
 mytrace
-  {- s x = trace s x -}
+  -- s x = trace s x
   _ x = x
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -72,7 +72,7 @@ import qualified Data.Store              as S
 import qualified Data.HashMap.Strict      as M
 import qualified Language.Fixpoint.Misc   as Misc
 
-import Debug.Trace
+-- import Debug.Trace
 
 --------------------------------------------------------------------------------
 -- | 'Raw' is the low-level representation for SMT values
@@ -261,7 +261,8 @@ symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> SymM Text
 symbolAtSmtName mkSym e fs =
   -- formerly: intSymbol mkSym . funcSortIndex env e
   do fsi <- funcSortIndex e fs
-     let fsi' = trace ("sasn " ++ show fsi) fsi
+     let fsi' = -- trace ("sasn " ++ show fsi)
+                fsi
      pure $ appendSymbolText mkSym . Text.pack . show $ fsi'
 {-# SCC symbolAtSmtName #-}
 

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -20,6 +20,7 @@ module Language.Fixpoint.Types.Theories (
 
     -- * Theory Sorts
     , SmtSort (..)
+    , FuncSort
     , sortSmtSort
     , isIntSmtSort
 

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -113,6 +113,11 @@ data SymEnv = SymEnv
 {- type FuncSort = {v:Sort | isFFunc v} @-}
 type FuncSort = (SmtSort, SmtSort)
 
+-- | Generating SMT expressions is a stateful process because new symbols ('apply', 'coerce',
+--   'smt_lambda' and 'lam_arg') need to be emitted with unique ids for each newly encountered
+--   function sort. The 'SymM' monad carries the 'SymEnv' state required to track the ids.
+--   The state updates are performed in `L.F.Smt.Serialize` (functions `smt2App`, `smt2Coerc`,
+--   `smt2Lam` and `smtLamArg`, correspondingly).
 type SymM a = State SymEnv a
 
 instance NFData   SymEnv

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -47,7 +47,8 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
-import           Control.Monad.Reader
+--import           Control.Monad.Reader
+import           Control.Monad.State
 import           Control.DeepSeq
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
@@ -86,7 +87,7 @@ data SymEnv = SymEnv
 {- type FuncSort = {v:Sort | isFFunc v} @-}
 type FuncSort = (SmtSort, SmtSort)
 
-type SymM a = Reader SymEnv a
+type SymM a = State SymEnv a
 
 instance NFData   SymEnv
 instance S.Store SymEnv
@@ -220,7 +221,7 @@ insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
 symbolAtName :: (PPrint a) => Symbol -> a -> Sort -> SymM Text
 symbolAtName mkSym e s =
-  do env <- ask
+  do env <- get
      symbolAtSmtName mkSym e (ffuncSort env s)
 {-# SCC symbolAtName #-}
 
@@ -232,7 +233,7 @@ symbolAtSmtName mkSym e fs =
 
 funcSortIndex :: (PPrint a) => a -> FuncSort -> SymM Int
 funcSortIndex e fs =
-  do env <- ask
+  do env <- get
      let aps = seAppls env
      pure $ M.lookupDefault err fs aps
 {-

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -54,7 +54,7 @@ import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Sorts
-import           Language.Fixpoint.Types.Errors
+-- import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Types.Environments
 
 import           Text.PrettyPrint.HughesPJ.Compat
@@ -64,6 +64,8 @@ import qualified Data.Text                as Text
 import qualified Data.Store              as S
 import qualified Data.HashMap.Strict      as M
 import qualified Language.Fixpoint.Misc   as Misc
+
+import Debug.Trace
 
 --------------------------------------------------------------------------------
 -- | 'Raw' is the low-level representation for SMT values
@@ -80,6 +82,7 @@ data SymEnv = SymEnv
   , seLits   :: !(SEnv Sort)              -- ^ Distinct Constant symbols
   , seAppls  :: !(M.HashMap FuncSort Int) -- ^ Types at which `apply` was used;
                                            --   see [NOTE:apply-monomorphization]
+  , seApplsNew :: !(M.HashMap FuncSort Int)
   , seIx     :: !Int                      -- ^ Largest unused index for sorts
   }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -98,20 +101,21 @@ instance Semigroup SymEnv where
                     , seData   = seData   e1 <> seData   e2
                     , seLits   = seLits   e1 <> seLits   e2
                     , seAppls  = seAppls  e1 <> seAppls  e2
+                    , seApplsNew  = seApplsNew  e1 <> seApplsNew e2
                     , seIx     = seIx     e1 `max` seIx  e2
                     }
 
 instance Monoid SymEnv where
-  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty 0
+  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty mempty 0
   mappend       = (<>)
 
 symEnv :: SEnv Sort -> SEnv TheorySymbol -> [DataDecl] -> SEnv Sort -> [Sort] -> SymEnv
-symEnv xEnv fEnv ds ls ts = SymEnv xEnv' fEnv dEnv ls applsMap {- mempty -} 0
+symEnv xEnv fEnv ds ls _ {-ts-} = SymEnv xEnv' fEnv dEnv ls {-applsMap-} mempty mempty 0
   where
     xEnv'   = unionSEnv xEnv wiredInEnv
     dEnv    = fromListSEnv [(symbol d, d) | d <- ds]
-    applsMap = M.fromList (zip smts [0..])
-    smts    = funcSorts dEnv ts
+--    applsMap = M.fromList (zip smts [0..])
+--    smts    = funcSorts dEnv ts
 
 -- | These are "BUILT-in" polymorphic functions which are
 --   UNINTERPRETED but POLYMORPHIC, hence need to go through
@@ -146,6 +150,7 @@ wiredInEnv = M.fromList
 --   such a strategy would NUKE the entire apply-sort machinery from the CODE base.
 --   [TODO]: dynamic-apply-declaration
 
+{-
 funcSorts :: SEnv DataDecl -> [Sort] -> [FuncSort]
 funcSorts dEnv ts = [ (t1, t2) | t1 <- smts, t2 <- smts]
   where
@@ -202,7 +207,7 @@ inlineArrSetBagFApp m env = go
       | Just n <- tyArgs c env
       , let i = n - length ts   = [SData c ((inlineArrSetBag False env . FAbs m =<< ts) ++ replicate i SInt)]
     go _ _                      = [SInt]
-
+-}
 
 symEnvTheory :: Symbol -> SymEnv -> Maybe TheorySymbol
 symEnvTheory x env = lookupSEnv x (seTheory env)
@@ -228,24 +233,30 @@ symbolAtName mkSym e s =
 symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> SymM Text
 symbolAtSmtName mkSym e fs =
   -- formerly: intSymbol mkSym . funcSortIndex env e
-  appendSymbolText mkSym . Text.pack . show <$> funcSortIndex e fs
+  do fsi <- funcSortIndex e fs
+     let fsi' = trace ("sasn " ++ show fsi) fsi
+     pure $ appendSymbolText mkSym . Text.pack . show $ fsi'
 {-# SCC symbolAtSmtName #-}
 
 funcSortIndex :: (PPrint a) => a -> FuncSort -> SymM Int
-funcSortIndex e fs =
+--funcSortIndex e fs =
+funcSortIndex _ fs =
   do env <- get
      let aps = seAppls env
-     pure $ M.lookupDefault err fs aps
-{-
+     let apsn = seApplsNew env
+--     pure $ M.lookupDefault err fs aps
      case M.lookup fs aps of
       Just i  -> pure i
       Nothing ->
-        do let i = seIx env
-           modify (\env -> env { seAppls = M.insert fs i aps , seIx = 1 + i })
-           pure i
--}
-  where
-    err = panic ("Unknown func-sort: " ++ show fs ++ " for " ++ showpp e)
+        case M.lookup fs apsn of
+         Just i  -> pure i
+         Nothing ->
+           do let i = seIx env
+              modify (\env -> env { seApplsNew = M.insert fs i apsn , seIx = 1 + i })
+              pure i
+
+--  where
+--    err = panic ("Unknown func-sort: " ++ show fs ++ " for " ++ showpp e)
 
 ffuncSort :: SymEnv -> Sort -> FuncSort
 ffuncSort env t      = {- tracepp ("ffuncSort " ++ showpp (t1,t2)) -} (tx t1, tx t2)
@@ -409,5 +420,6 @@ coerceEnv slv env =
          , seData   = seData   env
          , seLits   = seLits   env
          , seAppls  = seAppls  env
+         , seApplsNew = seApplsNew env
          , seIx     = seIx     env
          }

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -89,7 +89,7 @@ mergeTopAppls m (top : rest) = (top <> m) : rest
 mergeTopAppls m [] = [m]
 
 pushAppls :: Appls -> Appls
-pushAppls aps = (M.empty : aps)
+pushAppls aps = M.empty : aps
 
 popAppls :: Appls -> Appls
 popAppls [] = []

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -23,6 +23,11 @@ module Language.Fixpoint.Types.Theories (
     , sortSmtSort
     , isIntSmtSort
 
+    , mergeTopAppls
+    , pushAppls
+    , popAppls
+    , peekAppls
+
     -- * Symbol Environments
     , SymEnv (..)
     , SymM
@@ -48,6 +53,7 @@ import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
 --import           Control.Monad.Reader
+import           Control.Applicative
 import           Control.Monad.State
 import           Control.DeepSeq
 import           Language.Fixpoint.Types.Config
@@ -59,6 +65,7 @@ import           Language.Fixpoint.Types.Environments
 
 import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.List                as L
+import Data.Maybe ()
 import           Data.Text (Text)
 import qualified Data.Text                as Text
 import qualified Data.Store              as S
@@ -75,14 +82,34 @@ type Raw = Text
 --------------------------------------------------------------------------------
 -- | 'SymEnv' is used to resolve the 'Sort' and 'Sem' of each 'Symbol'
 --------------------------------------------------------------------------------
+
+type Appls = [M.HashMap FuncSort Int]
+
+lookupAppls :: FuncSort -> Appls -> Maybe Int
+lookupAppls fs = foldr (\hm acc -> acc <|> M.lookup fs hm) Nothing
+
+mergeTopAppls :: M.HashMap FuncSort Int -> Appls -> Appls
+mergeTopAppls m (top : rest) = (top <> m) : rest
+mergeTopAppls m [] = [m]
+
+pushAppls :: Appls -> Appls
+pushAppls aps = (M.empty : aps)
+
+popAppls :: Appls -> Appls
+popAppls [] = []
+popAppls (_:xs) = xs
+
+peekAppls :: Appls -> Maybe (M.HashMap FuncSort Int)
+peekAppls [] = Nothing
+peekAppls (x:_) = Just x
+
 data SymEnv = SymEnv
   { seSort   :: !(SEnv Sort)              -- ^ Sorts of *all* defined symbols
   , seTheory :: !(SEnv TheorySymbol)      -- ^ Information about theory-specific Symbols
   , seData   :: !(SEnv DataDecl)          -- ^ User-defined data-declarations
   , seLits   :: !(SEnv Sort)              -- ^ Distinct Constant symbols
-  , seAppls  :: !(M.HashMap FuncSort Int) -- ^ Types at which `apply` was used;
-                                           --   see [NOTE:apply-monomorphization]
-  , seApplsNew :: !(M.HashMap FuncSort Int)
+  , seAppls  :: !Appls                    -- ^ Stack of function sort maps
+  , seApplsCur :: !(M.HashMap FuncSort Int) -- ^ Current function sort map
   , seIx     :: !Int                      -- ^ Largest unused index for sorts
   }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -100,17 +127,17 @@ instance Semigroup SymEnv where
                     , seTheory = seTheory e1 <> seTheory e2
                     , seData   = seData   e1 <> seData   e2
                     , seLits   = seLits   e1 <> seLits   e2
-                    , seAppls  = seAppls  e1 <> seAppls  e2
-                    , seApplsNew  = seApplsNew  e1 <> seApplsNew e2
+                    , seAppls  = zipWith (<>) (seAppls e1) (seAppls e2)
+                    , seApplsCur = seApplsCur e1 <> seApplsCur e2
                     , seIx     = seIx     e1 `max` seIx  e2
                     }
 
 instance Monoid SymEnv where
-  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty mempty 0
+  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv [] mempty 0
   mappend       = (<>)
 
 symEnv :: SEnv Sort -> SEnv TheorySymbol -> [DataDecl] -> SEnv Sort -> [Sort] -> SymEnv
-symEnv xEnv fEnv ds ls _ {-ts-} = SymEnv xEnv' fEnv dEnv ls {-applsMap-} mempty mempty 0
+symEnv xEnv fEnv ds ls _ {-ts-} = SymEnv xEnv' fEnv dEnv ls {-applsMap-} [] mempty 0
   where
     xEnv'   = unionSEnv xEnv wiredInEnv
     dEnv    = fromListSEnv [(symbol d, d) | d <- ds]
@@ -243,16 +270,16 @@ funcSortIndex :: (PPrint a) => a -> FuncSort -> SymM Int
 funcSortIndex _ fs =
   do env <- get
      let aps = seAppls env
-     let apsn = seApplsNew env
+     let apsc = seApplsCur env
 --     pure $ M.lookupDefault err fs aps
-     case M.lookup fs aps of
+     case lookupAppls fs aps of
       Just i  -> pure i
       Nothing ->
-        case M.lookup fs apsn of
-         Just i  -> pure i
-         Nothing ->
+        case M.lookup fs apsc of
+          Just i  -> pure i
+          Nothing ->
            do let i = seIx env
-              modify (\env -> env { seApplsNew = M.insert fs i apsn , seIx = 1 + i })
+              modify (\env -> env { seApplsCur = M.insert fs i apsc , seIx = 1 + i })
               pure i
 
 --  where
@@ -420,6 +447,6 @@ coerceEnv slv env =
          , seData   = seData   env
          , seLits   = seLits   env
          , seAppls  = seAppls  env
-         , seApplsNew = seApplsNew env
+         , seApplsCur = seApplsCur env
          , seIx     = seIx     env
          }

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -46,6 +46,7 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
+import           Control.Monad.State
 import           Control.DeepSeq
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
@@ -77,6 +78,7 @@ data SymEnv = SymEnv
   , seLits   :: !(SEnv Sort)              -- ^ Distinct Constant symbols
   , seAppls  :: !(M.HashMap FuncSort Int) -- ^ Types at which `apply` was used;
                                            --   see [NOTE:apply-monomorphization]
+  , seIx     :: !Int                      -- ^ Largest unused index for sorts
   }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -92,18 +94,19 @@ instance Semigroup SymEnv where
                     , seData   = seData   e1 <> seData   e2
                     , seLits   = seLits   e1 <> seLits   e2
                     , seAppls  = seAppls  e1 <> seAppls  e2
+                    , seIx     = seIx     e1 `max` seIx  e2
                     }
 
 instance Monoid SymEnv where
-  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty
+  mempty        = SymEnv emptySEnv emptySEnv emptySEnv emptySEnv mempty 0
   mappend       = (<>)
 
 symEnv :: SEnv Sort -> SEnv TheorySymbol -> [DataDecl] -> SEnv Sort -> [Sort] -> SymEnv
-symEnv xEnv fEnv ds ls ts = SymEnv xEnv' fEnv dEnv ls sortMap
+symEnv xEnv fEnv ds ls ts = SymEnv xEnv' fEnv dEnv ls applsMap {- mempty -} 0
   where
     xEnv'   = unionSEnv xEnv wiredInEnv
     dEnv    = fromListSEnv [(symbol d, d) | d <- ds]
-    sortMap = M.fromList (zip smts [0..])
+    applsMap = M.fromList (zip smts [0..])
     smts    = funcSorts dEnv ts
 
 -- | These are "BUILT-in" polymorphic functions which are
@@ -212,18 +215,32 @@ deleteSymEnv x env = env { seSort = deleteSEnv x (seSort env) }
 insertsSymEnv :: SymEnv -> [(Symbol, Sort)] -> SymEnv
 insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
-symbolAtName :: (PPrint a) => Symbol -> SymEnv -> a -> Sort -> Text
-symbolAtName mkSym env e = symbolAtSmtName mkSym env e . ffuncSort env
+symbolAtName :: (PPrint a) => Symbol -> a -> Sort -> State SymEnv Text
+symbolAtName mkSym e s =
+  do env <- get
+     symbolAtSmtName mkSym e (ffuncSort env s)
 {-# SCC symbolAtName #-}
 
-symbolAtSmtName :: (PPrint a) => Symbol -> SymEnv -> a -> FuncSort -> Text
-symbolAtSmtName mkSym env e =
+symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> State SymEnv Text
+symbolAtSmtName mkSym e fs =
   -- formerly: intSymbol mkSym . funcSortIndex env e
-  appendSymbolText mkSym . Text.pack . show . funcSortIndex env e
+  appendSymbolText mkSym . Text.pack . show <$> funcSortIndex e fs
 {-# SCC symbolAtSmtName #-}
 
-funcSortIndex :: (PPrint a) => SymEnv -> a -> FuncSort -> Int
-funcSortIndex env e fs = M.lookupDefault err fs (seAppls env)
+funcSortIndex :: (PPrint a) => a -> FuncSort -> State SymEnv Int
+funcSortIndex e fs =
+  do env <- get
+     let aps = seAppls env
+     pure $ M.lookupDefault err fs aps
+     {-
+     case M.lookup fs aps of
+      Just i  -> pure i
+      Nothing ->
+        do let i = seIx env
+           modify (\env -> env { seAppls = M.insert fs i aps , seIx = 1 + i })
+           pure i
+     -}
+
   where
     err = panic ("Unknown func-sort: " ++ show fs ++ " for " ++ showpp e)
 
@@ -335,9 +352,9 @@ fappSmtSort poly m env = go
 -- HKT    go t@(FVar _) ts            = SApp (sortSmtSort poly env <$> (t:ts))
 
     go (FTC c) [a]
-      | setConName == symbol c  = SSet (sortSmtSort poly env a)
+      | setConName == symbol c   = SSet (sortSmtSort poly env a)
     go (FTC c) [a]
-      | bagConName == symbol c  = SBag (sortSmtSort poly env a)
+      | bagConName == symbol c   = SBag (sortSmtSort poly env a)
     go (FTC c) [a, b]
       | arrayConName == symbol c = SArray (sortSmtSort poly env a) (sortSmtSort poly env b)
     go (FTC bv) [FTC s]
@@ -389,4 +406,5 @@ coerceEnv slv env =
          , seData   = seData   env
          , seLits   = seLits   env
          , seAppls  = seAppls  env
+         , seIx     = seIx     env
          }

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -119,13 +119,13 @@ instance NFData   SymEnv
 instance S.Store SymEnv
 
 instance Semigroup SymEnv where
-  e1 <> e2 = SymEnv { seSort   = seSort   e1 <> seSort   e2
-                    , seTheory = seTheory e1 <> seTheory e2
-                    , seData   = seData   e1 <> seData   e2
-                    , seLits   = seLits   e1 <> seLits   e2
-                    , seAppls  = zipWith (<>) (seAppls e1) (seAppls e2)
+  e1 <> e2 = SymEnv { seSort     = seSort     e1 <> seSort     e2
+                    , seTheory   = seTheory   e1 <> seTheory   e2
+                    , seData     = seData     e1 <> seData     e2
+                    , seLits     = seLits     e1 <> seLits     e2
+                    , seAppls    = zipWith (<>) (seAppls e1) (seAppls e2)
                     , seApplsCur = seApplsCur e1 <> seApplsCur e2
-                    , seIx     = seIx     e1 `max` seIx  e2
+                    , seIx       = seIx       e1 `max` seIx    e2
                     }
 
 instance Monoid SymEnv where

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -39,7 +39,7 @@ module Language.Fixpoint.Types.Theories (
     , deleteSymEnv
     , insertsSymEnv
     , symbolAtName
-    , symbolAtSmtName
+    , symbolAtSortIndex
 
     -- * Coercing sorts in environments
     , coerceSort
@@ -79,6 +79,13 @@ type Raw = Text
 -- | 'SymEnv' is used to resolve the 'Sort' and 'Sem' of each 'Symbol'
 --------------------------------------------------------------------------------
 
+-- | This is a type of "apply tags", i.e. a stack of lookup maps relating a
+--   function sort to a numeric tag. Every time we issue a `push` a new level
+--   is added to the stack, and correspondingly, a `pop` removes a level. This
+--   way we can emit new tag "lazily", i.e. only the first time they are
+--   encountered in an expression during SMT serialization. This means we
+--   can repeatedly re-emit same definitions in new push/pop brackets, but
+--   this doesn't seem to incur any significant performance penalties.
 type Appls = [M.HashMap FuncSort Int]
 
 lookupAppls :: FuncSort -> Appls -> Maybe Int
@@ -99,6 +106,11 @@ peekAppls :: Appls -> Maybe (M.HashMap FuncSort Int)
 peekAppls [] = Nothing
 peekAppls (x:_) = Just x
 
+-- | In addition to the tag map stack, we also maintain a "workplace" or "current"
+--   map that holds the tags that have been created but not yet emitted at the
+--   current bracket level. After emitting, the contents of the current map are
+--   moved to the top of the map stack, this way we ensure that there are no
+--   duplicate definitions (which crash the SMT solver).
 data SymEnv = SymEnv
   { seSort     :: !(SEnv Sort)              -- ^ Sorts of *all* defined symbols
   , seTheory   :: !(SEnv TheorySymbol)      -- ^ Information about theory-specific Symbols
@@ -167,18 +179,16 @@ deleteSymEnv x env = env { seSort = deleteSEnv x (seSort env) }
 insertsSymEnv :: SymEnv -> [(Symbol, Sort)] -> SymEnv
 insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
+symbolAtSortIndex :: Symbol -> Int -> Text
+symbolAtSortIndex mkSym si = appendSymbolText mkSym . Text.pack . show $ si
+{-# SCC symbolAtSortIndex #-}
+
 symbolAtName :: Symbol -> Sort -> SymM Text
 symbolAtName mkSym s =
   do env <- get
-     symbolAtSmtName mkSym (ffuncSort env s)
+     fsi <- funcSortIndex (ffuncSort env s)
+     pure $ symbolAtSortIndex mkSym fsi
 {-# SCC symbolAtName #-}
-
-symbolAtSmtName :: Symbol -> FuncSort -> SymM Text
-symbolAtSmtName mkSym fs =
-  -- formerly: intSymbol mkSym . funcSortIndex env e
-  do fsi <- funcSortIndex fs
-     pure $ appendSymbolText mkSym . Text.pack . show $ fsi
-{-# SCC symbolAtSmtName #-}
 
 funcSortIndex :: FuncSort -> SymM Int
 funcSortIndex fs =

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -25,6 +25,7 @@ module Language.Fixpoint.Types.Theories (
 
     -- * Symbol Environments
     , SymEnv (..)
+    , SymM
     , symEnv
     , symEnvSort
     , symEnvTheory
@@ -46,7 +47,7 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
-import           Control.Monad.State
+import           Control.Monad.Reader
 import           Control.DeepSeq
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
@@ -84,6 +85,8 @@ data SymEnv = SymEnv
 
 {- type FuncSort = {v:Sort | isFFunc v} @-}
 type FuncSort = (SmtSort, SmtSort)
+
+type SymM a = Reader SymEnv a
 
 instance NFData   SymEnv
 instance S.Store SymEnv
@@ -215,32 +218,31 @@ deleteSymEnv x env = env { seSort = deleteSEnv x (seSort env) }
 insertsSymEnv :: SymEnv -> [(Symbol, Sort)] -> SymEnv
 insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
-symbolAtName :: (PPrint a) => Symbol -> a -> Sort -> State SymEnv Text
+symbolAtName :: (PPrint a) => Symbol -> a -> Sort -> SymM Text
 symbolAtName mkSym e s =
-  do env <- get
+  do env <- ask
      symbolAtSmtName mkSym e (ffuncSort env s)
 {-# SCC symbolAtName #-}
 
-symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> State SymEnv Text
+symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> SymM Text
 symbolAtSmtName mkSym e fs =
   -- formerly: intSymbol mkSym . funcSortIndex env e
   appendSymbolText mkSym . Text.pack . show <$> funcSortIndex e fs
 {-# SCC symbolAtSmtName #-}
 
-funcSortIndex :: (PPrint a) => a -> FuncSort -> State SymEnv Int
+funcSortIndex :: (PPrint a) => a -> FuncSort -> SymM Int
 funcSortIndex e fs =
-  do env <- get
+  do env <- ask
      let aps = seAppls env
      pure $ M.lookupDefault err fs aps
-     {-
+{-
      case M.lookup fs aps of
       Just i  -> pure i
       Nothing ->
         do let i = seIx env
            modify (\env -> env { seAppls = M.insert fs i aps , seIx = 1 + i })
            pure i
-     -}
-
+-}
   where
     err = panic ("Unknown func-sort: " ++ show fs ++ " for " ++ showpp e)
 

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -181,7 +181,6 @@ insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
 symbolAtSortIndex :: Symbol -> Int -> Text
 symbolAtSortIndex mkSym si = appendSymbolText mkSym . Text.pack . show $ si
-{-# SCC symbolAtSortIndex #-}
 
 symbolAtName :: Symbol -> Sort -> SymM Text
 symbolAtName mkSym s =

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -53,7 +53,6 @@ import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           Data.Hashable
 import           GHC.Generics              (Generic)
---import           Control.Monad.Reader
 import           Control.Applicative
 import           Control.Monad.State
 import           Control.DeepSeq
@@ -61,19 +60,15 @@ import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Sorts
--- import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Types.Environments
 
 import           Text.PrettyPrint.HughesPJ.Compat
 import qualified Data.List                as L
-import Data.Maybe ()
 import           Data.Text (Text)
 import qualified Data.Text                as Text
 import qualified Data.Store              as S
 import qualified Data.HashMap.Strict      as M
 import qualified Language.Fixpoint.Misc   as Misc
-
--- import Debug.Trace
 
 --------------------------------------------------------------------------------
 -- | 'Raw' is the low-level representation for SMT values
@@ -105,13 +100,13 @@ peekAppls [] = Nothing
 peekAppls (x:_) = Just x
 
 data SymEnv = SymEnv
-  { seSort   :: !(SEnv Sort)              -- ^ Sorts of *all* defined symbols
-  , seTheory :: !(SEnv TheorySymbol)      -- ^ Information about theory-specific Symbols
-  , seData   :: !(SEnv DataDecl)          -- ^ User-defined data-declarations
-  , seLits   :: !(SEnv Sort)              -- ^ Distinct Constant symbols
-  , seAppls  :: !Appls                    -- ^ Stack of function sort maps
+  { seSort     :: !(SEnv Sort)              -- ^ Sorts of *all* defined symbols
+  , seTheory   :: !(SEnv TheorySymbol)      -- ^ Information about theory-specific Symbols
+  , seData     :: !(SEnv DataDecl)          -- ^ User-defined data-declarations
+  , seLits     :: !(SEnv Sort)              -- ^ Distinct Constant symbols
+  , seAppls    :: !Appls                    -- ^ Stack of function sort maps
   , seApplsCur :: !(M.HashMap FuncSort Int) -- ^ Current function sort map
-  , seIx     :: !Int                      -- ^ Largest unused index for sorts
+  , seIx       :: !Int                      -- ^ Largest unused index for sorts
   }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -138,12 +133,10 @@ instance Monoid SymEnv where
   mappend       = (<>)
 
 symEnv :: SEnv Sort -> SEnv TheorySymbol -> [DataDecl] -> SEnv Sort -> [Sort] -> SymEnv
-symEnv xEnv fEnv ds ls _ {-ts-} = SymEnv xEnv' fEnv dEnv ls {-applsMap-} [] mempty 0
+symEnv xEnv fEnv ds ls _ = SymEnv xEnv' fEnv dEnv ls [] mempty 0
   where
     xEnv'   = unionSEnv xEnv wiredInEnv
     dEnv    = fromListSEnv [(symbol d, d) | d <- ds]
---    applsMap = M.fromList (zip smts [0..])
---    smts    = funcSorts dEnv ts
 
 -- | These are "BUILT-in" polymorphic functions which are
 --   UNINTERPRETED but POLYMORPHIC, hence need to go through
@@ -153,89 +146,6 @@ wiredInEnv = M.fromList
   [ (toIntName, mkFFunc 1 [FVar 0, FInt])
   , (tyCastName, FAbs 0 $ FAbs 1 $ FFunc (FVar 0) (FVar 1))
   ]
-
-
--- | 'funcSorts' attempts to compute a list of all the input-output sorts
---   at which applications occur. This is a gross hack; as during unfolding
---   we may create _new_ terms with weird new sorts. Ideally, we MUST allow
---   for EXTENDING the apply-sorts with those newly created terms.
---   the solution is perhaps to *preface* each VC query of the form
---
---      push
---      assert p
---      check-sat
---      pop
---
---   with the declarations needed to make 'p' well-sorted under SMT, i.e.
---   change the above to
---
---      declare apply-sorts
---      push
---      assert p
---      check-sat
---      pop
---
---   such a strategy would NUKE the entire apply-sort machinery from the CODE base.
---   [TODO]: dynamic-apply-declaration
-
-{-
-funcSorts :: SEnv DataDecl -> [Sort] -> [FuncSort]
-funcSorts dEnv ts = [ (t1, t2) | t1 <- smts, t2 <- smts]
-  where
-    smts = Misc.sortNub $ concat $ [ tx t1 ++ tx t2 | FFunc t1 t2 <- ts ]
-    tx   = inlineArrSetBag False dEnv
-
--- Related to the above, after merging #688, we now allow types other than
--- Int to which Arrays/Sets/Bags can be applied.
--- However, the `sortSmtSort` function below, previously used in `funcSorts`,
--- only instantiates type variables at Ints. This causes the solver to crash
--- when PLE generates apply queries for polymorphic sets (see
--- https://github.com/ucsd-progsys/liquidhaskell/issues/2438). The following
--- pair of functions is a temporary fix for this - it generates additional
--- array/set/bag sorts instantiated at all user types for a "polymorphic depth 1"
--- (i.e., `Array (Foo Int) Int` but not `Array (Foo (Foo Int)) Int`, to keep
--- the applys table from blowing up exponentially). Ultimately, a general
--- solution should be implemented for generating ad-hoc sets of applys on the
--- fly, as described above.
-
-inlineArrSetBag :: Bool -> SEnv DataDecl -> Sort -> [SmtSort]
-inlineArrSetBag isASB env t = go . unAbs $ t
-  where
-    m = sortAbs t
-    go (FFunc _ _)    = [SInt]
-    go FInt           = [SInt]
-    go FReal          = [SReal]
-    go t
-      | t == boolSort = [SBool]
-      | isString t    = [SString]
-    go (FVar _)
-      | isASB     = SInt : map (\q -> let dd = snd q in
-                                      SData (ddTyCon dd) (replicate (ddVars dd) SInt))
-                               (M.toList $ seBinds env)
-      | otherwise = [SInt]
-    go t
-      | (ct:ts) <- unFApp t = inlineArrSetBagFApp m env ct ts
-      | otherwise = error "Unexpected empty 'unFApp t'"
-
-inlineArrSetBagFApp :: Int -> SEnv DataDecl -> Sort -> [Sort] -> [SmtSort]
-inlineArrSetBagFApp m env = go
-  where
-    go (FTC c) [a]
-      | setConName == symbol c   = SSet <$> inlineArrSetBag True env a
-    go (FTC c) [a]
-      | bagConName == symbol c   = SBag <$> inlineArrSetBag True env a
-    go (FTC c) [a, b]
-      | arrayConName == symbol c = SArray <$> inlineArrSetBag True env a <*> inlineArrSetBag True env b
-    go (FTC bv) [FTC s]
-      | bitVecName == symbol bv
-      , Just n <- sizeBv s      = [SBitVec n]
-    go s []
-      | isString s              = [SString]
-    go (FTC c) ts
-      | Just n <- tyArgs c env
-      , let i = n - length ts   = [SData c ((inlineArrSetBag False env . FAbs m =<< ts) ++ replicate i SInt)]
-    go _ _                      = [SInt]
--}
 
 symEnvTheory :: Symbol -> SymEnv -> Maybe TheorySymbol
 symEnvTheory x env = lookupSEnv x (seTheory env)
@@ -252,28 +162,24 @@ deleteSymEnv x env = env { seSort = deleteSEnv x (seSort env) }
 insertsSymEnv :: SymEnv -> [(Symbol, Sort)] -> SymEnv
 insertsSymEnv = L.foldl' (\env (x, s) -> insertSymEnv x s env)
 
-symbolAtName :: (PPrint a) => Symbol -> a -> Sort -> SymM Text
-symbolAtName mkSym e s =
+symbolAtName :: Symbol -> Sort -> SymM Text
+symbolAtName mkSym s =
   do env <- get
-     symbolAtSmtName mkSym e (ffuncSort env s)
+     symbolAtSmtName mkSym (ffuncSort env s)
 {-# SCC symbolAtName #-}
 
-symbolAtSmtName :: (PPrint a) => Symbol -> a -> FuncSort -> SymM Text
-symbolAtSmtName mkSym e fs =
+symbolAtSmtName :: Symbol -> FuncSort -> SymM Text
+symbolAtSmtName mkSym fs =
   -- formerly: intSymbol mkSym . funcSortIndex env e
-  do fsi <- funcSortIndex e fs
-     let fsi' = -- trace ("sasn " ++ show fsi)
-                fsi
-     pure $ appendSymbolText mkSym . Text.pack . show $ fsi'
+  do fsi <- funcSortIndex fs
+     pure $ appendSymbolText mkSym . Text.pack . show $ fsi
 {-# SCC symbolAtSmtName #-}
 
-funcSortIndex :: (PPrint a) => a -> FuncSort -> SymM Int
---funcSortIndex e fs =
-funcSortIndex _ fs =
+funcSortIndex :: FuncSort -> SymM Int
+funcSortIndex fs =
   do env <- get
      let aps = seAppls env
      let apsc = seApplsCur env
---     pure $ M.lookupDefault err fs aps
      case lookupAppls fs aps of
       Just i  -> pure i
       Nothing ->
@@ -283,9 +189,6 @@ funcSortIndex _ fs =
            do let i = seIx env
               modify (\env -> env { seApplsCur = M.insert fs i apsc , seIx = 1 + i })
               pure i
-
---  where
---    err = panic ("Unknown func-sort: " ++ show fs ++ " for " ++ showpp e)
 
 ffuncSort :: SymEnv -> Sort -> FuncSort
 ffuncSort env t      = {- tracepp ("ffuncSort " ++ showpp (t1,t2)) -} (tx t1, tx t2)
@@ -444,11 +347,11 @@ coerceSort ef = (if elabSetBag ef then coerceSetBagToArray else id) . coerceMapT
 
 coerceEnv :: ElabFlags -> SymEnv -> SymEnv
 coerceEnv slv env =
-  SymEnv { seSort   = coerceSortEnv slv (seSort env)
-         , seTheory = seTheory env
-         , seData   = seData   env
-         , seLits   = seLits   env
-         , seAppls  = seAppls  env
+  SymEnv { seSort     = coerceSortEnv slv (seSort env)
+         , seTheory   = seTheory env
+         , seData     = seData   env
+         , seLits     = seLits   env
+         , seAppls    = seAppls  env
          , seApplsCur = seApplsCur env
-         , seIx     = seIx     env
+         , seIx       = seIx     env
          }

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -17,7 +17,7 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
       KN
         { knSims = M.empty, -- :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
           knAms = M.empty, -- :: Map Symbol Equation
-          knContext = undefined, -- :: SMT.Context
+--          knContext = undefined, -- :: SMT.Context
           knPreds = undefined, -- :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
           knLams = [], -- :: ![(Symbol, Sort)]
           knSummary = [], -- :: ![(Symbol, Int)]

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -17,7 +17,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
       KN
         { knSims = M.empty, -- :: Map Symbol [(Rewrite, IsUserDataSMeasure)]
           knAms = M.empty, -- :: Map Symbol Equation
---          knContext = undefined, -- :: SMT.Context
           knPreds = undefined, -- :: SMT.Context -> [(Symbol, Sort)] -> Expr -> IO Bool
           knLams = [], -- :: ![(Symbol, Sort)]
           knSummary = [], -- :: ![(Symbol, Int)]


### PR DESCRIPTION
This PR removes `Language.Fixpoint.Types.Theories.funcSorts`, which was an ad-hoc function pre-generating all possible sort combinations for applys statically. Instead, new apply definitions are now accumulated in a state monad and emitted dynamically next to the declarations that require them, as late as possible. This is achieved by tracking the definitions in a stack of sort maps, where the nesting level corresponds to the SMT push/pop level.

All SMT symbol generation is now done in a `SymM` monad responsible for tracking the definition stack, which lifts into `SmtM` monad, used for interacting with the SMT solver. The `SmtM` monad itself is lifted into `SolveM` and `EvalST` monads where necessary.

Also, a heuristic has been added that suppresses the generation of `lam_arg` definitions unless the `allowHO` flag is set. This is sufficient to pass all tests in LF and LH, but adjustments to the heuristic may be necessary for larger codebases.