### PR TITLE
Create nightly release workflow

### DIFF
--- a/.github/actions/github-release/Dockerfile
+++ b/.github/actions/github-release/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:slim
+
+COPY . /action
+WORKDIR /action
+
+RUN npm install --production
+
+ENTRYPOINT ["node", "/action/main.js"]

--- a/.github/actions/github-release/README.md
+++ b/.github/actions/github-release/README.md
@@ -1,0 +1,21 @@
+# github-release
+
+Adapted from
+<https://github.com/rust-lang/rust-analyzer/tree/b40fce3ccdc5f94453c6aca4da8b64174a03a5ad/.github/actions/github-release>
+
+An action used to publish GitHub releases.
+
+As of the time of this writing there's a few actions floating around which
+perform GitHub releases, but they all tend to have their set of drawbacks.
+Additionally, nothing handles deleting releases which we need for our rolling
+`nightly` release.
+
+To handle all this, this action rolls its own implementation using the
+actions/toolkit repository and packages published there. These run in a Docker
+container and take various inputs to orchestrate the release from the build.
+
+More comments can be found in `main.js`.
+
+Testing this is really hard. If you want to try though run `npm install` and
+then `node main.js`. You'll have to configure a bunch of env vars though to get
+anything reasonably working.

--- a/.github/actions/github-release/action.yml
+++ b/.github/actions/github-release/action.yml
@@ -1,0 +1,24 @@
+name: "Github releases"
+description: "Create or update a github releases with artifacts"
+inputs:
+  token:
+    description: "GitHub token"
+    required: true
+  name:
+    description: "Name of the release"
+    required: true
+  body:
+    description: "Message body of the release"
+    required: true
+  tag_name:
+    description: "Name of the tag to create or update the release with"
+    required: true
+  tag_message:
+    description: "Tag message to create or update the release with"
+    required: true
+  files:
+    description: "Glob pattern of files to upload to the release"
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -1,0 +1,149 @@
+const core = require('@actions/core');
+const path = require("path");
+const fs = require("fs");
+const github = require('@actions/github');
+const glob = require('glob');
+
+function sleep(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function runOnce() {
+  // Load all our inputs and env vars. Note that `getInput` reads from `INPUT_*`
+  const files = core.getInput('files');
+  const releaseName = core.getInput('name');
+  const tagName = core.getInput('tag_name');
+  const tagMessage = core.getInput('tag_message');
+  const token = core.getInput('token');
+  const body = core.getInput('body');
+  const slug = process.env.GITHUB_REPOSITORY;
+  const owner = slug.split('/')[0];
+  const repo = slug.split('/')[1];
+  const sha = process.env.GITHUB_SHA;
+
+  core.info(`files: ${files}`);
+  core.info(`name: ${releaseName}`);
+  core.info(`tag: ${tagName}`);
+  core.info(`body:\n${body}`);
+
+  const options = {
+    request: {
+      timeout: 30000,
+    }
+  };
+  const octokit = github.getOctokit(token, options);
+
+  // Delete the previous release since we can't overwrite one.
+  const releases = await octokit.paginate("GET /repos/:owner/:repo/releases", { owner, repo });
+  for (const release of releases) {
+    if (release.tag_name !== tagName) {
+      continue;
+    }
+    const release_id = release.id;
+    core.info(`> deleting release ${release_id}`);
+    await octokit.rest.repos.deleteRelease({ owner, repo, release_id });
+  }
+
+  // Update the tag to point to the new commit, if it doen't exist then create a new one.
+  try {
+    core.info(`> updating tag`);
+    await octokit.rest.git.updateRef({
+      owner,
+      repo,
+      ref: `tags/${tagName}`,
+      sha,
+      force: true,
+    });
+  } catch (e) {
+    core.error(e);
+    core.info(`> creating tag`);
+    await octokit.rest.git.createTag({
+      owner,
+      repo,
+      tag: tagName,
+      message: tagMessage,
+      object: sha,
+      type: 'commit',
+    });
+  }
+
+  // Creates an official GitHub release for this `tag`, and if this is `dev`
+  // then we know that from the previous block this should be a fresh release.
+  core.info(`> creating a release`);
+  const releaseParams = {
+    owner,
+    repo,
+    name: releaseName,
+    tag_name: tagName,
+    target_commitish: sha,
+    prerelease: true,
+  };
+  if (body) {
+    releaseParams.body = body;
+  }
+  const release = await octokit.rest.repos.createRelease(releaseParams);
+  const release_id = release.data.id;
+
+  // Upload all the relevant assets for this release as just general blobs.
+  for (const file of glob.sync(files)) {
+    const size = fs.statSync(file).size;
+    const pathName = path.basename(file);
+
+    await runWithRetry(async function () {
+      // We can't overwrite assets, so remove existing ones from a previous try.
+      let assets = await octokit.rest.repos.listReleaseAssets({
+        owner,
+        repo,
+        release_id
+      });
+      for (const asset of assets.data) {
+        if (asset.name === pathName) {
+          core.info(`> delete asset ${pathName}`);
+          const asset_id = asset.id;
+          await octokit.rest.repos.deleteReleaseAsset({ owner, repo, asset_id });
+        }
+      }
+
+      core.info(`> upload ${file}`);
+      const headers = { 'content-length': size, 'content-type': 'application/octet-stream' };
+      const data = fs.createReadStream(file);
+      await octokit.rest.repos.uploadReleaseAsset({
+        data,
+        headers,
+        name: pathName,
+        url: release.data.upload_url,
+      });
+    });
+  }
+}
+
+async function runWithRetry(f) {
+  const retries = 10;
+  const maxDelay = 4000;
+  let delay = 1000;
+
+  for (let i = 0; i < retries; i++) {
+    try {
+      await f();
+      break;
+    } catch (e) {
+      if (i === retries - 1)
+        throw e;
+
+      core.error(e);
+      const currentDelay = Math.round(Math.random() * delay);
+      core.info(`> sleeping ${currentDelay} ms`);
+      await sleep(currentDelay);
+      delay = Math.min(delay * 2, maxDelay);
+    }
+  }
+}
+
+async function run() {
+  await runWithRetry(runOnce);
+}
+
+run().catch(err => {
+  core.error(err);
+  core.setFailed(err.message);
+});

--- a/.github/actions/github-release/package.json
+++ b/.github/actions/github-release/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wasmtime-github-release",
+  "version": "0.0.0",
+  "main": "main.js",
+  "dependencies": {
+    "@actions/core": "^1.6",
+    "@actions/github": "^5.0",
+    "glob": "^7.1.5"
+  }
+}

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -58,7 +58,9 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          key:
+            ${{ runner.os }}-${{ matrix.ghc }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project',
+            '**/cabal.project.freeze') }}
 
       - name: Update package list
         run: cabal update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: |
