### PR TITLE
Shorten flags and add git-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Liquid Fixpoint
 ===============
 
 
-[![Hackage](https://img.shields.io/hackage/v/liquid-fixpoint.svg)](https://hackage.haskell.org/package/liquid-fixpoint) [![Hackage-Deps](https://img.shields.io/hackage-deps/v/liquid-fixpoint.svg)](http://packdeps.haskellers.com/feed?needle=liquid-fixpoint) 
+[![Hackage](https://img.shields.io/hackage/v/liquid-fixpoint.svg)](https://hackage.haskell.org/package/liquid-fixpoint) [![Hackage-Deps](https://img.shields.io/hackage-deps/v/liquid-fixpoint.svg)](http://packdeps.haskellers.com/feed?needle=liquid-fixpoint)
 [![CircleCI](https://circleci.com/gh/ucsd-progsys/liquid-fixpoint.svg?style=svg)](https://circleci.com/gh/ucsd-progsys/liquid-fixpoint)
 [![hlint](https://github.com/ucsd-progsys/liquid-fixpoint/actions/workflows/hlint.yml/badge.svg)](https://github.com/ucsd-progsys/liquid-fixpoint/actions/workflows/hlint.yml)
 [![cabal](https://github.com/ucsd-progsys/liquid-fixpoint/actions/workflows/cabal.yml/badge.svg)](https://github.com/ucsd-progsys/liquid-fixpoint/actions/workflows/cabal.yml)
@@ -62,7 +62,7 @@ Currently, we support
     * CVC4
     * MathSat
 
-"Horn" Format 
+"Horn" Format
 -------------
 
 See the examples in `tests/horn/{pos, neg}` eg
@@ -73,8 +73,8 @@ See the examples in `tests/horn/{pos, neg}` eg
 
 For how to write VCs "by hand".
 
-See [this tutorial](https://arxiv.org/abs/2010.07763) 
-with [accompanying code](https://github.com/ranjitjhala/sprite-lang) 
+See [this tutorial](https://arxiv.org/abs/2010.07763)
+with [accompanying code](https://github.com/ranjitjhala/sprite-lang)
 for an example of how to generate Horn queries.
 
 The main datatypes are described in [src/Language/Fixpoint/Horn/Types.hs](src/Language/Fixpoint/Horn/Types.hs)
@@ -145,7 +145,7 @@ Use `--stdin` to read files from `stdin`
 ```
 $ more tests/horn/pos/test01.smt2 | fixpoint --stdin
 
-Liquid-Fixpoint Copyright 2013-21 Regents of the University of California.
+Liquid-Fixpoint Copyright 2009-25 Regents of the University of California.
 All Rights Reserved.
 
 Working 166% [===============================================================]
@@ -227,7 +227,7 @@ bind 2 y : ...
   one of `1` or `12`.
 
 * There is also a "tree-shape" property that its a bit hard
-  to describe ... TODO     
+  to describe ... TODO
 
 ### LHS
 
@@ -280,7 +280,7 @@ Similarly each `rhs` of a `SubC` must either be a single `$k[...]` or an plain `
 
 ```
      , gLits    :: !(SEnv Sort)               -- ^ Global Constant symbols
-     , dLits    :: !(SEnv Sort)       
+     , dLits    :: !(SEnv Sort)
 ```
 
 The _global_ literals `gLits` are symbols that
@@ -326,15 +326,15 @@ from the `[(Symbol, Sort)]`.
 
 > What's the difference between an FTC and an FObj?
 
-In early versions of fixpoint, there was support for 
-three sorts for expressions (`Expr`) that were sent 
+In early versions of fixpoint, there was support for
+three sorts for expressions (`Expr`) that were sent
 to the SMT solver:
 
 1. `int`
 2. `bool`
 3. "other"
 
-The `FObj` sort was introduced to represent essentially _all_ 
+The `FObj` sort was introduced to represent essentially _all_
 non-int and non-bool values (e.g. tuples, lists, trees, pointers...)
 
 However, we later realized that it is valuable to keep _more_
@@ -351,17 +351,17 @@ respectively as:
 > Does that then make FTC types that the SMT solver does
 > know about (bools, ints, lists, sets, etc.)?
 
-The SMT solver knows about `bool`, `int` and `set` (also `bitvector` 
-and `map`) but _all_ other types are _currently_ represented as plain 
-`Int` inside the SMT solver. However, we _will be_ changing this 
+The SMT solver knows about `bool`, `int` and `set` (also `bitvector`
+and `map`) but _all_ other types are _currently_ represented as plain
+`Int` inside the SMT solver. However, we _will be_ changing this
 to make use of SMT support for ADTs ...
 
-To sum up: the `FObj` is there for historical reasons; it has been 
-subsumed by `FTC` which is what I recomend you use. However `FObj` 
-is there if you want a simple "unitype" / "any" type for terms 
+To sum up: the `FObj` is there for historical reasons; it has been
+subsumed by `FTC` which is what I recomend you use. However `FObj`
+is there if you want a simple "unitype" / "any" type for terms
 that are not "interpreted".
 
-## Qualifier Patterns 
+## Qualifier Patterns
 
 ```haskell
 λ> doParse' (qualParamP sortP) "" "z as (mon . $1) : int"

--- a/bin/Fixpoint.hs
+++ b/bin/Fixpoint.hs
@@ -24,10 +24,10 @@ solveQuery cfg     = solver cfg `Ex.catch` errorExit
       | otherwise  = solveFQ
 
 isHorn :: F.Config -> Bool
-isHorn cfg = F.isExtFile F.Smt2 file 
+isHorn cfg = F.isExtFile F.Smt2 file
           || F.isExtFile F.Json file
           || F.stdin cfg
-  where 
+  where
     file = F.srcFile cfg
 
 errorExit :: F.Error -> IO ExitCode

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -144,6 +144,7 @@ library
                   , directory
                   , fgl
                   , filepath
+                  , gitrev              >= 1.3.1
                   , hashable
                   , intern
                   , lens-family
@@ -194,7 +195,7 @@ executable fixpoint
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   bin
   ghc-options:      -threaded -W -Wno-missing-methods
-  build-depends:    base >= 4.9.1.0 && < 5, liquid-fixpoint
+  build-depends:    base >= 4.9.1.0 && < 5, liquid-fixpoint, gitrev >= 1.3.1
   if flag(devel)
     ghc-options: -Werror
   default-language: Haskell98

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -264,7 +264,7 @@ reduceFInfo cfg fi = do
       reducedFi = {- SCC "reduceEnvironments" -} reduceEnvironments simplifiedFi
   when (save cfg) $
     savePrettifiedQuery cfg reducedFi
-  if noEnvironmentReduction cfg then
+  if noEnvReduction cfg then
     return fi
   else
     return reducedFi

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -516,7 +516,7 @@ simplifyBindings cfg finfo =
 
           mergedEnv = mergeDuplicatedBindings env
           undoANFEnv =
-            if inlineANFBindings cfg then undoANFOnlyModified mergedEnv else HashMap.empty
+            if inlineANFBinds cfg then undoANFOnlyModified mergedEnv else HashMap.empty
           boolSimplEnv =
             simplifyBooleanRefts $ HashMap.union undoANFEnv mergedEnv
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -301,7 +301,7 @@ ple1 ie@InstEnv{..} ictx i res = do
   where
     -- Pending unfoldings (i.e. with undecided guards) are collected only
     -- when we reach a leaf in the Trie, and only if the user asked for them.
-    collectPendingUnfoldings env (Just _) | pleWithUndecidedGuards ieCfg =
+    collectPendingUnfoldings env (Just _) | pleUndecGuards ieCfg =
       M.toList (evPendingUnfoldings env)
     collectPendingUnfoldings _ _ = []
 
@@ -1276,7 +1276,7 @@ knowledge cfg si = KN
   , knConsts                   = Mb.mapMaybe makeCons sims
   , knAutoRWs                  = aenvAutoRW aenv
   , knRWTerminationOpts        =
-      if rwTerminationCheck cfg
+      if rwTermination cfg
       then RWTerminationCheckEnabled
       else RWTerminationCheckDisabled
   }

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -103,26 +103,24 @@ data Config = Config
   , nonLinCuts       :: Bool           -- ^ Treat non-linear vars as cuts
   , noslice          :: Bool           -- ^ Disable non-concrete KVar slicing
   , rewriteAxioms    :: Bool           -- ^ Allow axiom instantiation via rewriting
-  , pleWithUndecidedGuards :: Bool     -- ^ Unfold invocations with undecided guards in PLE
+  , pleUndecGuards   :: Bool           -- ^ Unfold invocations with undecided guards in PLE
   , etabeta          :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
   , localRewrites    :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
   , interpreter      :: Bool           -- ^ Do not use the interpreter to assist PLE
   , oldPLE           :: Bool           -- ^ Use old version of PLE
   , noIncrPle        :: Bool           -- ^ Use incremental PLE
-  , noEnvironmentReduction :: Bool     -- ^ Don't use environment reduction
-  , inlineANFBindings :: Bool          -- ^ Inline ANF bindings.
+  , noEnvReduction   :: Bool     -- ^ Don't use environment reduction
+  , inlineANFBinds   :: Bool          -- ^ Inline ANF bindings.
                                        -- Sometimes improves performance and sometimes worsens it.
   , checkCstr        :: [Integer]      -- ^ Only check these specific constraints
   , extensionality   :: Bool           -- ^ Enable extensional interpretation of function equality
-  , rwTerminationCheck  :: Bool        -- ^ Enable termination checking for rewriting
+  , rwTermination    :: Bool        -- ^ Enable termination checking for rewriting
   , stdin               :: Bool        -- ^ Read input query from stdin
   , json                :: Bool        -- ^ Render output in JSON format
   , noLazyPLE           :: Bool
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
-  -- , version             :: Bool        -- ^ Show version information
-  -- , numericVersion      :: Bool        -- ^ Show numeric version only
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -266,7 +264,7 @@ defConfig = Config {
   , nonLinCuts               = False &= help "Treat non-linear kvars as cuts"
   , noslice                  = False &= help "Disable non-concrete KVar slicing"
   , rewriteAxioms            = False &= name "ple" &= help "Allow axiom instantiation via rewriting (PLE)"
-  , pleWithUndecidedGuards   =
+  , pleUndecGuards   =
       False
         &= name "ple-with-undecided-guards"
         &= help "Unfold invocations with undecided guards in PLE"
@@ -277,33 +275,23 @@ defConfig = Config {
         &= help "Use the interpreter to assist PLE"
   , oldPLE                   = False &= help "Use old version of PLE"
   , etabeta                  = False &= help "Use eta expansion and beta reduction to aid PLE"
-  , localRewrites            = False &= name "local-rewrites" &= help "Perform local rewrites inside PLE"
+  , localRewrites            = False &= help "Perform local rewrites inside PLE"
   , noIncrPle                = False &= help "Don't use incremental PLE"
-  , noEnvironmentReduction   =
-      False
-        &= name "no-environment-reduction"
-        &= help "Don't perform environment reduction"
-  , inlineANFBindings        =
-      False
-        &= name "inline-anf-bindings"
-        &= help (unwords
+  , noEnvReduction           = False &= help "Don't perform environment reduction"
+  , inlineANFBinds           = False &= help (unwords
           [ "Inline ANF bindings."
           , "Sometimes improves performance and sometimes worsens it."
-          , "Disabled by --no-environment-reduction"
+          , "Disabled by --noenvreduction"
           ])
   , checkCstr                = []    &= help "Only check these specific constraint-ids"
   , extensionality           = False &= help "Allow extensional interpretation of extensionality"
-  , rwTerminationCheck       = False   &= help "Enable rewrite divergence checker"
+  , rwTermination       = False   &= help "Enable rewrite divergence checker"
   , stdin                    = False   &= help "Read input query from stdin"
   , json                     = False   &= help "Render result in JSON"
   , noLazyPLE                = False   &= help "Don't use lazy PLE"
   , fuel                     = Nothing &= help "Maximum fuel (per-function unfoldings) for PLE"
-  , restOrdering             = "rpo"
-        &= name "rest-ordering"
-        &= help "Ordering Constraint Algebra to use for REST"
+  , restOrdering             = "rpo"   &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"
-  -- , version                  = False &= help "Show version information"
-  -- , numericVersion           = False &= help "Show numeric version only"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE UndecidableInstances      #-}
 {-# LANGUAGE DeriveGeneric             #-}
+{-# LANGUAGE TemplateHaskell           #-}
 
 module Language.Fixpoint.Types.Config (
     Config  (..)
@@ -45,7 +46,9 @@ import System.Console.CmdArgs.Explicit
 
 import qualified Language.Fixpoint.Conditional.Z3 as Conditional.Z3
 import Language.Fixpoint.Utils.Files
-
+import Development.GitRev (gitHash)
+import Data.Version (showVersion)
+import Paths_liquid_fixpoint (version)
 
 --------------------------------------------------------------------------------
 withPragmas :: Config -> [String] -> IO Config
@@ -118,6 +121,8 @@ data Config = Config
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
+  -- , version             :: Bool        -- ^ Show version information
+  -- , numericVersion      :: Bool        -- ^ Show numeric version only
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -297,17 +302,21 @@ defConfig = Config {
         &= name "rest-ordering"
         &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"
+  -- , version                  = False &= help "Show version information"
+  -- , numericVersion           = False &= help "Show numeric version only"
   }
   &= verbosity
   &= program "fixpoint"
   &= help    "Predicate Abstraction Based Horn-Clause Solver"
-  &= summary "fixpoint Copyright 2009-15 Regents of the University of California."
+  &= summary summaryInfo
   &= details [ "Predicate Abstraction Based Horn-Clause Solver"
              , ""
              , "To check a file foo.fq type:"
              , "  fixpoint foo.fq"
              ]
 
+summaryInfo :: String
+summaryInfo = "fixpoint " ++ showVersion version ++ " " ++ "("  ++ $(gitHash) ++ ")"
 config :: Mode (CmdArgs Config)
 config = cmdArgsMode defConfig
 
@@ -318,7 +327,7 @@ getOpts = do
   return md
 
 banner :: String
-banner =  "\n\nLiquid-Fixpoint Copyright 2013-21 Regents of the University of California.\n"
+banner =  "\n\nLiquid-Fixpoint Copyright 2009-25 Regents of the University of California.\n"
        ++ "All Rights Reserved.\n"
 
 restOC :: Config -> RESTOrdering


### PR DESCRIPTION
I shortened the flag names so the `--help` renders more nicely (otherwise the text is weirdly squished into too few columns making it hard to read...) This may require matching updates to LH.