### PR TITLE
Generalize bindings

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -98,6 +98,7 @@ library
                     Language.Fixpoint.Solver.Worklist
                     Language.Fixpoint.SortCheck
                     Language.Fixpoint.Types
+                    Language.Fixpoint.Types.Binders
                     Language.Fixpoint.Types.Config
                     Language.Fixpoint.Types.Constraints
                     Language.Fixpoint.Types.Environments

--- a/src/Language/Fixpoint/Horn/Info.hs
+++ b/src/Language/Fixpoint/Horn/Info.hs
@@ -108,7 +108,7 @@ predExpr kve        = go
 kvApp :: KVEnv a -> F.Symbol -> [F.Expr] -> F.Expr
 kvApp kve k ys = F.PKVar (F.KV k) su
   where
-    su         = F.mkSubst (zip params ys)
+    su         = F.mkKVarSubst (zip params ys)
     params     = maybe err1 kvParams (M.lookup k kve)
     err1       = F.panic ("Unknown Horn variable: " ++ F.showpp k)
 

--- a/src/Language/Fixpoint/Horn/Transformations.hs
+++ b/src/Language/Fixpoint/Horn/Transformations.hs
@@ -476,7 +476,7 @@ cstrToExpr (All (Bind x t p _) c) = F.PAll [(x,t)] $ F.PImp (predToExpr p) $ cst
 
 predToExpr :: Pred -> F.Expr
 predToExpr (Reft e) = e
-predToExpr (Var k xs) = F.PKVar (F.KV k) (F.Su $ M.fromList su)
+predToExpr (Var k xs) = F.PKVar (F.KV k) (F.toKVarSubst $ M.fromList su)
   where su = zip (kargs k) xs
 predToExpr (PAnd ps) = F.PAnd $ predToExpr <$> ps
 

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -85,9 +85,9 @@ getUniqueInt = do
 -- | Edit Distance --------------------------------------------
 ---------------------------------------------------------------
 