-            ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+            ${{ matrix.os }}-${{ env.GHC_VERSION }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,101 @@
+name: release
+
+on:
+  # We trigger the workflow in PRs to build the binaries as a sanity check, but we only publish
+  # the release when pushing to `develop`.
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    env:
+      GHC_VERSION: "9.12.2"
+      CABAL_VERSION: "3.12.1.0"
+    strategy:
+      matrix:
+        include:
+          # I couldn't find a minimum supported glibc version for ghc, but ubuntu 22.04
+          # has 2.35 which is oldish and has been tested to work, so we use this as the
+          # minimum supported version.
+          - os: ubuntu-22.04
+            artifact: fixpoint-x86_64-linux-gnu
+          - os: macos-13
+            artifact: fixpoint-x86_64-apple-darwin
+          - os: macos-14
+            artifact: fixpoint-aarch64-apple-darwin
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ env.GHC_VERSION }}
+          cabal-version: ${{ env.CABAL_VERSION }}
+
+      # Use cache in PRs, but do a clean build before releases
+      - name: Cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: |
+            ${{ runner.os }}-${{ env.GHC_VERSION }}-cabal-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+
+      - name: Build
+        run: |
+          cabal update
+          cabal build exe:fixpoint
+          cp $(cabal list-bin exe:fixpoint) ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  publish:
+    # Only publish a release when pushing to `develop`, i.e, after merging the PR
+    if: github.event_name == 'push'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: fixpoint-x86_64-linux-gnu
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: fixpoint-aarch64-apple-darwin
+          path: dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: fixpoint-x86_64-apple-darwin
+          path: dist
+
+      - name: Publish Nightly Release
+        uses: ./.github/actions/github-release
+        with:
+          files: "dist/*"
+          name: Nightly Release
+          tag_name: nightly
+          tag_message: nightly release
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            Automated nightly release of liquid-fixpoint.
+            - Darwin aarch64 (built on macOS 14)
+            - Darwin x86_64 (built on macOS 13)
+            - Linux x86_64 (built on Ubuntu 22.04)
+              - glibc (2.35)
+              - gmp (6.2)


### PR DESCRIPTION
Add a workflow to publish "nightly releases" with binaries.

* A release is published every time a commit is pushed to `develop`.
* The release always points to the same tag, i.e., there's always a single nightly release.
* This is what the release looks like https://github.com/nilehmann/liquid-fixpoint/releases/tag/nightly.
* The workflow builds binaries for linux x86_64, macos x86_64, and macos aarch64.
* The workflow runs on PRs to build the binaries as a sanity check, but no release is published until merging. Building for macOS x86_64 is kind of slow (~25min), so I can modify the workflow to only run after merging if you want. Although there's some caching enabled for PRs, so this may be ok.