-{-# SCC editDistance #-}
-editDistance :: Eq a => [a] -> [a] -> Int
-editDistance xs ys = table ! (m, n)
+{-# SCC levenshteinDistance #-}
+levenshteinDistance :: Eq a => [a] -> [a] -> Int
+levenshteinDistance xs ys = table ! (m, n)
     where
     (m,n) = (length xs, length ys)
     x     = array (1,m) (zip [1..] xs)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -777,12 +777,12 @@ symconstP = SL . T.pack <$> stringLiteral
 -- parse names as LocSymbol as well, this class can be eliminated.
 class (Fixpoint v, Ord v) => ParseableV v where
   parseV :: ParserV v v
-  mkSu :: [(Symbol, ExprV v)] -> SubstV v
+  mkSu :: [(Symbol, ExprV v)] -> KVarSubst Symbol v
   vFromString :: Located String -> v
 
 instance ParseableV Symbol where
   parseV = symbolP
-  mkSu = mkSubst
+  mkSu = mkKVarSubst
   vFromString = symbol
 
 -- | Parser for "atomic" expressions.
@@ -1102,7 +1102,7 @@ kvarPredP = PKVar <$> kvarP <*> substP
 kvarP :: ParserV v KVar
 kvarP = KV <$> lexeme (char '$' *> symbolR)
 
-substP :: ParseableV v => ParserV v (SubstV v)
+substP :: ParseableV v => ParserV v (KVarSubst Symbol v)
 substP = mkSu <$> many (brackets $ pairP symbolP aP exprP)
   where
     aP = reservedOp ":="

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -111,9 +111,9 @@ nonCutHyp kI si k = nonCutCube <$> cs
     cs            = getSubC   si <$> M.lookupDefault [] k kI
 
 nonCutCube :: SimpC a -> Sol.Cube
-nonCutCube c = Sol.Cube (senv c) (rhsSubst c) (subcId c) (stag c)
+nonCutCube c = Sol.Cube (senv c) (substFromKSubst $ rhsSubst c) (subcId c) (stag c)
 
-rhsSubst :: SimpC a -> Subst
+rhsSubst :: SimpC a -> KVarSubst Symbol Symbol
 rhsSubst             = rsu . crhs
   where
     rsu (PKVar _ su) = su

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -76,8 +76,7 @@ import           Language.Fixpoint.Types.Refinements
   , Expr
   , KVar(..)
   , SortedReft(..)
-  , Subst
-  , SubstV(..)
+  , KVarSubst
   , pattern PTrue
   , pattern PFalse
   , dropECst
@@ -91,6 +90,7 @@ import           Language.Fixpoint.Types.Refinements
   , reftPred
   , sortedReftSymbols
   , subst1
+  , fromKVarSubst
   )
 import           Language.Fixpoint.Types.Sorts (boolSort, sortSymbols)
 import           Language.Fixpoint.Types.Visitor (mapExprOnExpr)
@@ -399,7 +399,7 @@ relatedKVarBinds bindEnv cs =
    in
       (bindIdsByKVar, substsByKVar, kvarsBySubC)
   where
-    kvarsByBindId :: HashMap BindId (HashMap KVar [Subst])
+    kvarsByBindId :: HashMap BindId (HashMap KVar [KVarSubst Symbol Symbol])
     kvarsByBindId =
       HashMap.map (exprKVars . reftPred . sr_reft . snd3) $ beBinds bindEnv
 
@@ -408,9 +408,8 @@ relatedKVarBinds bindEnv cs =
     kvarBindsFromSubC :: ReducedConstraint a -> HashMap KVar (HashSet Symbol)
     kvarBindsFromSubC sc =
       let c = originalConstraint sc
-          unSubst (Su su) = su
           substsToHashSet =
-            HashSet.fromMap . HashMap.map (const ()) . HashMap.unions . map unSubst
+            HashSet.fromMap . HashMap.map (const ()) . HashMap.unions . map fromKVarSubst
        in foldl' (HashMap.unionWith HashSet.union) HashMap.empty $
           map (HashMap.map substsToHashSet) $
           (exprKVars (reftPred $ sr_reft $ srhs c) :) $

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -72,7 +72,7 @@ import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Refinements
   ( Brel(..)
-  , ExprV(..)
+  , ExprBV(..)
   , Expr
   , KVar(..)
   , SortedReft(..)

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -38,7 +38,7 @@ import           Language.Fixpoint.Types.Names
   )
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Refinements
-  ( ExprV(..)
+  ( ExprBV(..)
   , pattern PFalse
   , Reft
   , SortedReft(..)

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -189,7 +189,7 @@ kvarDefUses si = (Misc.group ins, Misc.group outs)
 -- | `dropDeadSubsts` removes dead `K[x := e]` where `x` NOT in the domain of K.
 --------------------------------------------------------------------------------
 dropDeadSubsts :: F.SInfo a -> F.SInfo a
-dropDeadSubsts si = mapKVarSubsts (F.filterSubst . f) si
+dropDeadSubsts si = mapKVarSubsts (\k su -> F.toKVarSubst $ M.filterWithKey (f k) $ F.fromKVarSubst su) si
   where
     kvsM          = M.mapWithKey (\k _ -> kvDom k) (F.ws si)
     kvDom         = S.fromList . F.kvarDomain si
@@ -244,9 +244,9 @@ dropBadParams kBads k kEnv = L.foldl' (flip F.deleteSEnv) kEnv xs
 badParams :: F.SInfo a -> F.SimpC a -> M.HashMap F.KVar [F.Symbol]
 badParams si c = Misc.group bads
   where
-    bads       = [ (k, x) | (v, k, F.Su su) <- subcKSubs xsrs c
+    bads       = [ (k, x) | (v, k, su) <- subcKSubs xsrs c
                           , let vEnv = maybe sEnv (`S.insert` sEnv) v
-                          , (x, e)          <- M.toList su
+                          , (x, e)          <- M.toList (F.fromKVarSubst su)
                           , badArg vEnv e
                  ]
     sEnv       = S.fromList (fst <$> xsrs)
@@ -256,7 +256,7 @@ badArg :: S.HashSet F.Symbol -> F.Expr -> Bool
 badArg sEnv (F.EVar y) = not (y `S.member` sEnv)
 badArg _    _          = True
 
-type KSub = (Maybe F.Symbol, F.KVar, F.Subst)
+type KSub = (Maybe F.Symbol, F.KVar, F.KVarSubst F.Symbol F.Symbol)
 
 subcKSubs :: [(F.Symbol, F.SortedReft)] -> F.SimpC a -> [KSub]
 subcKSubs xsrs c = rhs ++ lhs

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -328,7 +328,7 @@ applyKVars cfg g s ks =
 applyKVar :: Config -> CombinedEnv ann -> Sol.Sol Sol.QBind -> F.KVSub -> ExprInfo
 applyKVar cfg  g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
   Left cs   -> hypPred cfg g s ksu cs
-  Right eqs -> let qbp = Sol.qbPreds (F.ksuSubst ksu) eqs
+  Right eqs -> let qbp = Sol.qbPreds (F.substFromKSubst $ F.ksuSubst ksu) eqs
                 in (F.pAndNoDedup $ fst <$> qbp, mempty) -- TODO: don't initialize kvars that have a hyp solution
 
 mkNonCutsExpr :: Config -> CombinedEnv ann -> Sol.Sol Sol.QBind -> F.KVar -> Sol.Hyp -> F.Expr
@@ -422,7 +422,7 @@ cubePred cfg g s ksu c    =
     bs' = F.diffIBindEnv bs (Misc.safeLookup "sScp" k (Sol.sScp s))
     bs  = Sol.cuBinds c
     k   = F.ksuKVar ksu
-    su = dropUnsortedExprs cfg g (F.ksuSubst  ksu)
+    su = dropUnsortedExprs cfg g (F.substFromKSubst $ F.ksuSubst  ksu)
 
 -- | @cubePredExc@ computes the predicate for the subset of binders bs'.
 --

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -268,10 +268,10 @@ refineC bindingsInSmt be _i s c =
     rhsCands s = M.toList $ M.fromList $ map cnd ks
       where
         ks          = predKs . F.crhs $ c
-        cnd :: (F.KVar, F.Subst) -> (F.KVar , Sol.Cand Sol.EQual)
-        cnd (k, su) = (k, Sol.qbPreds su (Sol.lookupQBind s k))
+        cnd :: (F.KVar, F.KVarSubst F.Symbol F.Symbol) -> (F.KVar , Sol.Cand Sol.EQual)
+        cnd (k, su) = (k, Sol.qbPreds (F.substFromKSubst su) (Sol.lookupQBind s k))
 
-predKs :: F.Expr -> [(F.KVar, F.Subst)]
+predKs :: F.ExprBV b v -> [(F.KVar, F.KVarSubst b v)]
 predKs (F.PAnd ps)    = concatMap predKs ps
 predKs (F.PKVar k su) = [(k, su)]
 predKs _              = []

--- a/src/Language/Fixpoint/Solver/UniqifyKVars.hs
+++ b/src/Language/Fixpoint/Solver/UniqifyKVars.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                    #-}
+{-# LANGUAGE ViewPatterns           #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 {- | This module creates new bindings for each argument of each kvar.
@@ -56,14 +57,14 @@ remakeSubsts :: SInfo a -> SInfo a
 --------------------------------------------------------------------------------
 remakeSubsts fi = mapKVarSubsts (remakeSubst fi) fi
 
-remakeSubst :: SInfo a -> KVar -> Subst -> Subst
+remakeSubst :: SInfo a -> KVar -> KVarSubst Symbol Symbol -> KVarSubst Symbol Symbol
 remakeSubst fi k su = foldl' (updateSubst k) su (kvarDomain fi k)
 
-updateSubst :: KVar -> Subst -> Symbol -> Subst
-updateSubst k (Su su) sym
+updateSubst :: KVar -> KVarSubst Symbol Symbol -> Symbol -> KVarSubst Symbol Symbol
+updateSubst k (fromKVarSubst -> su) sym
   = case M.lookup sym su of
-      Just z  -> Su $ M.delete sym $ M.insert ksym z          su
-      Nothing -> Su $                M.insert ksym (eVar sym) su
+      Just z  -> toKVarSubst $ M.delete sym $ M.insert ksym z          su
+      Nothing -> toKVarSubst $                M.insert ksym (eVar sym) su
     where
       kx      = kv k
       ksym    = kArgSymbol sym kx

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -286,7 +286,7 @@ elabFMap (PAtom r e1 e2)   = PAtom r (elabFMap e1) (elabFMap e2)
 elabFMap (PAll   bs e)     = PAll bs (elabFMap e)
 elabFMap (PExist bs e)     = PExist bs (elabFMap e)
 elabFMap (ECoerc a t e)    = ECoerc a t (elabFMap e)
-elabFMap (PKVar k (Su m))  = PKVar k (Su (elabFMap <$> m))
+elabFMap (PKVar k su)      = PKVar k (toKVarSubst (elabFMap <$> fromKVarSubst su))
 elabFMap e                 = e
 
 
@@ -333,7 +333,7 @@ elabFSetBagZ3 = go
     go (PAll   bs e)      = PAll bs (go e)
     go (PExist bs e)      = PExist bs (go e)
     go (ECoerc a t e)     = ECoerc a t (go e)
-    go (PKVar k (Su m))   = PKVar k (Su (go <$> m))
+    go (PKVar k su)       = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
     go e                  = e
 
 -- | Reverse transformation of elabFSetBagZ3: converts array representations back to set/bag operations
@@ -412,7 +412,7 @@ unElabFSetBagZ3 = go
     go (PAll   bs e)      = PAll bs (go e)
     go (PExist bs e)      = PExist bs (go e)
     go (ECoerc a t e)     = ECoerc a t (go e)
-    go (PKVar k (Su m))   = PKVar k (Su (go <$> m))
+    go (PKVar k su)       = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
     go e                  = e
 
 
@@ -435,7 +435,7 @@ elabSorts ef (PAtom r e1 e2)   = PAtom r (elabSorts ef e1) (elabSorts ef e2)
 elabSorts ef (PAll   bs e)     = PAll bs (elabSorts ef e)
 elabSorts ef (PExist bs e)     = PExist bs (elabSorts ef e)
 elabSorts ef (ECoerc s1 s2 e)  = ECoerc (coerceSort ef s1) (coerceSort ef s2) (elabSorts ef e)
-elabSorts ef (PKVar k (Su m))  = PKVar k (Su (elabSorts ef <$> m))
+elabSorts ef (PKVar k su)      = PKVar k (toKVarSubst (elabSorts ef <$> fromKVarSubst su))
 elabSorts _ e                 = e
 
 --------------------------------------------------------------------------------
@@ -502,7 +502,7 @@ elabApply env = go
     step e@EApp {}        = go e
     step (ELam b e)       = ELam b       (go e)
     step (ECoerc a t e)   = ECoerc a t   (go e)
-    step (PKVar k (Su m)) = PKVar k (Su (go <$> m))
+    step (PKVar k su)     = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
     step e@ESym{}         = e
     step e@ECon{}         = e
     step e@EVar{}         = e
@@ -759,14 +759,14 @@ elab !_ e@(ECon (L _ !s)) =
 -- TODO: the guard below is because some LH tests generate PKVar with ill-sorted substitutions.
 -- However, a cleaner solution could be to modify `Sanitize.restrictKVarDomain` to simply
 -- those ill-sorted substitutions right up at the outset.
-elab !f e@(PKVar k (Su m)) = do
+elab !f e@(PKVar k su) = do
   expKvars <- asks (elabExplicitKvars . chElabF)
   if expKvars
     then do
-      xargs' <- forM (HashMap.toList m) $ \(x, arg) -> do
+      xargs' <- forM (HashMap.toList $ fromKVarSubst su) $ \(x, arg) -> do
         (arg', _) <- elab f arg
         return (x, arg')
-      return (PKVar k (Su (HashMap.fromList xargs')), boolSort)
+      return (PKVar k (toKVarSubst (HashMap.fromList xargs')), boolSort)
     else
       return (e, boolSort)
 

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE PatternGuards         #-}
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE InstanceSigs #-}
 
 -- | This module has the functions that perform sort-checking, and related
@@ -535,7 +536,7 @@ checkSortExpr sp γ e = case runCM0 sp Nothing (checkExpr f e) of
             Just z  -> Found z
             Nothing -> Alts []
 
-subEnv :: (Subable e) => SEnv a -> e -> SEnv a
+subEnv :: (Subable e, Variable e ~ Symbol) => SEnv a -> e -> SEnv a
 subEnv g e = intersectWithSEnv const g g'
   where
     g' = fromListSEnv $ (, ()) <$> syms e

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -287,7 +287,7 @@ elabFMap (PAtom r e1 e2)   = PAtom r (elabFMap e1) (elabFMap e2)
 elabFMap (PAll   bs e)     = PAll bs (elabFMap e)
 elabFMap (PExist bs e)     = PExist bs (elabFMap e)
 elabFMap (ECoerc a t e)    = ECoerc a t (elabFMap e)
-elabFMap (PKVar k su)      = PKVar k (toKVarSubst (elabFMap <$> fromKVarSubst su))
+elabFMap (PKVar k su)      = PKVar k (mapKVarSubst elabFMap su)
 elabFMap e                 = e
 
 
@@ -334,7 +334,7 @@ elabFSetBagZ3 = go
     go (PAll   bs e)      = PAll bs (go e)
     go (PExist bs e)      = PExist bs (go e)
     go (ECoerc a t e)     = ECoerc a t (go e)
-    go (PKVar k su)       = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
+    go (PKVar k su)       = PKVar k (mapKVarSubst go su)
     go e                  = e
 
 -- | Reverse transformation of elabFSetBagZ3: converts array representations back to set/bag operations
@@ -413,7 +413,7 @@ unElabFSetBagZ3 = go
     go (PAll   bs e)      = PAll bs (go e)
     go (PExist bs e)      = PExist bs (go e)
     go (ECoerc a t e)     = ECoerc a t (go e)
-    go (PKVar k su)       = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
+    go (PKVar k su)       = PKVar k (mapKVarSubst go su)
     go e                  = e
 
 
@@ -436,7 +436,7 @@ elabSorts ef (PAtom r e1 e2)   = PAtom r (elabSorts ef e1) (elabSorts ef e2)
 elabSorts ef (PAll   bs e)     = PAll bs (elabSorts ef e)
 elabSorts ef (PExist bs e)     = PExist bs (elabSorts ef e)
 elabSorts ef (ECoerc s1 s2 e)  = ECoerc (coerceSort ef s1) (coerceSort ef s2) (elabSorts ef e)
-elabSorts ef (PKVar k su)      = PKVar k (toKVarSubst (elabSorts ef <$> fromKVarSubst su))
+elabSorts ef (PKVar k su)      = PKVar k (mapKVarSubst (elabSorts ef) su)
 elabSorts _ e                 = e
 
 --------------------------------------------------------------------------------
@@ -503,7 +503,7 @@ elabApply env = go
     step e@EApp {}        = go e
     step (ELam b e)       = ELam b       (go e)
     step (ECoerc a t e)   = ECoerc a t   (go e)
-    step (PKVar k su)     = PKVar k (toKVarSubst (go <$> fromKVarSubst su))
+    step (PKVar k su)     = PKVar k (mapKVarSubst go su)
     step e@ESym{}         = e
     step e@ECon{}         = e
     step e@EVar{}         = e

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -5,7 +5,7 @@
 
 module Language.Fixpoint.Types (module X) where
 
-import Language.Fixpoint.Types.SMTPrint      as X
+import Language.Fixpoint.Types.SMTPrint         as X
 import Language.Fixpoint.Types.PrettyPrint      as X
 import Language.Fixpoint.Types.Names            as X
 import Language.Fixpoint.Types.Errors           as X
@@ -19,3 +19,4 @@ import Language.Fixpoint.Types.Utils            as X
 import Language.Fixpoint.Types.Triggers         as X
 import Language.Fixpoint.Types.Theories         as X
 import Language.Fixpoint.Types.Templates        as X
+import Language.Fixpoint.Types.Binders          as X

--- a/src/Language/Fixpoint/Types/Binders.hs
+++ b/src/Language/Fixpoint/Types/Binders.hs
@@ -1,0 +1,10 @@
+module Language.Fixpoint.Types.Binders where
+
+import Data.Hashable (Hashable)
+
+class (Eq b, Ord b, Hashable b) => Binder b where
+  wildcard :: b
+  editDistance :: b -> b -> Int
+  editDistance b1 b2
+    | b1 == b2  = 0
+    | otherwise = maxBound

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -121,7 +121,7 @@ import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Refinements
-import           Language.Fixpoint.Types.Substitutions
+import           Language.Fixpoint.Types.Substitutions()
 import           Language.Fixpoint.Types.Environments
 import qualified Language.Fixpoint.Utils.Files as Files
 import qualified Language.Fixpoint.Solver.Stats as Solver
@@ -442,7 +442,7 @@ instance B.Binary v => B.Binary (EquationV v)
 ---------------------------------------------------------------------------
 
 wfC :: (Fixpoint a) => IBindEnv -> SortedReft -> a -> [WfC a]
-wfC be sr x = if all isEmptySubst sus -- ++ gsus)
+wfC be sr x = if all isEmptyKVarSubst sus -- ++ gsus)
                  -- NV TO RJ This tests fails with [LT:=GHC.Types.LT][EQ:=GHC.Types.EQ][GT:=GHC.Types.GT]]
                  -- NV TO RJ looks like a resolution issue
                 then [WfC be (v, sr_sort sr, k) x      | k         <- ks ]
@@ -1059,29 +1059,28 @@ data AutoRewrite = AutoRewrite
 
 instance Hashable AutoRewrite
 
+autoRWToFix :: M.HashMap SubcId [AutoRewrite] -> Doc
+autoRWToFix autoRW =
+  vcat $
+  map fixRW rewrites ++
+  rwsMapping
+  where
+    rewrites = dedupAutoRewrites autoRW
 
-instance Fixpoint (M.HashMap SubcId [AutoRewrite]) where
-  toFix autoRW =
-    vcat $
-    map fixRW rewrites ++
-    rwsMapping
-    where
-      rewrites = dedupAutoRewrites autoRW
+    fixRW rw@(AutoRewrite args lhs rhs) =
+        text ("autorewrite " ++ show (hash rw))
+        <+> hsep (map toFix args)
+        <+> text "="
+        <+> text "{"
+        <+> toFix lhs
+        <+> text "="
+        <+> toFix rhs
+        <+> text "}"
 
-      fixRW rw@(AutoRewrite args lhs rhs) =
-          text ("autorewrite " ++ show (hash rw))
-          <+> hsep (map toFix args)
-          <+> text "="
-          <+> text "{"
-          <+> toFix lhs
-          <+> text "="
-          <+> toFix rhs
-          <+> text "}"
-
-      rwsMapping = do
-        (cid, rws) <- M.toList autoRW
-        rw         <-  rws
-        return $ "rewrite" <+> brackets (text $ show cid ++ " : " ++ show (hash rw))
+    rwsMapping = do
+      (cid, rws) <- M.toList autoRW
+      rw         <-  rws
+      return $ "rewrite" <+> brackets (text $ show cid ++ " : " ++ show (hash rw))
 
 
 
@@ -1103,7 +1102,7 @@ instance ToHornSMT Rewrite where
 instance Fixpoint AxiomEnv where
   toFix axe = vcat ((toFix <$> L.sort (aenvEqs axe)) ++ (toFix <$> L.sort (aenvSimpl axe)))
               $+$ renderExpand (pairdoc <$> L.sort (M.toList $ aenvExpand axe))
-              $+$ toFix (aenvAutoRW axe)
+              $+$ autoRWToFix (aenvAutoRW axe)
     where
       pairdoc (x,y) = text $ show x ++ " : " ++ show y
       renderExpand [] = empty

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -14,8 +14,10 @@
 module Language.Fixpoint.Types.Environments (
 
   -- * Environments
-    SEnv(..)
-  , SESearch(..)
+    SEnv
+  , SEnvB(..)
+  , SESearch
+  , SESearchB(..)
   , emptySEnv, toListSEnv, fromListSEnv, fromMapSEnv
   , mapSEnvWithKey, mapSEnv, mapMSEnv
   , insertSEnv, deleteSEnv, memberSEnv, lookupSEnv, unionSEnv, unionSEnv'
@@ -66,6 +68,7 @@ import qualified Data.List   as L
 import           Data.Generics             (Data)
 import           Data.Typeable             (Typeable)
 import           GHC.Generics              (Generic)
+import           Data.Hashable             (Hashable)
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
 import           Data.Maybe
@@ -75,6 +78,7 @@ import           Control.DeepSeq
 
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.PrettyPrint
+import           Language.Fixpoint.Types.Binders
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Refinements
@@ -89,8 +93,9 @@ newtype IBindEnv   = FB (S.HashSet BindId) deriving (Eq, Data, Show, Typeable, G
 instance PPrint IBindEnv where
   pprintTidy _ = pprint . L.sort . elemsIBindEnv
 
-newtype SEnv a     = SE { seBinds :: M.HashMap Symbol a }
-                     deriving (Eq, Data, Typeable, Generic, Foldable, Traversable)
+type SEnv a = SEnvB Symbol a
+newtype SEnvB b a = SE { seBinds :: M.HashMap b a }
+                    deriving (Eq, Data, Typeable, Generic, Foldable, Traversable)
 
 data SizedEnv a    = BE { _beSize  :: !Int
                         , beBinds :: !(BindMap a)
@@ -111,74 +116,74 @@ splitByQuantifiers (BE i bs) ebs = ( BE i $ M.filterWithKey (\k _ -> notElem k e
 -- data SolEnv        = SolEnv { soeBinds :: !BindEnv }
 --                     deriving (Eq, Show, Generic)
 
-instance PPrint a => PPrint (SEnv a) where
+instance (Ord b, PPrint b, PPrint a) => PPrint (SEnvB b a) where
   pprintTidy k = pprintKVs k . L.sortBy (compare `on` fst) . toListSEnv
 
 {-# SCC toListSEnv #-}
-toListSEnv              ::  SEnv a -> [(Symbol, a)]
+toListSEnv              ::  SEnvB b a -> [(b, a)]
 toListSEnv (SE env)     = M.toList env
 
-fromListSEnv            ::  [(Symbol, a)] -> SEnv a
+fromListSEnv            ::  Hashable b => [(b, a)] -> SEnvB b a
 fromListSEnv            = SE . M.fromList
 
-fromMapSEnv             ::  M.HashMap Symbol a -> SEnv a
+fromMapSEnv             ::  M.HashMap b a -> SEnvB b a
 fromMapSEnv             = SE
 
-mapSEnv                 :: (a -> b) -> SEnv a -> SEnv b
+mapSEnv                 :: (a₁ -> a₂) -> SEnvB b a₁ -> SEnvB b a₂
 mapSEnv f (SE env)      = SE (fmap f env)
 
-mapMSEnv                :: (Monad m) => (a -> m b) -> SEnv a -> m (SEnv b)
+mapMSEnv                :: (Monad m, Hashable b) => (a₁ -> m a₂) -> SEnvB b a₁ -> m (SEnvB b a₂)
 mapMSEnv f env          = fromListSEnv <$> mapM (secondM f) (toListSEnv env)
 
-mapSEnvWithKey          :: ((Symbol, a) -> (Symbol, b)) -> SEnv a -> SEnv b
+mapSEnvWithKey          :: Hashable b => ((b, a₁) -> (b, a₂)) -> SEnvB b a₁ -> SEnvB b a₂
 mapSEnvWithKey f        = fromListSEnv . fmap f . toListSEnv
 
-deleteSEnv :: Symbol -> SEnv a -> SEnv a
+deleteSEnv :: Hashable b => b -> SEnvB b a -> SEnvB b a
 deleteSEnv x (SE env)   = SE (M.delete x env)
 
-insertSEnv :: Symbol -> a -> SEnv a -> SEnv a
+insertSEnv :: Hashable b => b -> a -> SEnvB b a -> SEnvB b a
 insertSEnv x v (SE env) = SE (M.insert x v env)
 
 {-# SCC lookupSEnv #-}
-lookupSEnv :: Symbol -> SEnv a -> Maybe a
+lookupSEnv :: Hashable b => b -> SEnvB b a -> Maybe a
 lookupSEnv x (SE env)   = M.lookup x env
 
-emptySEnv :: SEnv a
+emptySEnv :: SEnvB b a
 emptySEnv               = SE M.empty
 
-memberSEnv :: Symbol -> SEnv a -> Bool
+memberSEnv :: Hashable b => b -> SEnvB b a -> Bool
 memberSEnv x (SE env)   = M.member x env
 
-intersectWithSEnv :: (v1 -> v2 -> a) -> SEnv v1 -> SEnv v2 -> SEnv a
+intersectWithSEnv :: Eq b => (a₁ -> a₂ -> a) -> SEnvB b a₁ -> SEnvB b a₂ -> SEnvB b a
 intersectWithSEnv f (SE m1) (SE m2) = SE (M.intersectionWith f m1 m2)
 
-differenceSEnv :: SEnv a -> SEnv w -> SEnv a
+differenceSEnv :: Hashable b => SEnvB b a -> SEnvB b w -> SEnvB b a
 differenceSEnv (SE m1) (SE m2) = SE (M.difference m1 m2)
 
-filterSEnv :: (a -> Bool) -> SEnv a -> SEnv a
+filterSEnv :: (a -> Bool) -> SEnvB b a -> SEnvB b a
 filterSEnv f (SE m)     = SE (M.filter f m)
 
-unionSEnv :: SEnv a -> M.HashMap Symbol a -> SEnv a
+unionSEnv :: Eq b => SEnvB b a -> M.HashMap b a -> SEnvB b a
 unionSEnv (SE m1) m2    = SE (M.union m1 m2)
 
-unionSEnv' :: SEnv a -> SEnv a -> SEnv a
+unionSEnv' :: Eq b => SEnvB b a -> SEnvB b a -> SEnvB b a
 unionSEnv' (SE m1) (SE m2)    = SE (M.union m1 m2)
 
 {-# SCC lookupSEnvWithDistance #-}
-lookupSEnvWithDistance :: Symbol -> SEnv a -> SESearch a
+lookupSEnvWithDistance :: Binder b => b -> SEnvB b a -> SESearchB b a
 lookupSEnvWithDistance x (SE env)
   = case M.lookup x env of
      Just z  -> Found z
-     Nothing -> Alts $ symbol <$> alts
+     Nothing -> Alts $ alts
   where
-    alts       = takeMin $ zip (editDistance x' <$> ss) ss
-    ss         = symbolString . fst <$> M.toList env
-    x'         = symbolString x
+    alts       = takeMin $ zip (editDistance x <$> ss) ss
+    ss         = fst <$> M.toList env
     takeMin xs = [z | (d, z) <- xs, d == getMin xs]
     getMin     = minimum . (fst <$>)
 
 
-data SESearch a = Found a | Alts [Symbol]
+type SESearch a = SESearchB Symbol a
+data SESearchB b a = Found a | Alts [b]
   deriving Show
 
 -- | Functions for Indexed Bind Environment
@@ -283,7 +288,7 @@ adjustBindEnv f i (BE n m) = BE n (M.adjust f' i m)
 deleteBindEnv :: BindId -> BindEnv a -> BindEnv a
 deleteBindEnv i (BE n m) = BE n $ M.delete i m
 
-instance Functor SEnv where
+instance Functor (SEnvB b) where
   fmap = mapSEnv
 
 instance Fixpoint (EBindEnv a) where
@@ -302,10 +307,10 @@ instance (Fixpoint a) => Fixpoint (SEnv a) where
 instance Fixpoint (SEnv a) => Show (SEnv a) where
   show = render . toFix
 
-instance Semigroup (SEnv a) where
+instance Eq b => Semigroup (SEnvB b a) where
   s1 <> s2 = SE $ M.union (seBinds s1) (seBinds s2)
 
-instance Monoid (SEnv a) where
+instance Eq b => Monoid (SEnvB b a) where
   mempty        = SE M.empty
 
 instance Semigroup (BindEnv a) where

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -174,7 +174,7 @@ lookupSEnvWithDistance :: Binder b => b -> SEnvB b a -> SESearchB b a
 lookupSEnvWithDistance x (SE env)
   = case M.lookup x env of
      Just z  -> Found z
-     Nothing -> Alts $ alts
+     Nothing -> Alts alts
   where
     alts       = takeMin $ zip (editDistance x <$> ss) ss
     ss         = fst <$> M.toList env

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -148,6 +148,8 @@ import           Data.Typeable               (Typeable)
 import qualified GHC.Arr                     as Arr
 import           GHC.Generics                (Generic)
 import           Text.PrettyPrint.HughesPJ   (text)
+import           Language.Fixpoint.Misc
+import           Language.Fixpoint.Types.Binders
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Utils.Builder as Builder (fromText)
@@ -208,6 +210,10 @@ instance Hashable (Description Symbol) where
 instance Hashable Symbol where
   -- NOTE: hash based on original text rather than id
   hashWithSalt s (S _ t _) = hashWithSalt s t
+
+instance Binder Symbol where
+  wildcard = vv Nothing
+  editDistance s1 s2 = levenshteinDistance (symbolString s1) (symbolString s2)
 
 instance NFData Symbol where
   rnf S {} = ()

--- a/src/Language/Fixpoint/Types/PrettyPrint.hs
+++ b/src/Language/Fixpoint/Types/PrettyPrint.hs
@@ -31,6 +31,12 @@ instance (Ord a, Hashable a, Fixpoint a) => Fixpoint (S.HashSet a) where
   toFix xs = brackets $ sep $ punctuate ";" (toFix <$> L.sort (S.toList xs))
   simplify = S.fromList . map simplify . S.toList
 
+instance (Ord k, Hashable k, Fixpoint k, Fixpoint v) => Fixpoint (M.HashMap k v) where
+  toFix m = case hashMapToAscList m of
+              []  -> empty
+              xys -> hcat $ map (\(x,y) -> brackets $ toFix x <-> text ":=" <-> toFix y) xys
+  simplify = M.map simplify . M.mapKeys simplify
+
 instance Fixpoint () where
   toFix _ = "()"
 

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -39,7 +39,8 @@ module Language.Fixpoint.Types.Refinements (
   , KVarSubst
   , KVSub (..)
   , Reft
-  , ReftV (..)
+  , ReftV
+  , ReftBV (..)
   , SortedReft (..)
 
   -- * Constructing Terms
@@ -105,15 +106,18 @@ module Language.Fixpoint.Types.Refinements (
   -- * Transforming
   , mapPredReft
   , onEverySubexpr
+  , mapBindExpr
   , pprintReft
   , mapKVarSubst
+  , mapBindKVarSubst
+  , mapBindReft
 
   , debruijnIndex
 
   ) where
 
 import           Prelude hiding ((<>))
-import           Data.Bifunctor (second)
+import           Data.Bifunctor (first, second)
 import qualified Data.Store as S
 import           Data.Generics             (Data, gmapT, mkT, extT)
 import           Data.Typeable             (Typeable)
@@ -137,6 +141,7 @@ import qualified Data.HashMap.Strict       as M
 import           Control.DeepSeq
 import           Data.Maybe                (isJust)
 import           Language.Fixpoint.Types.Names
+import           Language.Fixpoint.Types.Binders
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Sorts
@@ -264,6 +269,9 @@ toKVarSubst = KSu . M.toList
 mapKVarSubst :: (ExprBV b v -> ExprBV b v) -> KVarSubst b v -> KVarSubst b v
 mapKVarSubst f (KSu su) = KSu $ fmap (fmap f) su
 
+mapBindKVarSubst :: (Hashable b, Hashable b') => (b -> b') -> KVarSubst b v -> KVarSubst b' v
+mapBindKVarSubst f = toKVarSubst . fmap (mapBindExpr f) . M.mapKeys f . fromKVarSubst
+
 isEmptyKVarSubst :: KVarSubst b v -> Bool
 isEmptyKVarSubst (KSu su) = null su
 
@@ -388,6 +396,32 @@ pattern EDiv e1 e2 = EBin Div    e1 e2
 pattern ERDiv :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern ERDiv e1 e2 = EBin RDiv   e1 e2
 
+mapBindExpr :: (Hashable b, Hashable b') => (b -> b') -> ExprBV b v -> ExprBV b' v
+mapBindExpr f = go
+  where
+    go (ESym c) = ESym c
+    go (ECon c) = ECon c
+    go (EVar v) = EVar v
+    go (EApp e1 e2) = EApp (go e1) (go e2)
+    go (ENeg e) = ENeg (go e)
+    go (EBin op e1 e2) = EBin op (go e1) (go e2)
+    go (ELet b e1 e2) = ELet (f b) (go e1) (go e2)
+    go (EIte e1 e2 e3) = EIte (go e1) (go e2) (go e3)
+    go (ECst e s) = ECst (go e) s
+    go (ELam (b, s) e) = ELam (f b, s) (go e)
+    go (ETApp e s) = ETApp (go e) s
+    go (ETAbs e b) = ETAbs (go e) (f b)
+    go (PAnd es) = PAnd (go <$> es)
+    go (POr es) = POr (go <$> es)
+    go (PNot e) = PNot (go e)
+    go (PImp e1 e2) = PImp (go e1) (go e2)
+    go (PIff e1 e2) = PIff (go e1) (go e2)
+    go (PAtom rel e1 e2) = PAtom rel (go e1) (go e2)
+    go (PKVar k su) = PKVar k (mapBindKVarSubst f su)
+    go (PAll bs e) = PAll (first f <$> bs) (go e)
+    go (PExist bs e) = PExist (first f <$> bs) (go e)
+    go (ECoerc s1 s2 e) = ECoerc s1 s2 (go e)
+
 exprSymbolsSet :: (Eq v, Hashable v) => ExprBV v v -> HashSet v
 exprSymbolsSet = go
   where
@@ -460,7 +494,7 @@ exprKVars = go
     go (PExist _xts p)     = go p
     go _                  = HashMap.empty
 
-mkEApp :: LocSymbol -> [Expr] -> Expr
+mkEApp :: Located v -> [ExprBV b v] -> ExprBV b v
 mkEApp = eApps . EVar . val
 
 eApps :: ExprBV b v -> [ExprBV b v] -> ExprBV b v
@@ -522,11 +556,15 @@ debruijnIndex = go
     go (ECoerc _ _ e)  = go e
 
 type Reft = ReftV Symbol
+type ReftV v = ReftBV Symbol v
 
 -- | Refinement of @v@ satisfying a predicate
 --   e.g. in '{x: _ | e }' x is the @Symbol@ and e the @ExprV v@
-newtype ReftV v = Reft (Symbol, ExprV v)
+newtype ReftBV b v = Reft (b, ExprBV b v)
     deriving (Eq, Ord, Data, Typeable, Generic, Functor, Foldable, Traversable)
+
+mapBindReft :: (Hashable b, Hashable b') => (b -> b') -> ReftBV b v -> ReftBV b' v
+mapBindReft f (Reft (b, e)) = Reft (f b, mapBindExpr f e)
 
 data SortedReft = RR { sr_sort :: !Sort, sr_reft :: !Reft }
                   deriving (Eq, Ord, Data, Typeable, Generic)
@@ -616,9 +654,10 @@ instance (Ord b, Fixpoint b, Hashable b, Ord v, Fixpoint v) => Fixpoint (ExprBV 
   toFix (ECoerc a t e)   = parens (text "coerce" <+> toFix a <+> text "~" <+> toFix t <+> text "in" <+> toFix e)
   toFix (ELam (x,s) e)   = parens (char '\\' <+> toFix x <+> ":" <+> toFix s <+> "->" <+> toFix e)
 
-  simplify = simplifyExpr dedup
-    where
-      dedup = Set.toList . Set.fromList
+  simplify = simplifyExprDefault
+
+simplifyExprDefault :: (Ord b, Ord v) => ExprBV b v -> ExprBV b v
+simplifyExprDefault = simplifyExpr (Set.toList . Set.fromList)
 
 simplifyExpr :: (Eq b, Eq v) => ([ExprBV b v] -> [ExprBV b v]) -> ExprBV b v -> ExprBV b v
 simplifyExpr dedup = go
@@ -920,13 +959,13 @@ conj ps  = PAnd ps
 --   so they SHOULD NOT be used inside the solver loop. Instead, use 'conj' which ensures
 --   some basic things but is faster.
 
-pAnd, pOr     :: (Fixpoint b, Ord b, Hashable b, Fixpoint v, Ord v) => ListNE (ExprBV b v) -> ExprBV b v
-pAnd          = simplify . PAnd
+pAnd, pOr     :: (Ord b, Hashable b, Ord v) => ListNE (ExprBV b v) -> ExprBV b v
+pAnd          = simplifyExprDefault . PAnd
 
 pAndNoDedup :: ListNE Pred -> Pred
 pAndNoDedup = simplifyExpr id . PAnd
 
-pOr           = simplify . POr
+pOr           = simplifyExprDefault . POr
 
 infixl 9 &.&
 (&.&) :: Pred -> Pred -> Pred
@@ -983,13 +1022,13 @@ isFunctionSortedReft = isJust . functionSort . sr_sort
 isNonTrivial :: SortedReft -> Bool
 isNonTrivial = not . isTautoReft . sr_reft
 
-isTautoReft :: Eq v => ReftV v -> Bool
+isTautoReft :: (Eq b, Eq v) => ReftBV b v -> Bool
 isTautoReft = all isTautoPred . conjuncts . reftPred
 
-reftPred :: ReftV v -> ExprV v
+reftPred :: ReftBV b v -> ExprBV b v
 reftPred (Reft (_, p)) = p
 
-reftBind :: ReftV v -> Symbol
+reftBind :: ReftBV b v -> b
 reftBind (Reft (x, _)) = x
 
 ------------------------------------------------------------
@@ -1008,9 +1047,9 @@ vv_ = vv Nothing
 trueSortedReft :: Sort -> SortedReft
 trueSortedReft = (`RR` trueReft)
 
-trueReft, falseReft :: ReftV v
-trueReft  = Reft (vv_, PTrue)
-falseReft = Reft (vv_, PFalse)
+trueReft, falseReft :: Binder b => ReftBV b v
+trueReft  = Reft (wildcard, PTrue)
+falseReft = Reft (wildcard, PFalse)
 
 flattenRefas :: [ExprBV b v] -> [ExprBV b v]
 flattenRefas        = flatP []
@@ -1033,11 +1072,11 @@ conjuncts p
 class Falseable a where
   isFalse :: a -> Bool
 
-instance Falseable Expr where
+instance Falseable (ExprBV b v) where
   isFalse PFalse = True
   isFalse _      = False
 
-instance Falseable Reft where
+instance Falseable (ReftBV b v) where
   isFalse (Reft (_, ra)) = isFalse ra
 
 -------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -35,6 +35,7 @@ module Language.Fixpoint.Types.Refinements (
   , KVar (..)
   , Subst
   , SubstV (..)
+  , KVarSubst
   , KVSub (..)
   , Reft
   , ReftV (..)
@@ -69,6 +70,7 @@ module Language.Fixpoint.Types.Refinements (
   , predReft                -- any pred : p
   , reftPred
   , reftBind
+  , toKVarSubst
 
   -- * Predicates
   , isFunctionSortedReft, functionSort
@@ -96,11 +98,14 @@ module Language.Fixpoint.Types.Refinements (
   , sortedReftSymbols
   , substSortInExpr
   , sortSubstInExpr
+  , fromKVarSubst
+  , isEmptyKVarSubst
 
   -- * Transforming
   , mapPredReft
   , onEverySubexpr
   , pprintReft
+  , mapKVarSubst
 
   , debruijnIndex
 
@@ -148,6 +153,7 @@ instance NFData Constant
 instance NFData SymConst
 instance NFData Brel
 instance NFData Bop
+instance (NFData b, NFData v) => NFData (KVarSubst b v)
 instance (NFData b, NFData v) => NFData (ExprBV b v)
 instance NFData v => NFData (ReftV v)
 instance NFData SortedReft
@@ -162,6 +168,7 @@ instance S.Store Constant
 instance S.Store SymConst
 instance S.Store Brel
 instance S.Store Bop
+instance S.Store (KVarSubst Symbol Symbol)
 instance S.Store Expr
 instance S.Store Reft
 instance S.Store SortedReft
@@ -178,8 +185,9 @@ instance (Hashable k, Eq k, B.Binary k, B.Binary v) => B.Binary (M.HashMap k v) 
   put = B.put . M.toList
   get = M.fromList <$> B.get
 
-instance B.Binary v => B.Binary (SubstV v)
-instance (B.Binary b, Hashable b, B.Binary v) => B.Binary (ExprBV b v)
+instance (B.Binary v, Hashable v) => B.Binary (SubstV v)
+instance (B.Binary b, B.Binary v) => B.Binary (KVarSubst b v)
+instance (B.Binary b, B.Binary v) => B.Binary (ExprBV b v)
 instance B.Binary v => B.Binary (ReftV v)
 
 
@@ -220,6 +228,7 @@ instance Hashable Bop
 instance Hashable SymConst
 instance Hashable Constant
 instance Hashable v => Hashable (SubstV v)
+instance (Hashable b, Hashable v) => Hashable (KVarSubst b v)
 instance (Hashable b, Hashable v) => Hashable (ExprBV b v)
 instance Hashable v => Hashable (ReftV v)
 
@@ -227,28 +236,50 @@ instance Hashable v => Hashable (ReftV v)
 -- | Substitutions -------------------------------------------------------------
 --------------------------------------------------------------------------------
 type Subst = SubstV Symbol
-newtype SubstV v = Su (M.HashMap Symbol (ExprV v))
-                deriving (Eq, Data, Ord, Typeable, Generic, Functor, Foldable, Traversable)
+newtype SubstV v = Su (M.HashMap v (ExprBV v v))
+                deriving (Eq, Data, Ord, Typeable, Generic)
 
 instance ToJSON Subst
 instance FromJSON Subst
 
-instance (Fixpoint v, Ord v, Show v) => Show (SubstV v) where
+instance (Fixpoint v, Ord v, Hashable v, Show v) => Show (SubstV v) where
   show = showFix
 
-instance (Ord v, Fixpoint v) => Fixpoint (SubstV v) where
-  toFix (Su m) = case hashMapToAscList m of
-                   []  -> empty
-                   xys -> hcat $ map (\(x,y) -> brackets $ toFix x <-> text ":=" <-> toFix y) xys
+instance (Ord v, Hashable v, Fixpoint v) => Fixpoint (SubstV v) where
+  toFix (Su m) = toFix m
 
-instance (Ord v, Fixpoint v) => PPrint (SubstV v) where
+instance (Ord v, Hashable v, Fixpoint v) => PPrint (SubstV v) where
+  pprintTidy _ = toFix
+
+newtype KVarSubst b v = KSu [(b, ExprBV b v)]
+  deriving (Eq, Ord, Data, Typeable, Generic, Functor, Foldable, Traversable)
+
+fromKVarSubst :: Hashable b => KVarSubst b v -> M.HashMap b (ExprBV b v)
+fromKVarSubst (KSu su) = M.fromList su
+
+toKVarSubst :: M.HashMap b (ExprBV b v) -> KVarSubst b v
+toKVarSubst = KSu . M.toList
+
+mapKVarSubst :: (ExprBV b v -> ExprBV b v) -> KVarSubst b v -> KVarSubst b v
+mapKVarSubst f (KSu su) = KSu $ fmap (fmap f) su
+
+isEmptyKVarSubst :: KVarSubst b v -> Bool
+isEmptyKVarSubst (KSu su) = null su
+
+instance (Ord v, Fixpoint v, Ord b, Fixpoint b, Hashable b) => Show (KVarSubst b v) where
+  show = showFix
+
+instance (Ord v, Fixpoint v, Ord b, Fixpoint b, Hashable b) => Fixpoint (KVarSubst b v) where
+  toFix = toFix . fromKVarSubst
+
+instance (Ord v, Fixpoint v, Ord b, Fixpoint b, Hashable b) => PPrint (KVarSubst b v) where
   pprintTidy _ = toFix
 
 data KVSub = KVS
   { ksuVV    :: Symbol
   , ksuSort  :: Sort
   , ksuKVar  :: KVar
-  , ksuSubst :: Subst
+  , ksuSubst :: KVarSubst Symbol Symbol
   } deriving (Eq, Data, Typeable, Generic, Show)
 
 instance PPrint KVSub where
@@ -278,11 +309,13 @@ data Bop  = Plus | Minus | Times | Div | Mod | RTimes | RDiv
 instance ToJSON Constant  where
 instance ToJSON Brel      where
 instance ToJSON Bop       where
+instance ToJSON (KVarSubst Symbol Symbol) where
 instance ToJSON Expr      where
 
 instance FromJSON Constant  where
 instance FromJSON Brel      where
 instance FromJSON Bop       where
+instance FromJSON (KVarSubst Symbol Symbol) where
 instance FromJSON Expr      where
 
 
@@ -308,7 +341,7 @@ data ExprBV b v
           | PImp   !(ExprBV b v) !(ExprBV b v)
           | PIff   !(ExprBV b v) !(ExprBV b v)
           | PAtom  !Brel  !(ExprBV b v) !(ExprBV b v)
-          | PKVar  !KVar !(SubstV v)
+          | PKVar  !KVar !(KVarSubst b v)
           | PAll   ![(b, Sort)] !(ExprBV b v)
           | PExist ![(b, Sort)] !(ExprBV b v)
           | ECoerc !Sort !Sort !(ExprBV b v)
@@ -373,7 +406,7 @@ exprSymbolsSet = go
     go (PIff p1 p2)       = gos [p1, p2]
     go (PImp p1 p2)       = gos [p1, p2]
     go (PAtom _ e1 e2)    = gos [e1, e2]
-    go (PKVar _ (Su su))  = HashSet.unions $ map exprSymbolsSet (M.elems su)
+    go (PKVar _ su)       = HashSet.unions $ map exprSymbolsSet (M.elems $ fromKVarSubst su)
     go (PAll xts p)       = go p `HashSet.difference` HashSet.fromList (fst <$> xts)
     go (PExist xts p)     = go p `HashSet.difference` HashSet.fromList (fst <$> xts)
     go _                  = HashSet.empty
@@ -401,7 +434,7 @@ sortSubstInExpr f = onEverySubexpr go
       ECoerc t0 t1 e -> ECoerc (sortSubst f t0) (sortSubst f t1) e
       e -> e
 
-exprKVars :: Expr -> HashMap KVar [Subst]
+exprKVars :: Expr -> HashMap KVar [KVarSubst Symbol Symbol]
 exprKVars = go
   where
     gos es                = HashMap.unions (go <$> es)
@@ -420,8 +453,8 @@ exprKVars = go
     go (PIff p1 p2)       = gos [p1, p2]
     go (PImp p1 p2)       = gos [p1, p2]
     go (PAtom _ e1 e2)    = gos [e1, e2]
-    go (PKVar k substs@(Su su))  =
-      HashMap.insertWith (++) k [substs] $ HashMap.unions $ map exprKVars (M.elems su)
+    go (PKVar k su) =
+      HashMap.insertWith (++) k [su] $ HashMap.unions $ map exprKVars (M.elems $ fromKVarSubst su)
     go (PAll _xts p)       = go p
     go (PExist _xts p)     = go p
     go _                  = HashMap.empty
@@ -551,7 +584,7 @@ instance Fixpoint Bop where
   toFix RDiv   = text "/."
   toFix Mod    = text "mod"
 
-instance (Ord b, Fixpoint b, Ord v, Fixpoint v) => Fixpoint (ExprBV b v) where
+instance (Ord b, Fixpoint b, Hashable b, Ord v, Fixpoint v) => Fixpoint (ExprBV b v) where
   toFix (ESym c)       = toFix c
   toFix (ECon c)       = toFix c
   toFix (EVar s)       = toFix s
@@ -718,7 +751,7 @@ opPrec RTimes = 7
 opPrec Div    = 7
 opPrec RDiv   = 7
 
-instance (Ord b, Fixpoint b, Ord v, Fixpoint v, PPrint v) => PPrint (ExprBV b v) where
+instance (Ord b, Fixpoint b, Hashable b, PPrint b, Ord v, Fixpoint v, PPrint v) => PPrint (ExprBV b v) where
   pprintPrec _ k (ESym c)        = pprintTidy k c
   pprintPrec _ k (ECon c)        = pprintTidy k c
   pprintPrec _ k (EVar s)        = pprintTidy k s
@@ -782,7 +815,7 @@ instance (Ord b, Fixpoint b, Ord v, Fixpoint v, PPrint v) => PPrint (ExprBV b v)
   pprintPrec _ _ (ETAbs e s)     = "ETAbs" <+> toFix e <+> toFix s
 
 pprintQuant
-  :: (Ord b, Fixpoint b, Ord v, Fixpoint v, PPrint v)
+  :: (Ord b, Fixpoint b, Hashable b, PPrint b, Ord v, Fixpoint v, PPrint v)
   => Tidy -> Doc -> [(b, Sort)] -> ExprBV b v -> Doc
 pprintQuant k d xts p = (d <+> pprintTidy k xts)
                         $+$
@@ -886,7 +919,7 @@ conj ps  = PAnd ps
 --   so they SHOULD NOT be used inside the solver loop. Instead, use 'conj' which ensures
 --   some basic things but is faster.
 
-pAnd, pOr     :: (Fixpoint b, Ord b, Fixpoint v, Ord v) => ListNE (ExprBV b v) -> ExprBV b v
+pAnd, pOr     :: (Fixpoint b, Ord b, Hashable b, Fixpoint v, Ord v) => ListNE (ExprBV b v) -> ExprBV b v
 pAnd          = simplify . PAnd
 
 pAndNoDedup :: ListNE Pred -> Pred
@@ -902,7 +935,7 @@ infixl 9 |.|
 (|.|) :: Pred -> Pred -> Pred
 (|.|) p q = pOr [p, q]
 
-pIte :: (Fixpoint b, Ord b, Fixpoint v, Ord v) => ExprBV b v -> ExprBV b v -> ExprBV b v -> ExprBV b v
+pIte :: (Fixpoint b, Ord b, Hashable b, Fixpoint v, Ord v) => ExprBV b v -> ExprBV b v -> ExprBV b v -> ExprBV b v
 pIte p1 p2 p3 = pAnd [p1 `PImp` p2, PNot p1 `PImp` p3]
 
 pExist :: [(b, Sort)] -> ExprBV b v -> ExprBV b v

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE PatternSynonyms            #-}
 {-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE TypeFamilies               #-}
 
 {-# OPTIONS_GHC -Wno-orphans            #-}
 
@@ -387,7 +388,7 @@ pattern EDiv e1 e2 = EBin Div    e1 e2
 pattern ERDiv :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern ERDiv e1 e2 = EBin RDiv   e1 e2
 
-exprSymbolsSet :: Expr -> HashSet Symbol
+exprSymbolsSet :: (Eq v, Hashable v) => ExprBV v v -> HashSet v
 exprSymbolsSet = go
   where
     gos es                = HashSet.unions (go <$> es)
@@ -1043,17 +1044,21 @@ instance Falseable Reft where
 -- | Class Predicates for Valid Refinements -----------------------------
 -------------------------------------------------------------------------
 
-class Subable a where
-  syms   :: a -> [Symbol]                   -- ^ free symbols of a
-  substa :: (Symbol -> Symbol) -> a -> a
+class (Eq (Variable a), Hashable (Variable a)) => Subable a where
+  type Variable a
+  type Variable a = Symbol
+
+  syms   :: a -> [Variable a]                   -- ^ free symbols of a
+  substa :: (Variable a -> Variable a) -> a -> a
   -- substa f  = substf (EVar . f)
 
-  substf :: (Symbol -> Expr) -> a -> a
-  subst  :: HasCallStack => Subst -> a -> a
-  subst1 :: a -> (Symbol, Expr) -> a
+  substf :: (Variable a -> ExprBV (Variable a) (Variable a)) -> a -> a
+  subst  :: HasCallStack => SubstV (Variable a) -> a -> a
+  subst1 :: a -> (Variable a, ExprBV (Variable a) (Variable a)) -> a
   subst1 y (x, e) = subst (Su $ M.fromList [(x,e)]) y
 
 instance Subable a => Subable (Located a) where
+  type Variable (Located a) = Variable a
   syms (Loc _ _ x)   = syms x
   substa f (Loc l l' x) = Loc l l' (substa f x)
   substf f (Loc l l' x) = Loc l l' (substf f x)

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -26,7 +26,8 @@ module Language.Fixpoint.Types.Refinements (
   , Constant (..)
   , Bop (..)
   , Brel (..)
-  , ExprV (..), Pred
+  , ExprBV (..)
+  , ExprV, Pred
   , Expr
   , pattern PTrue, pattern PTop, pattern PFalse, pattern EBot
   , pattern ETimes, pattern ERTimes, pattern EDiv, pattern ERDiv
@@ -147,7 +148,7 @@ instance NFData Constant
 instance NFData SymConst
 instance NFData Brel
 instance NFData Bop
-instance NFData v => NFData (ExprV v)
+instance (NFData b, NFData v) => NFData (ExprBV b v)
 instance NFData v => NFData (ReftV v)
 instance NFData SortedReft
 
@@ -178,7 +179,7 @@ instance (Hashable k, Eq k, B.Binary k, B.Binary v) => B.Binary (M.HashMap k v) 
   get = M.fromList <$> B.get
 
 instance B.Binary v => B.Binary (SubstV v)
-instance B.Binary v => B.Binary (ExprV v)
+instance (B.Binary b, Hashable b, B.Binary v) => B.Binary (ExprBV b v)
 instance B.Binary v => B.Binary (ReftV v)
 
 
@@ -219,7 +220,7 @@ instance Hashable Bop
 instance Hashable SymConst
 instance Hashable Constant
 instance Hashable v => Hashable (SubstV v)
-instance Hashable v => Hashable (ExprV v)
+instance (Hashable b, Hashable v) => Hashable (ExprBV b v)
 instance Hashable v => Hashable (ReftV v)
 
 --------------------------------------------------------------------------------
@@ -286,30 +287,31 @@ instance FromJSON Expr      where
 
 
 type Expr = ExprV Symbol
+type ExprV v = ExprBV Symbol v
 
-data ExprV v
+data ExprBV b v
           = ESym !SymConst
           | ECon !Constant
           | EVar !v
-          | EApp !(ExprV v) !(ExprV v)
-          | ENeg !(ExprV v)
-          | EBin !Bop !(ExprV v) !(ExprV v)
-          | ELet !Symbol !(ExprV v) !(ExprV v)
-          | EIte !(ExprV v) !(ExprV v) !(ExprV v)
-          | ECst !(ExprV v) !Sort
-          | ELam !(Symbol, Sort)   !(ExprV v)
-          | ETApp !(ExprV v) !Sort
-          | ETAbs !(ExprV v) !Symbol
-          | PAnd   ![ExprV v]
-          | POr    ![ExprV v]
-          | PNot   !(ExprV v)
-          | PImp   !(ExprV v) !(ExprV v)
-          | PIff   !(ExprV v) !(ExprV v)
-          | PAtom  !Brel  !(ExprV v) !(ExprV v)
+          | EApp !(ExprBV b v) !(ExprBV b v)
+          | ENeg !(ExprBV b v)
+          | EBin !Bop !(ExprBV b v) !(ExprBV b v)
+          | ELet !b !(ExprBV b v) !(ExprBV b v)
+          | EIte !(ExprBV b v) !(ExprBV b v) !(ExprBV b v)
+          | ECst !(ExprBV b v) !Sort
+          | ELam !(b, Sort)   !(ExprBV b v)
+          | ETApp !(ExprBV b v) !Sort
+          | ETAbs !(ExprBV b v) !b
+          | PAnd   ![ExprBV b v]
+          | POr    ![ExprBV b v]
+          | PNot   !(ExprBV b v)
+          | PImp   !(ExprBV b v) !(ExprBV b v)
+          | PIff   !(ExprBV b v) !(ExprBV b v)
+          | PAtom  !Brel  !(ExprBV b v) !(ExprBV b v)
           | PKVar  !KVar !(SubstV v)
-          | PAll   ![(Symbol, Sort)] !(ExprV v)
-          | PExist ![(Symbol, Sort)] !(ExprV v)
-          | ECoerc !Sort !Sort !(ExprV v)
+          | PAll   ![(b, Sort)] !(ExprBV b v)
+          | PExist ![(b, Sort)] !(ExprBV b v)
+          | ECoerc !Sort !Sort !(ExprBV b v)
           deriving (Eq, Show, Ord, Data, Typeable, Generic, Functor, Foldable, Traversable)
 
 onEverySubexpr :: (Expr -> Expr) -> Expr -> Expr
@@ -325,31 +327,31 @@ everywhereOnA f = go
 
 type Pred = Expr
 
-pattern PTrue :: ExprV v
+pattern PTrue :: ExprBV b v
 pattern PTrue = PAnd []
 
-pattern PTop :: ExprV v
+pattern PTop :: ExprBV b v
 pattern PTop = PAnd []
 
-pattern PFalse :: ExprV v
+pattern PFalse :: ExprBV b v
 pattern PFalse = POr  []
 
-pattern EBot :: ExprV v
+pattern EBot :: ExprBV b v
 pattern EBot = POr  []
 
-pattern EEq :: ExprV v -> ExprV v -> ExprV v
+pattern EEq :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern EEq e1 e2 = PAtom Eq    e1 e2
 
-pattern ETimes :: ExprV v -> ExprV v -> ExprV v
+pattern ETimes :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern ETimes e1 e2 = EBin Times  e1 e2
 
-pattern ERTimes :: ExprV v -> ExprV v -> ExprV v
+pattern ERTimes :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern ERTimes e1 e2 = EBin RTimes e1 e2
 
-pattern EDiv :: ExprV v -> ExprV v -> ExprV v
+pattern EDiv :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern EDiv e1 e2 = EBin Div    e1 e2
 
-pattern ERDiv :: ExprV v -> ExprV v -> ExprV v
+pattern ERDiv :: ExprBV b v -> ExprBV b v -> ExprBV b v
 pattern ERDiv e1 e2 = EBin RDiv   e1 e2
 
 exprSymbolsSet :: Expr -> HashSet Symbol
@@ -427,10 +429,10 @@ exprKVars = go
 mkEApp :: LocSymbol -> [Expr] -> Expr
 mkEApp = eApps . EVar . val
 
-eApps :: ExprV v -> [ExprV v] -> ExprV v
+eApps :: ExprBV b v -> [ExprBV b v] -> ExprBV b v
 eApps f es  = foldl' EApp f es
 
-splitEApp :: ExprV v -> (ExprV v, [ExprV v])
+splitEApp :: ExprBV b v -> (ExprBV b v, [ExprBV b v])
 splitEApp = go []
   where
     go acc (EApp f e) = go (e:acc) f
@@ -549,7 +551,7 @@ instance Fixpoint Bop where
   toFix RDiv   = text "/."
   toFix Mod    = text "mod"
 
-instance (Ord v, Fixpoint v) => Fixpoint (ExprV v) where
+instance (Ord b, Fixpoint b, Ord v, Fixpoint v) => Fixpoint (ExprBV b v) where
   toFix (ESym c)       = toFix c
   toFix (ECon c)       = toFix c
   toFix (EVar s)       = toFix s
@@ -584,7 +586,7 @@ instance (Ord v, Fixpoint v) => Fixpoint (ExprV v) where
     where
       dedup = Set.toList . Set.fromList
 
-simplifyExpr :: Eq v => ([ExprV v] -> [ExprV v]) -> ExprV v -> ExprV v
+simplifyExpr :: (Eq b, Eq v) => ([ExprBV b v] -> [ExprBV b v]) -> ExprBV b v -> ExprBV b v
 simplifyExpr dedup = go
   where
     go (POr  [])     = PFalse
@@ -629,7 +631,7 @@ simplifyExpr dedup = go
       | isTautoPred  p     = PTrue
       | otherwise          = p
 
-isContraPred   :: Eq v => ExprV v -> Bool
+isContraPred   :: (Eq b, Eq v) => ExprBV b v -> Bool
 isContraPred z = eqC z || (z `elem` contras)
   where
     contras    = [PFalse]
@@ -644,7 +646,7 @@ isContraPred z = eqC z || (z `elem` contras)
                = x == y
     eqC _      = False
 
-isTautoPred   :: Eq v => ExprV v -> Bool
+isTautoPred   :: (Eq b, Eq v) => ExprBV b v -> Bool
 isTautoPred z  = z == PTop || z == PTrue || eqT z
   where
     eqT (PAnd [])
@@ -716,7 +718,7 @@ opPrec RTimes = 7
 opPrec Div    = 7
 opPrec RDiv   = 7
 
-instance (Ord v, Fixpoint v, PPrint v) => PPrint (ExprV v) where
+instance (Ord b, Fixpoint b, Ord v, Fixpoint v, PPrint v) => PPrint (ExprBV b v) where
   pprintPrec _ k (ESym c)        = pprintTidy k c
   pprintPrec _ k (ECon c)        = pprintTidy k c
   pprintPrec _ k (EVar s)        = pprintTidy k s
@@ -780,8 +782,8 @@ instance (Ord v, Fixpoint v, PPrint v) => PPrint (ExprV v) where
   pprintPrec _ _ (ETAbs e s)     = "ETAbs" <+> toFix e <+> toFix s
 
 pprintQuant
-  :: (Ord v, Fixpoint v, PPrint v)
-  => Tidy -> Doc -> [(Symbol, Sort)] -> ExprV v -> Doc
+  :: (Ord b, Fixpoint b, Ord v, Fixpoint v, PPrint v)
+  => Tidy -> Doc -> [(b, Sort)] -> ExprBV b v -> Doc
 pprintQuant k d xts p = (d <+> pprintTidy k xts)
                         $+$
                         ("  ." <+> pprintTidy k p)
@@ -884,7 +886,7 @@ conj ps  = PAnd ps
 --   so they SHOULD NOT be used inside the solver loop. Instead, use 'conj' which ensures
 --   some basic things but is faster.
 
-pAnd, pOr     :: (Fixpoint v, Ord v) => ListNE (ExprV v) -> ExprV v
+pAnd, pOr     :: (Fixpoint b, Ord b, Fixpoint v, Ord v) => ListNE (ExprBV b v) -> ExprBV b v
 pAnd          = simplify . PAnd
 
 pAndNoDedup :: ListNE Pred -> Pred
@@ -900,10 +902,10 @@ infixl 9 |.|
 (|.|) :: Pred -> Pred -> Pred
 (|.|) p q = pOr [p, q]
 
-pIte :: (Fixpoint v, Ord v) => ExprV v -> ExprV v -> ExprV v -> ExprV v
+pIte :: (Fixpoint b, Ord b, Fixpoint v, Ord v) => ExprBV b v -> ExprBV b v -> ExprBV b v -> ExprBV b v
 pIte p1 p2 p3 = pAnd [p1 `PImp` p2, PNot p1 `PImp` p3]
 
-pExist :: [(Symbol, Sort)] -> ExprV v -> ExprV v
+pExist :: [(b, Sort)] -> ExprBV b v -> ExprBV b v
 pExist []  p = p
 pExist xts p = PExist xts p
 
@@ -976,14 +978,14 @@ trueReft, falseReft :: ReftV v
 trueReft  = Reft (vv_, PTrue)
 falseReft = Reft (vv_, PFalse)
 
-flattenRefas :: [ExprV v] -> [ExprV v]
+flattenRefas :: [ExprBV b v] -> [ExprBV b v]
 flattenRefas        = flatP []
   where
     flatP acc (PAnd ps:xs) = flatP (flatP acc xs) ps
     flatP acc (p:xs)       = p : flatP acc xs
     flatP acc []           = acc
 
-conjuncts :: Eq v => ExprV v -> [ExprV v]
+conjuncts :: (Eq b, Eq v) => ExprBV b v -> [ExprBV b v]
 conjuncts (PAnd ps) = concatMap conjuncts ps
 conjuncts p
   | isTautoPred p   = []

--- a/src/Language/Fixpoint/Types/SMTPrint.hs
+++ b/src/Language/Fixpoint/Types/SMTPrint.hs
@@ -92,7 +92,8 @@ toHornFApp ts  = toHornSMT ts
 instance ToHornSMT F.Subst where
   toHornSMT (F.Su m) = toHornSMT (Misc.hashMapToAscList m)
 
-
+instance ToHornSMT (F.KVarSubst F.Symbol F.Symbol) where
+  toHornSMT = toHornSMT . Misc.hashMapToAscList . F.fromKVarSubst
 
 instance ToHornSMT F.KVar where
   toHornSMT (F.KV k) = "$" P.<-> toHornSMT k

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -9,6 +9,10 @@
 --   be in the same place as the @Term@ definitions.
 module Language.Fixpoint.Types.Substitutions (
     mkSubst
+  , mkKVarSubst
+  , substFromKSubst
+  , kSubstFromSubst
+  , ksubst
   , isEmptySubst
   , substExcept
   , substfExcept
@@ -26,6 +30,7 @@ module Language.Fixpoint.Types.Substitutions (
 
 import           Data.List                 as List
 import           Data.Maybe
+import           Data.Hashable             (Hashable)
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
 import           Language.Fixpoint.Types.PrettyPrint
@@ -43,6 +48,22 @@ instance Monoid Subst where
   mempty  = emptySubst
   mappend = (<>)
 
+instance Semigroup (KVarSubst Symbol Symbol) where
+  su1 <> su2 = kSubstFromSubst $ substFromKSubst su1 <> substFromKSubst su2
+
+instance Monoid (KVarSubst Symbol Symbol) where
+  mempty = kSubstFromSubst mempty
+  mappend = (<>)
+
+substFromKSubst :: Hashable v => KVarSubst v v -> SubstV v
+substFromKSubst = Su . fromKVarSubst
+
+kSubstFromSubst :: SubstV v -> KVarSubst v v
+kSubstFromSubst (Su m) = toKVarSubst m
+
+ksubst :: KVarSubst Symbol Symbol -> Expr -> Expr
+ksubst = subst . substFromKSubst
+
 filterSubst :: (Symbol -> Expr -> Bool) -> Subst -> Subst
 filterSubst f (Su m) = Su (M.filterWithKey f m)
 
@@ -59,6 +80,9 @@ mkSubst = Su . M.fromList . reverse . filter notTrivial
   where
     notTrivial (x, EVar y) = x /= y
     notTrivial _           = True
+
+mkKVarSubst :: [(Symbol, Expr)] -> KVarSubst Symbol Symbol
+mkKVarSubst = kSubstFromSubst . mkSubst
 
 isEmptySubst :: Subst -> Bool
 isEmptySubst (Su xes) = M.null xes
@@ -148,7 +172,7 @@ instance Subable Expr where
   substf f (PImp p1 p2)    = PImp (substf f p1) (substf f p2)
   substf f (PIff p1 p2)    = PIff (substf f p1) (substf f p2)
   substf f (PAtom r e1 e2) = PAtom r (substf f e1) (substf f e2)
-  substf f (PKVar k (Su su)) = PKVar k (Su $ M.map (substf f) su)
+  substf f (PKVar k su)    = PKVar k (mapKVarSubst (substf f) su)
   substf _ (PAll _ _)      = errorstar "substf: FORALL"
   substf f (PExist xts e)  = PExist xts (substf f e)
   substf _  p              = p
@@ -193,7 +217,7 @@ instance Subable Expr where
         PAtom r e1 e2 ->
           PAtom r (go su e1) (go su e2)
         PKVar k su' ->
-          PKVar k $ su' `catSubst` su
+          PKVar k $ kSubstFromSubst $ substFromKSubst su' `catSubst` su
         PAll bs p
           | disjointRange su' bs ->
             PAll bs $ go su' p
@@ -288,10 +312,10 @@ rapierSubstExpr s su e0 =
     maybeFresh x =
       if x `S.member` s then Right (x, fresh x) else Left x
 
-    catSubstGo :: Subst -> Subst -> Subst
-    catSubstGo (Su s1) su2@(Su s2) = Su $ M.union s1' s2
+    catSubstGo :: KVarSubst Symbol Symbol -> Subst -> KVarSubst Symbol Symbol
+    catSubstGo su1 su2@(Su s2) = toKVarSubst $ M.union s1 s2
       where
-        s1' = rapierSubstExpr s su2 <$> s1
+        s1 = rapierSubstExpr s su2 <$> fromKVarSubst su1
 
 extendSubst :: Subst -> Symbol -> Expr -> Subst
 extendSubst (Su m) x e = Su $ M.insert x e m
@@ -332,7 +356,7 @@ pprReft (Reft (v, p)) d
   = braces (toFix v <+> colon <+> d <+> text "|" <+> ppRas [p])
 
 -- RJ: this depends on `isTauto` hence, here.
-instance (PPrint v, Fixpoint v, Ord v) => PPrint (ReftV v) where
+instance (PPrint v, Fixpoint v, Ord v, Hashable v) => PPrint (ReftV v) where
   pprintTidy k r
     | isTautoReft r        = text "true"
     | otherwise        = pprintReft k r

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
 
 {-# OPTIONS_GHC -Wno-orphans   #-}
 {-# LANGUAGE InstanceSigs #-}
@@ -41,10 +43,10 @@ import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ.Compat
 import           Text.Printf               (printf)
 
-instance Semigroup Subst where
+instance (Eq v, Hashable v) => Semigroup (SubstV v) where
   (<>) = catSubst
 
-instance Monoid Subst where
+instance (Eq v, Hashable v) => Monoid (SubstV v) where
   mempty  = emptySubst
   mappend = (<>)
 
@@ -64,18 +66,18 @@ kSubstFromSubst (Su m) = toKVarSubst m
 ksubst :: KVarSubst Symbol Symbol -> Expr -> Expr
 ksubst = subst . substFromKSubst
 
-filterSubst :: (Symbol -> Expr -> Bool) -> Subst -> Subst
+filterSubst :: (v -> ExprBV v v -> Bool) -> SubstV v -> SubstV v
 filterSubst f (Su m) = Su (M.filterWithKey f m)
 
-emptySubst :: Subst
+emptySubst :: SubstV v
 emptySubst = Su M.empty
 
-catSubst :: Subst -> Subst -> Subst
+catSubst :: (Eq v, Hashable v) => SubstV v -> SubstV v -> SubstV v
 catSubst (Su s1) θ2@(Su s2) = Su $ M.union s1' s2
   where
     s1'                     = subst θ2 <$> s1
 
-mkSubst :: [(Symbol, Expr)] -> Subst
+mkSubst :: Hashable v => [(v, ExprBV v v)] -> SubstV v
 mkSubst = Su . M.fromList . reverse . filter notTrivial
   where
     notTrivial (x, EVar y) = x /= y
@@ -84,10 +86,10 @@ mkSubst = Su . M.fromList . reverse . filter notTrivial
 mkKVarSubst :: [(Symbol, Expr)] -> KVarSubst Symbol Symbol
 mkKVarSubst = kSubstFromSubst . mkSubst
 
-isEmptySubst :: Subst -> Bool
+isEmptySubst :: SubstV v -> Bool
 isEmptySubst (Su xes) = M.null xes
 
-targetSubstSyms :: Subst -> [Symbol]
+targetSubstSyms :: (Eq v, Hashable v) => SubstV v -> [v]
 targetSubstSyms (Su ms) = syms $ M.elems ms
 
 substSymbolsSet :: Subst -> S.HashSet Symbol
@@ -99,19 +101,22 @@ instance Subable () where
   substf _ () = ()
   substa _ () = ()
 
-instance (Subable a, Subable b) => Subable (a,b) where
+instance (Subable a, Subable b, Variable a ~ Variable b) => Subable (a,b) where
+  type Variable (a, b) = Variable a
   syms  (x, y)   = syms x ++ syms y
   subst su (x,y) = (subst su x, subst su y)
   substf f (x,y) = (substf f x, substf f y)
   substa f (x,y) = (substa f x, substa f y)
 
 instance Subable a => Subable [a] where
+  type Variable [a] = Variable a
   syms   = concatMap syms
   subst  = fmap . subst
   substf = fmap . substf
   substa = fmap . substa
 
 instance Subable a => Subable (Maybe a) where
+  type Variable (Maybe a) = Variable a
   syms   = concatMap syms . maybeToList
   subst  = fmap . subst
   substf = fmap . substf
@@ -119,20 +124,21 @@ instance Subable a => Subable (Maybe a) where
 
 
 instance Subable a => Subable (M.HashMap k a) where
+  type Variable (M.HashMap k a) = Variable a
   syms   = syms . M.elems
   subst  = M.map . subst
   substf = M.map . substf
   substa = M.map . substa
 
-subst1Except :: (Subable a) => [Symbol] -> a -> (Symbol, Expr) -> a
+subst1Except :: Subable a => [Variable a] -> a -> (Variable a, ExprBV (Variable a) (Variable a)) -> a
 subst1Except xs z su@(x, _)
   | x `elem` xs = z
   | otherwise   = subst1 z su
 
-substfExcept :: (Symbol -> Expr) -> [Symbol] -> Symbol -> Expr
+substfExcept :: Eq v => (v -> ExprBV b v) -> [v] -> v -> ExprBV b v
 substfExcept f xs y = if y `elem` xs then EVar y else f y
 
-substExcept  :: Subst -> [Symbol] -> Subst
+substExcept  :: Eq v => SubstV v -> [v] -> SubstV v
 -- substExcept  (Su m) xs = Su (foldr M.delete m xs)
 substExcept (Su xes) xs = Su $ M.filterWithKey (const . not . (`elem` xs)) xes
 
@@ -142,21 +148,22 @@ instance Subable Symbol where
   subst su x               = subSymbol (Just $ appSubst su x) x -- subSymbol (M.lookup x s) x
   syms x                   = [x]
 
-appSubst :: Subst -> Symbol -> Expr
+appSubst :: (Eq v, Hashable v) => SubstV v -> v -> ExprBV v v
 appSubst (Su s) x = fromMaybe (EVar x) (M.lookup x s)
 
-subSymbol :: Maybe Expr -> Symbol -> Symbol
+subSymbol :: (Ord v, Hashable v, Fixpoint v) => Maybe (ExprBV v v) -> v -> v
 subSymbol (Just (EVar y)) _ = y
 subSymbol Nothing         x = x
 subSymbol a               b = errorstar (printf "Cannot substitute symbol %s with expression %s" (showFix b) (showFix a))
 
-captureAvoiding :: Symbol -> (Symbol -> Expr) -> Symbol -> Expr
+captureAvoiding :: Eq v => v -> (v -> ExprBV b v) -> v -> ExprBV b v
 captureAvoiding x f y = if y == x then EVar x else f y
 
-instance Subable Expr where
+instance (Eq v, Hashable v) => Subable (ExprBV v v) where
+  type Variable (ExprBV v v) = v
   syms                     = exprSymbols
   substa f                 = substf (EVar . f)
-  substf :: (Symbol -> Expr) -> Expr -> Expr
+  substf :: (v -> ExprBV v v) -> ExprBV v v -> ExprBV v v
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
   substf f (ELam (x,t) e)  = ELam (x, t) (substf (captureAvoiding x f) e)
   substf f (ECoerc a t e)  = ECoerc a t (substf f e)
@@ -222,28 +229,17 @@ instance Subable Expr where
           | disjointRange su' bs ->
             PAll bs $ go su' p
           | otherwise ->
-            errorstar $ unlines
-              [ "subst: FORALL without disjoint binds"
-              , "su: " ++ showpp su'
-              , "expr: " ++ showpp e0
-              ]
-          where
-            su' = substExcept su (map fst bs)
+            errorstar "subst: PAll (without disjoint binds)"
+
         PExist bs p
           | disjointRange su' bs ->
             PExist bs $ go su' p
           | otherwise ->
-            errorstar $ unlines
-              [ "subst: EXISTS without disjoint binds"
-              , "su: " ++ showpp su'
-              , "expr: " ++ showpp e0
-              ]
-          where
-            su' = substExcept su (map fst bs)
+            errorstar "subst: EXISTS without disjoint binds"
         p ->
           p
 
-removeSubst :: Subst -> Symbol -> Subst
+removeSubst :: (Eq v, Hashable v) => SubstV v -> v -> SubstV v
 removeSubst (Su su) x = Su $ M.delete x su
 
 -- | Rapier style capture-avoiding substitution
@@ -320,7 +316,7 @@ rapierSubstExpr s su e0 =
 extendSubst :: Subst -> Symbol -> Expr -> Subst
 extendSubst (Su m) x e = Su $ M.insert x e m
 
-disjointRange :: Subst -> [(Symbol, Sort)] -> Bool
+disjointRange :: (Eq v, Hashable v) => SubstV v -> [(v, Sort)] -> Bool
 disjointRange (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
     suSyms = S.fromList $ syms (M.elems su)
@@ -356,7 +352,7 @@ pprReft (Reft (v, p)) d
   = braces (toFix v <+> colon <+> d <+> text "|" <+> ppRas [p])
 
 -- RJ: this depends on `isTauto` hence, here.
-instance (PPrint v, Fixpoint v, Ord v, Hashable v) => PPrint (ReftV v) where
+instance (PPrint v, Fixpoint v, Ord v) => PPrint (ReftV v) where
   pprintTidy k r
     | isTautoReft r        = text "true"
     | otherwise        = pprintReft k r
@@ -416,7 +412,7 @@ ppRas = cat . punctuate comma . map toFix . flattenRefas
     -- go _                  = []
 
 
-exprSymbols :: Expr -> [Symbol]
+exprSymbols :: (Eq v, Hashable v) => ExprBV v v -> [v]
 exprSymbols = S.toList . exprSymbolsSet
 
 instance Expression (Symbol, SortedReft) where

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -248,7 +248,10 @@ instance (Eq v, Hashable v) => Subable (ExprBV v v) where
 removeSubst :: (Eq v, Hashable v) => SubstV v -> v -> SubstV v
 removeSubst (Su su) x = Su $ M.delete x su
 
+-- | Variable names for which we can propose variations to avoid name captures
 class Refreshable v where
+  -- | Variations of a variable name. They must contain at least a fresh name in
+  -- the contexts where @candidates@ is used.
   candidates :: v -> [v]
 
 instance Refreshable Symbol where

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -20,6 +20,7 @@ module Language.Fixpoint.Types.Substitutions (
   , substfExcept
   , subst1Except
   , substSymbolsSet
+  , Refreshable(..)
   , rapierSubstExpr
   , targetSubstSyms
   , filterSubst
@@ -93,7 +94,7 @@ isEmptySubst (Su xes) = M.null xes
 targetSubstSyms :: (Eq v, Hashable v) => SubstV v -> [v]
 targetSubstSyms (Su ms) = syms $ M.elems ms
 
-substSymbolsSet :: Subst -> S.HashSet Symbol
+substSymbolsSet :: (Eq v, Hashable v) => SubstV v -> S.HashSet v
 substSymbolsSet (Su m) = S.unions $ map exprSymbolsSet (M.elems m)
 
 instance Subable () where
@@ -231,17 +232,27 @@ instance (Eq v, Hashable v) => Subable (ExprBV v v) where
             PAll bs $ go su' p
           | otherwise ->
             errorstar "subst: PAll (without disjoint binds)"
+          where
+            su' = substExcept su (map fst bs)
 
         PExist bs p
           | disjointRange su' bs ->
             PExist bs $ go su' p
           | otherwise ->
             errorstar "subst: EXISTS without disjoint binds"
+          where
+            su' = substExcept su (map fst bs)
         p ->
           p
 
 removeSubst :: (Eq v, Hashable v) => SubstV v -> v -> SubstV v
 removeSubst (Su su) x = Su $ M.delete x su
+
+class Refreshable v where
+  candidates :: v -> [v]
+
+instance Refreshable Symbol where
+  candidates x = [ renameSubstSymbol x i | i <- [0..] ]
 
 -- | Rapier style capture-avoiding substitution
 --
@@ -249,7 +260,7 @@ removeSubst (Su su) x = Su $ M.delete x su
 -- to appear free in the result expression. Typically, this is the set of
 -- symbols that are free in the range of the substitution, plus any symbols
 -- that are already free in the input expression.
-rapierSubstExpr :: S.HashSet Symbol -> Subst -> Expr -> Expr
+rapierSubstExpr :: (Hashable v, Refreshable v) => S.HashSet v -> SubstV v -> ExprBV v v -> ExprBV v v
 rapierSubstExpr s su e0 =
   let go = rapierSubstExpr
    in case e0 of
@@ -301,20 +312,16 @@ rapierSubstExpr s su e0 =
           PExist bs' $ go s' su' p
     p -> p
   where
-    fresh :: Symbol -> Symbol
-    fresh x = head $ dropWhile (`S.member` s) candidates
-      where
-        candidates = [ renameSubstSymbol x i | i <- [0..] ]
+    fresh x = head $ dropWhile (`S.member` s) (candidates x)
 
     maybeFresh x =
       if x `S.member` s then Right (x, fresh x) else Left x
 
-    catSubstGo :: KVarSubst Symbol Symbol -> Subst -> KVarSubst Symbol Symbol
     catSubstGo su1 su2@(Su s2) = toKVarSubst $ M.union s1 s2
       where
         s1 = rapierSubstExpr s su2 <$> fromKVarSubst su1
 
-extendSubst :: Subst -> Symbol -> Expr -> Subst
+extendSubst :: Hashable v => SubstV v -> v -> ExprBV v v -> SubstV v
 extendSubst (Su m) x e = Su $ M.insert x e m
 
 disjointRange :: (Eq v, Hashable v) => SubstV v -> [(v, Sort)] -> Bool
@@ -329,7 +336,7 @@ meetReft (Reft (v, ra)) (Reft (v', ra'))
   | v == wildcard    = Reft (v', pAnd [ra', ra `subst1`  (v , EVar v')])
   | otherwise        = Reft (v , pAnd [ra, ra' `subst1` (v', EVar v )])
 
-instance (Eq v, Hashable v) => Subable (ReftBV v v) where
+instance (Eq v, Hashable v, Refreshable v) => Subable (ReftBV v v) where
   type Variable (ReftBV v v) = v
   syms (Reft (v, ras))      = v : syms ras
   substa f (Reft (v, ras))  = Reft (f v, substa f ras)

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -35,6 +35,7 @@ import           Data.Maybe
 import           Data.Hashable             (Hashable)
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
+import           Language.Fixpoint.Types.Binders
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Sorts
@@ -322,13 +323,14 @@ disjointRange (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
     suSyms = S.fromList $ syms (M.elems su)
     bsSyms = S.fromList $ fst <$> bs
 
-meetReft :: Reft -> Reft -> Reft
+meetReft :: Binder v => ReftBV v v -> ReftBV v v -> ReftBV v v
 meetReft (Reft (v, ra)) (Reft (v', ra'))
   | v == v'          = Reft (v , pAnd [ra, ra'])
-  | v == dummySymbol = Reft (v', pAnd [ra', ra `subst1`  (v , EVar v')])
+  | v == wildcard    = Reft (v', pAnd [ra', ra `subst1`  (v , EVar v')])
   | otherwise        = Reft (v , pAnd [ra, ra' `subst1` (v', EVar v )])
 
-instance Subable Reft where
+instance (Eq v, Hashable v) => Subable (ReftBV v v) where
+  type Variable (ReftBV v v) = v
   syms (Reft (v, ras))      = v : syms ras
   substa f (Reft (v, ras))  = Reft (f v, substa f ras)
   subst su (Reft (v, ras))  =

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -359,7 +359,7 @@ mapExprOnExpr f = go
       ETAbs e s ->
         let !e' = go e
         in ETAbs e' s
-      PKVar k su -> PKVar k (toKVarSubst (go <$> fromKVarSubst su))
+      PKVar k su -> PKVar k (mapKVarSubst go su)
       e@EVar{} -> e
       e@ESym{} -> e
       e@ECon{} -> e

--- a/src/Language/Fixpoint/Types/Visitor.hs
+++ b/src/Language/Fixpoint/Types/Visitor.hs
@@ -281,11 +281,11 @@ mapKVars f = mapKVars' f'
   where
     f' (kv', _) = f kv'
 
-mapKVars' :: Visitable t => ((KVar, Subst) -> Maybe Expr) -> t -> t
+mapKVars' :: Visitable t => ((KVar, KVarSubst Symbol Symbol) -> Maybe Expr) -> t -> t
 mapKVars' f = trans txK
   where
     txK (PKVar k su)
-      | Just p' <- f (k, su) = subst su p'
+      | Just p' <- f (k, su) = ksubst su p'
     txK p = p
 
 
@@ -359,7 +359,7 @@ mapExprOnExpr f = go
       ETAbs e s ->
         let !e' = go e
         in ETAbs e' s
-      PKVar k (Su m) -> PKVar k (Su (go <$>m))
+      PKVar k su -> PKVar k (toKVarSubst (go <$> fromKVarSubst su))
       e@EVar{} -> e
       e@ESym{} -> e
       e@ECon{} -> e
@@ -418,7 +418,7 @@ mapMExpr f = go
     go (PAnd ps)       = f . PAnd =<< (go `traverse` ps)
     go (POr ps)        = f . POr =<< (go `traverse` ps)
 
-mapKVarSubsts :: Visitable t => (KVar -> Subst -> Subst) -> t -> t
+mapKVarSubsts :: Visitable t => (KVar -> KVarSubst Symbol Symbol -> KVarSubst Symbol Symbol) -> t -> t
 mapKVarSubsts f          = trans txK
   where
     txK (PKVar k su)   = PKVar k (f k su)

--- a/tests/tasty/Arbitrary.hs
+++ b/tests/tasty/Arbitrary.hs
@@ -139,6 +139,12 @@ instance Arbitrary Subst where
     return $ Su $ M.fromList l
   shrink _ = mempty
 
+instance Arbitrary (KVarSubst Symbol Symbol) where
+  arbitrary = do
+    n <- choose (0, 3)
+    l <- vectorOf n arbitrary
+    return $ toKVarSubst $ M.fromList l
+
 -- | This instance only creates `FVar` when they would be in scope from an
 -- enclosing `FAbs`, and does not create `FObj`s
 instance Arbitrary Sort where

--- a/tests/tasty/SimplifyInterpreter.hs
+++ b/tests/tasty/SimplifyInterpreter.hs
@@ -4,7 +4,7 @@ import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
 import Language.Fixpoint.Solver.Interpreter (ICtx (..), Knowledge (..))
 import qualified Language.Fixpoint.Solver.Interpreter as Interpreter
-import Language.Fixpoint.Types.Environments (SEnv (..))
+import Language.Fixpoint.Types.Environments (SEnvB (..))
 import Language.Fixpoint.Types.Refinements (Expr)
 
 interpret' :: Expr -> Expr

--- a/tests/tasty/SimplifyTests.hs
+++ b/tests/tasty/SimplifyTests.hs
@@ -1,7 +1,7 @@
 module SimplifyTests (tests) where
 
 import Arbitrary (subexprs)
-import Language.Fixpoint.Types.Refinements (Bop (Minus), Constant (I), Expr, ExprV (..))
+import Language.Fixpoint.Types.Refinements (Bop (Minus), Constant (I), Expr, ExprBV (..))
 import qualified SimplifyInterpreter
 import qualified SimplifyPLE
 import Test.Tasty


### PR DESCRIPTION
Generalize bindings (e.g. `Symbol` in `ELam`, `ELet`) to a type variable `b`. Similarly to when `v` was added, rename `ExprV` to `ExprBV` with a new type parameter, and add a type alias `ExprV v = ExprBV Symbol v`. Also generalize `Subable` over variables.

This is to support [#2572](https://github.com/ucsd-progsys/liquidhaskell/pull/2572), where the refinements of refinement types are usually stored as a fixpoint `Expr`. Since `ExprBV` requires that `SubstV` is also generalized, I thought it best to consider it jointly with `Subable`.

Some wrinkles to consider:

* For `Subable` I looked at various options, but there's not a clear winner for me. This try is to add a `Variable` type family to `Subable`, which makes sense to me: a type should know the variables it stores, or it is probably a convenience instance that does nothing (e.g. `Subable ()`). For existing instances without requirements it can safely remain a `Symbol` by default, but I generalize the instances in most places here.

  For sites that require `Subable x` for some `x` it was previously guaranteed that the associated functions like `syms` accept / return Symbols, so it is a breaking change for such sites. 
  
  Another option is to add a new class that is generic over variable types (e.g. `SubableV v a`). We could leave it as a separate class, or connect it with `Subable` in various ways. (e.g. make `Subable` a requirement of `SubableV`, or change `Subable` to a constraint alias `Subable = SubableV Symbol`, or add default signatures to `Subable` that require `SubableV Symbol`).
* I don't think substitutions make sense unless `b ~ v`. Consequently I'm not sure whether `SubstBV` deserves to have a separate `b` and `v`. This is currently required because it is also stored as the substitution next to k-vars. 
  
  It would at least make more sense if `SubstBV` would key over `v` instead of `b`, as that's what we're substituting, but this makes it impossible to implement `Functor (SubstBV b)`, as `HashMap` is not a functor in its key. Given that we only apply substitutions when `b ~ v` we can also just write it off as an abuse of notation, but I thought it deserves some consideration.

---

This work has been supported by funding from the _Agentur für Innovation in der Cybersicherheit GmbH ([Cyberagentur](https://www.cyberagentur.de))_ as part of the [Clash Formal](https://clash-formal.org) project.