### PR TITLE
Extend/Fix the Solution Printer

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -124,7 +124,8 @@ library
                     Language.Fixpoint.Utils.Statistics
                     Language.Fixpoint.Utils.Trie
                     Text.PrettyPrint.HughesPJ.Compat
-  other-modules:    Paths_liquid_fixpoint
+  other-modules:    Paths_liquid_fixpoint,
+                    Language.Fixpoint.Types.Version
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   src
   ghc-options:      -W -Wno-missing-methods -Wmissing-signatures

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -107,6 +107,7 @@ library
                     Language.Fixpoint.Types.Errors
                     Language.Fixpoint.Types.Graduals
                     Language.Fixpoint.Types.Names
+                    Language.Fixpoint.Types.SMTPrint
                     Language.Fixpoint.Types.PrettyPrint
                     Language.Fixpoint.Types.Refinements
                     Language.Fixpoint.Types.Solutions

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -124,8 +124,7 @@ library
                     Language.Fixpoint.Utils.Statistics
                     Language.Fixpoint.Utils.Trie
                     Text.PrettyPrint.HughesPJ.Compat
-  other-modules:    Paths_liquid_fixpoint,
-                    Language.Fixpoint.Types.Version
+  other-modules:    Paths_liquid_fixpoint
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   src
   ghc-options:      -W -Wno-missing-methods -Wmissing-signatures

--- a/src/Language/Fixpoint/Horn/Solve.hs
+++ b/src/Language/Fixpoint/Horn/Solve.hs
@@ -67,12 +67,12 @@ saveHornQuery cfg q = do
   saveHornSMT2 cfg q
   saveHornJSON cfg q
 
-saveHornSMT2 :: H.ToHornSMT a => F.Config -> a -> IO ()
+saveHornSMT2 :: F.ToHornSMT a => F.Config -> a -> IO ()
 saveHornSMT2 cfg q = do
   let hq   = F.queryFile Files.HSmt2 cfg
   putStrLn $ "Saving Horn Query: " ++ hq ++ "\n"
   Misc.ensurePath hq
-  writeFile hq $ render ({- F.pprint -} H.toHornSMT q)
+  writeFile hq $ render (F.toHornSMT q)
 
 saveHornJSON :: F.Config -> H.Query H.Tag -> IO ()
 saveHornJSON cfg q = do

--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Language.Fixpoint.Horn.Types
   ( -- * Horn Constraints and their components
@@ -34,8 +33,6 @@ module Language.Fixpoint.Horn.Types
     -- * extract qualifiers
   , quals
 
-    -- * SMTLIB style render
-  , ToHornSMT (..)
   )
   where
 
@@ -63,6 +60,8 @@ data Var a = HVar
   }
   deriving (Eq, Ord, Data, Typeable, Generic, Functor, ToJSON, FromJSON)
 
+
+
 -------------------------------------------------------------------------------
 -- | @HPred@ is a Horn predicate that appears as LHS (body) or RHS (head) of constraints
 -------------------------------------------------------------------------------
@@ -72,6 +71,12 @@ data Pred
   | PAnd  ![Pred]                               -- ^ p1 /\ .../\ pn
   deriving (Data, Typeable, Generic, Eq, ToJSON, FromJSON)
 
+instance F.ToHornSMT (Var a) where
+  toHornSMT (HVar k ts _) = P.parens ("var" P.<+> "$" P.<-> F.pprint k P.<+> F.toHornSMT ts)
+instance F.ToHornSMT Pred where
+  toHornSMT (Reft p)   = P.parens (F.toHornSMT p)
+  toHornSMT (Var k xs) = F.toHornMany (F.toHornSMT (F.KV k) : (F.toHornSMT <$> xs))
+  toHornSMT (PAnd ps)  = F.toHornMany ("and" : (F.toHornSMT <$> ps))
 
 instance F.Subable Pred where
   syms (Reft e)   = F.syms e
@@ -155,6 +160,9 @@ data Bind a = Bind
   }
   deriving (Data, Typeable, Generic, Functor, Eq, ToJSON, FromJSON)
 
+instance F.ToHornSMT (Bind a) where
+  toHornSMT (Bind x t p _) = P.parens (F.toHornSMT (x, t) P.<+> F.toHornSMT p)
+
 instance F.Subable (Bind a) where
     syms     (Bind x _ p _) = x : F.syms p
     substa f (Bind v t p a) = Bind (f v) t (F.substa f p) a
@@ -169,6 +177,17 @@ data Cstr a
   | All   !(Bind a)  !(Cstr a)      -- ^ \all x:t. p => c
   | Any   !(Bind a)  !(Cstr a)      -- ^ \exi x:t. p /\ c or is it \exi x:t. p => c?
   deriving (Data, Typeable, Generic, Functor, Eq, ToJSON, FromJSON)
+
+instance F.ToHornSMT (Cstr a) where
+  toHornSMT = toHornCstr
+
+toHornCstr :: Cstr a -> P.Doc
+toHornCstr (Head p _) = F.toHornSMT p
+toHornCstr (CAnd cs)  = F.toHornAnd toHornCstr cs
+toHornCstr (All b c)  = P.parens (P.vcat ["forall" P.<+> F.toHornSMT b
+                                         , P.nest 1 (toHornCstr c)])
+toHornCstr (Any b c)  = P.parens (P.vcat ["exists" P.<+> F.toHornSMT b
+                                         , P.nest 1 (toHornCstr c)])
 
 cLabel :: Cstr a -> a
 cLabel cstr = case go cstr of
@@ -236,7 +255,9 @@ instance FromJSON Tag where
   parseJSON (String t) = pure (Tag (T.unpack t))
   parseJSON invalid    = prependFailure "parsing `Tag` failed, " (typeMismatch "Object" invalid)
 
-
+instance F.ToHornSMT Tag where
+  toHornSMT NoTag   = mempty
+  toHornSMT (Tag s) = P.text s
 
 
 
@@ -317,163 +338,20 @@ instance F.PPrint (Cstr a) where
 instance F.PPrint (Bind a) where
   pprintPrec _ _ b = P.ptext $ show b
 
-
------------------------------------------------------------------------------------------------------------------
--- Human readable but robustly parseable SMT-LIB format pretty printer
------------------------------------------------------------------------------------------------------------------
-class ToHornSMT a where
-  toHornSMT :: a -> P.Doc
-
-instance ToHornSMT Tag where
-  toHornSMT NoTag   = mempty
-  toHornSMT (Tag s) = P.text s
-
-instance ToHornSMT F.Symbol where
-  toHornSMT s = F.pprint s
-
-instance ToHornSMT (Var a) where
-  toHornSMT (HVar k ts _) = P.parens ("var" P.<+> "$" P.<-> F.pprint k P.<+> toHornSMT ts)
-
-instance ToHornSMT (Query a) where
+instance F.ToHornSMT (Query a) where
   toHornSMT q = P.vcat $ L.intersperse " "
     [ P.vcat   (toHornOpt <$> qOpts q)
     , P.vcat   (toHornNum <$> qNums q)
-    , P.vcat   (toHornSMT <$> qQuals q)
-    , P.vcat   (toHornSMT <$> qVars q)
+    , P.vcat   (F.toHornSMT <$> qQuals q)
+    , P.vcat   (F.toHornSMT <$> qVars q)
     , P.vcat   [toHornCon x t | (x, t) <- M.toList (qCon q)]
-    , P.vcat   (eqnToHornSMT "define"     <$> qEqns q)
-    , P.vcat   (eqnToHornSMT "define_fun" <$> qDefs q)
-    , P.vcat   (toHornSMT <$> qData q)
-    , P.vcat   (toHornSMT <$> qMats q)
-    , P.parens (P.vcat ["constraint", P.nest 1 (toHornSMT (qCstr q))])
+    , P.vcat   (F.eqnToHornSMT "define"     <$> qEqns q)
+    , P.vcat   (F.eqnToHornSMT "define_fun" <$> qDefs q)
+    , P.vcat   (F.toHornSMT <$> qData q)
+    , P.vcat   (F.toHornSMT <$> qMats q)
+    , P.parens (P.vcat ["constraint", P.nest 1 (F.toHornSMT (qCstr q))])
     ]
     where
-      toHornNum x   = toHornMany ["numeric", toHornSMT x]
-      toHornOpt str = toHornMany ["fixpoint", P.text ("\"" ++ str ++ "\"")]
-      toHornCon x t = toHornMany ["constant", toHornSMT x, toHornSMT t]
-
-instance ToHornSMT F.Rewrite where
-  toHornSMT (F.SMeasure f d xs e) =  P.parens ("match" P.<+> toHornSMT f P.<+> toHornSMT (d:xs) P.<+> toHornSMT e)
-
-instance ToHornSMT F.Qualifier where
-  toHornSMT (F.Q n xts p _) =  P.parens ("qualif" P.<+> F.pprint n P.<+> toHornSMT xts P.<+> toHornSMT p)
-
-instance ToHornSMT F.QualParam where
-  toHornSMT qp = toHornSMT (F.qpSym qp, F.qpSort qp)
-
-instance ToHornSMT a => ToHornSMT (F.Symbol, a) where
-  toHornSMT (x, t) = P.parens $ F.pprint x P.<+> toHornSMT t
-
-instance ToHornSMT a => ToHornSMT [a] where
-  toHornSMT = toHornMany . fmap toHornSMT
-
-toHornMany :: [P.Doc] -> P.Doc
-toHornMany = P.parens . P.sep -- Misc.intersperse " "
-
-toHornAnd :: (a -> P.Doc) -> [a] -> P.Doc
-toHornAnd f xs = P.parens (P.vcat ("and" : (P.nest 1 . f <$> xs)))
-
-eqnToHornSMT :: P.Doc -> F.Equation -> P.Doc
-eqnToHornSMT keyword (F.Equ f xs e s _) = P.parens (keyword P.<+> F.pprint f P.<+> toHornSMT xs P.<+> toHornSMT s P.<+> toHornSMT e)
-
-
-instance ToHornSMT F.DataDecl where
-  toHornSMT (F.DDecl tc n ctors) =
-    P.parens $ P.vcat [
-      P.text "datatype" P.<+> P.parens (toHornSMT tc P.<+> P.int n)
-    , P.parens (P.vcat (toHornSMT <$> ctors))
-    ]
-
-instance ToHornSMT F.FTycon where
-  toHornSMT c
-    | c == F.listFTyCon = "list"
-    | otherwise         = toHornSMT (F.symbol c)
-
-instance ToHornSMT a => ToHornSMT (F.Located a) where
-  toHornSMT = toHornSMT . F.val
-instance ToHornSMT F.DataCtor where
-  toHornSMT (F.DCtor x flds) = P.parens (toHornSMT x P.<+> toHornSMT flds)
-
-instance ToHornSMT F.DataField where
-  toHornSMT (F.DField x t) = toHornSMT (F.val x, t)
-
-instance ToHornSMT F.Sort where
-  toHornSMT = toHornSort
-
-toHornSort :: F.Sort -> P.Doc
-toHornSort (F.FVar i)     = "@" P.<-> P.parens (P.int i)
-toHornSort F.FInt         = "Int"
-toHornSort F.FReal        = "Real"
-toHornSort F.FFrac        = "Frac"
-toHornSort (F.FObj x)     = toHornSMT x -- P.parens ("obj" P.<+> toHornSMT x)
-toHornSort F.FNum         = "num"
-toHornSort t@(F.FAbs _ _) = toHornAbsApp t
-toHornSort t@(F.FFunc _ _)= toHornAbsApp t
-toHornSort (F.FTC c)      = toHornSMT c
-toHornSort t@(F.FApp _ _) = toHornFApp (F.unFApp t)
-
-toHornAbsApp :: F.Sort -> P.Doc
-toHornAbsApp (F.functionSort -> Just (vs, ss, s)) = P.parens ("func" P.<+> P.int (length vs) P.<+> toHornSMT ss P.<+> toHornSMT s )
-toHornAbsApp _                                    = error "Unexpected nothing function sort"
-
-toHornFApp     :: [F.Sort] -> P.Doc
-toHornFApp [t] = toHornSMT t
-toHornFApp ts  = toHornSMT ts
-
-instance ToHornSMT F.Subst where
-  toHornSMT (F.Su m) = toHornSMT (Misc.hashMapToAscList m)
-
-instance ToHornSMT (Bind a) where
-  toHornSMT (Bind x t p _) = P.parens (toHornSMT (x, t) P.<+> toHornSMT p)
-
-instance ToHornSMT Pred where
-  toHornSMT (Reft p)   = P.parens (toHornSMT p)
-  toHornSMT (Var k xs) = toHornMany (toHornSMT (F.KV k) : (toHornSMT <$> xs))
-  toHornSMT (PAnd ps)  = toHornMany ("and" : (toHornSMT <$> ps))
-
-instance ToHornSMT F.KVar where
-  toHornSMT (F.KV k) = "$" P.<-> toHornSMT k
-
-instance ToHornSMT F.Expr where
-  toHornSMT = toHornExpr
-
-toHornExpr :: F.Expr -> P.Doc
-toHornExpr (F.ESym c)        = F.pprint c
-toHornExpr (F.ECon c)        = F.pprint c
-toHornExpr (F.EVar s)        = toHornSMT s
-toHornExpr (F.ENeg e)        = P.parens ("-" P.<+> toHornExpr e)
-toHornExpr (F.EApp e1 e2)    = toHornSMT [e1, e2]
-toHornExpr (F.EBin o e1 e2)  = toHornOp   (F.toFix o) [e1, e2]
-toHornExpr (F.ELet x e1 e2)  = toHornMany ["let", toHornSMT [(x, e1)], toHornSMT e2]
-toHornExpr (F.EIte e1 e2 e3) = toHornOp "if"  [e1, e2, e3]
-toHornExpr (F.ECst e t)      = toHornMany ["cast", toHornSMT e, toHornSMT t]
-toHornExpr (F.PNot p)        = toHornOp "not"  [p]
-toHornExpr (F.PImp e1 e2)    = toHornOp "=>"   [e1, e2]
-toHornExpr (F.PIff e1 e2)    = toHornOp "<=>"  [e1, e2]
-toHornExpr e@F.PTrue         = F.pprint e
-toHornExpr e@F.PFalse        = F.pprint e
-toHornExpr (F.PAnd es)       = toHornOp "and" es
-toHornExpr (F.POr  es)       = toHornOp "or"  es
-toHornExpr (F.PAtom r e1 e2) = toHornOp (F.toFix r) [e1, e2]
-toHornExpr (F.PAll xts p)    = toHornMany ["forall", toHornSMT xts, toHornSMT p]
-toHornExpr (F.PExist xts p)  = toHornMany ["exists", toHornSMT xts, toHornSMT p]
-toHornExpr (F.ELam b e)      = toHornMany ["lam", toHornSMT b, toHornSMT e]
-toHornExpr (F.ECoerc a t e)  = toHornMany ["coerce", toHornSMT a, toHornSMT t, toHornSMT e]
-toHornExpr (F.PKVar k su)    = toHornMany [toHornSMT k, toHornSMT su]
-toHornExpr (F.ETApp e s)     = toHornMany ["ETApp" , toHornSMT e, toHornSMT s]
-toHornExpr (F.ETAbs e s)     = toHornMany ["ETAbs" , toHornSMT e, toHornSMT s]
-toHornExpr (F.PGrad k _ _ e) = toHornMany ["&&", toHornSMT e, toHornSMT k]
-
-toHornOp :: ToHornSMT a => P.Doc -> [a] -> P.Doc
-toHornOp op es = toHornMany (op : (toHornSMT <$> es))
-
-instance ToHornSMT (Cstr a) where
-  toHornSMT = toHornCstr
-
-toHornCstr :: Cstr a -> P.Doc
-toHornCstr (Head p _) = toHornSMT p
-toHornCstr (CAnd cs)  = toHornAnd toHornCstr cs
-toHornCstr (All b c)  = P.parens (P.vcat ["forall" P.<+> toHornSMT b
-                                         , P.nest 1 (toHornCstr c)])
-toHornCstr (Any b c)  = P.parens (P.vcat ["exists" P.<+> toHornSMT b
-                                         , P.nest 1 (toHornCstr c)])
+      toHornNum x   = F.toHornMany ["numeric", F.toHornSMT x]
+      toHornOpt str = F.toHornMany ["fixpoint", P.text ("\"" ++ str ++ "\"")]
+      toHornCon x t = F.toHornMany ["constant", F.toHornSMT x, F.toHornSMT t]

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -33,7 +33,6 @@ import qualified Data.Text.Lazy.IO                as LT
 import qualified Data.Text.Lazy.Encoding          as LT
 import           System.Exit                        (ExitCode (..))
 import           System.Console.CmdArgs.Verbosity   (whenNormal, whenLoud)
-import           Text.PrettyPrint.HughesPJ          (render)
 import           Control.Monad                      (mplus, when)
 import           Control.Exception                  (catch)
 import           Language.Fixpoint.Solver.EnvironmentReduction
@@ -60,6 +59,8 @@ import           Language.Fixpoint.Solver.Instantiate (instantiate)
 import           Control.DeepSeq
 import qualified Data.ByteString as B
 import Data.Maybe (catMaybes, mapMaybe)
+import Data.Ord (comparing)
+import qualified Text.PrettyPrint.HughesPJ as PJ
 
 ---------------------------------------------------------------------------
 -- | Solve an .fq file ----------------------------------------------------
@@ -86,7 +87,7 @@ resultExitCode cfg r = do
     jStr    = LT.decodeUtf8 . encode $ r
     stat    = resStatus $!! r
     eCode   = resultExit . resStatus
-    statStr = render . resultDoc
+    statStr = PJ.render . resultDoc
 
 ignoreQualifiers :: Config -> FInfo a -> FInfo a
 ignoreQualifiers cfg fi
@@ -207,7 +208,7 @@ type ErrorMap a = HashMap.HashMap SrcSpan a
 findError :: ErrorMap a -> Error1 -> Maybe ((Integer, a), Maybe String)
 findError m e = do
   ann <- HashMap.lookup (errLoc e) m
-  let str = render (errMsg e)
+  let str = PJ.render (errMsg e)
   return ((-1, ann), Just str)
 
 -- The order is important here: we want the "binders" to get the "precedence"
@@ -219,7 +220,7 @@ errorMap fi = HashMap.fromList [ (srcSpan a, a) | a <- anns ]
             ++ [ a | (_, (_,_, a)) <- bindEnvToList (Types.bs fi) ]
 
 loudDump :: (Fixpoint a) => Int -> Config -> SInfo a -> IO ()
-loudDump i cfg si = when False (writeLoud $ msg ++ render (toFixpoint cfg si))
+loudDump i cfg si = when False (writeLoud $ msg ++ PJ.render (toFixpoint cfg si))
   where
     msg           = "fq file after Uniqify & Rename " ++ show i ++ "\n"
 
@@ -315,15 +316,32 @@ saveSolution cfg res = when (save cfg) $ do
     , ""
     , "Non-cut kvars:"
     , ""
-    , showpp (HashMap.map unElab $ resNonCutsSolution res)
+    , PJ.render nonCutsDoc
     ]
+    where
+      nonCutsDoc = PJ.vcat (ncDoc <$> nonCuts')
+      nonCuts = HashMap.toList ({- HashMap.map unElab $  -} resNonCutsSolution res)
+      nonCuts' = [ (k, scope k, e) | (k, e) <- nonCuts]
+      scope k = case HashMap.lookup k (resSorts res) of
+                  Just xts -> L.sortBy (comparing fst) xts
+                  Nothing -> []
+      ncDoc :: (KVar, [(Symbol, Sort)], Expr) -> PJ.Doc
+      ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> PJ.parens (pprint xts), ":=", pprint e ]
 
 simplifyResult :: Result a -> Result a
 simplifyResult res =
     res
-      { resSolution = HashMap.map simplifyKVar (resSolution res)
-      , resNonCutsSolution = HashMap.map simplifyKVar (resNonCutsSolution res)
+      { resSolution = HashMap.mapWithKey (simplifyKVar' sorts) (resSolution res)
+      , resNonCutsSolution = HashMap.mapWithKey (simplifyKVar' sorts) (resNonCutsSolution res)
       }
+  where
+    sorts = resSorts res
+
+simplifyKVar' :: HashMap.HashMap KVar [(Symbol, Sort)] -> KVar -> Expr -> Expr
+simplifyKVar' scope k e = {- tracepp msg -} unElab $ simplifyKVar xs e
+  where
+    _msg = "simplifyKVar: KVar " ++ showpp (k, xs, e)
+    xs = fst <$> HashMap.lookupDefault [] k scope
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.
 --
@@ -340,52 +358,55 @@ simplifyResult res =
 --
 -- We require that relevant variables occur more than once, or that
 -- they occur in some other place than as an argument to @==@.
---
-simplifyKVar :: Expr -> Expr
-simplifyKVar (POr es) = POr $ map simplifyKVar es
-simplifyKVar (PExist bs e@(PAnd es)) =
-    let fvs = L.group $ L.sort $ collectFreeVarOccurrences e
-        esv = map (isUniqueEq fvs) es
-        removed = mapMaybe fst esv
-        needed = map head fvs L.\\ removed
-        bs' = filter ((`elem` needed) . fst) bs
-     in
-        PExist bs' $ PAnd $ [ei | (Nothing, ei) <- esv]
+-- However, we do not want to eliminate any equalities over "free" variables, e.g.
+-- the parameters of the KVar, as those are important to keep.
+simplifyKVar :: [Symbol] -> Expr -> Expr
+simplifyKVar freeVars = go
   where
-    -- | Determine if the expression is an equality that sets the value of
-    -- a variable that doesn't occur elsewhere.
-    --
-    -- In @isUniqueEq fvs e@, @fvs@ contains the occurrences of the free
-    -- variables, so we can infer if there is more than one occurrence
-    -- of a given free variable, and @e@ is the equality to analyze.
-    --
-    -- Yields @(Just v, e)@ if @v@ doesn't occur elsewhere, and @e@ has
-    -- the form @v == e'@.
-    isUniqueEq :: [[Symbol]] -> Expr -> (Maybe Symbol, Expr)
-    isUniqueEq fvs er = case unElab er of
-      PAtom brel e0 e1
-        | isEqRel brel ->
-          let m = isVarToDrop fvs e0 `mplus` isVarToDrop fvs e1
-           in (m, er)
-      _ ->
-        (Nothing, er)
+    go (POr es) = POr $ map go es
+    go (PExist bs e@(PAnd es)) =
+      let fvs = L.group $ L.sort $ freeVars ++ collectFreeVarOccurrences e
+          esv = map (isUniqueEq fvs) es
+          removed = mapMaybe fst esv
+          needed = map head fvs L.\\ removed
+          bs' = filter ((`elem` needed) . fst) bs
+      in
+          PExist bs' $ PAnd $ [ei | (Nothing, ei) <- esv]
+    go e = e
+-- | Determine if the expression is an equality that sets the value of
+-- a variable that doesn't occur elsewhere.
+--
+-- In @isUniqueEq fvs e@, @fvs@ contains the occurrences of the free
+-- variables, so we can infer if there is more than one occurrence
+-- of a given free variable, and @e@ is the equality to analyze.
+--
+-- Yields @(Just v, e)@ if @v@ doesn't occur elsewhere, and @e@ has
+-- the form @v == e'@.
+isUniqueEq :: [[Symbol]] -> Expr -> (Maybe Symbol, Expr)
+isUniqueEq fvs er = case unElab er of
+  PAtom brel e0 e1
+    | isEqRel brel ->
+      let m = isVarToDrop fvs e0 `mplus` isVarToDrop fvs e1
+       in (m, er)
+  _ ->
+    (Nothing, er)
 
-    -- | Tells if the binary relation is an equality.
-    isEqRel Eq = True
-    isEqRel Ueq = True
-    isEqRel _ = False
+-- | Tells if the binary relation is an equality.
+isEqRel :: Brel -> Bool
+isEqRel Eq = True
+isEqRel Ueq = True
+isEqRel _ = False
 
-    -- | @isVarToDrop fvs s@ yields @Just s@ if the variable @s@ doesn't occur
-    -- elsewhere according to @fvs@.
-    --
-    -- > isVarToDrop fvs (cast_as_int s) == isVarToDrop fvs s
-    --
-    isVarToDrop fvs (EApp (EVar "cast_as_int") ei) = isVarToDrop fvs ei
-    isVarToDrop fvs (EVar s)
-      | elem [s] fvs = Just s
-    isVarToDrop _fvs _ = Nothing
-
-simplifyKVar e = e
+-- | @isVarToDrop fvs s@ yields @Just s@ if the variable @s@ doesn't occur
+-- elsewhere according to @fvs@.
+--
+-- > isVarToDrop fvs (cast_as_int s) == isVarToDrop fvs s
+--
+isVarToDrop ::  [[Symbol]] -> ExprV Symbol -> Maybe Symbol
+isVarToDrop fvs (EApp (EVar "cast_as_int") ei) = isVarToDrop fvs ei
+isVarToDrop fvs (EVar s)
+  | elem [s] fvs = Just s
+isVarToDrop _fvs _ = Nothing
 
 -- | Produces the free variables of an expressions as many times as they occur.
 --

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -338,9 +338,8 @@ simplifyResult res =
     sorts = resSorts res
 
 simplifyKVar' :: HashMap.HashMap KVar [(Symbol, Sort)] -> KVar -> Expr -> Expr
-simplifyKVar' scope k e = {- tracepp msg -} unElab $ simplifyKVar xs e
+simplifyKVar' scope k e = unElab $ simplifyKVar xs e
   where
-    _msg = "simplifyKVar: KVar " ++ showpp (k, xs, e)
     xs = fst <$> HashMap.lookupDefault [] k scope
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -327,16 +327,11 @@ saveSolution cfg res = when (save cfg) $ do
 simplifyResult :: Result a -> Result a
 simplifyResult res =
     res
-      { resSolution = HashMap.mapWithKey (simplifyKVar' sorts) (resSolution res)
-      , resNonCutsSolution = HashMap.mapWithKey (simplifyKVar' sorts) (resNonCutsSolution res)
+      { resSolution = HashMap.map simplifyKVar' (resSolution res)
+      , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
       }
   where
-    sorts = resSorts res
-
-simplifyKVar' :: HashMap.HashMap KVar [(Symbol, Sort)] -> KVar -> Expr -> Expr
-simplifyKVar' scope k e = unElab $ simplifyKVar xs e
-  where
-    xs = fst <$> HashMap.lookupDefault [] k scope
+    simplifyKVar' = unElab . simplifyKVar
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.
 --
@@ -353,14 +348,15 @@ simplifyKVar' scope k e = unElab $ simplifyKVar xs e
 --
 -- We require that relevant variables occur more than once, or that
 -- they occur in some other place than as an argument to @==@.
--- However, we do not want to eliminate any equalities over "free" variables, e.g.
--- the parameters of the KVar, as those are important to keep.
-simplifyKVar :: [Symbol] -> Expr -> Expr
-simplifyKVar freeVars = go
+simplifyKVar :: Expr -> Expr
+simplifyKVar = go
   where
     go (POr es) = POr $ map go es
     go (PExist bs e@(PAnd es)) =
-      let fvs = L.group $ L.sort $ freeVars ++ collectFreeVarOccurrences e
+      let fvs = [ g | g <- L.group $ L.sort $ collectFreeVarOccurrences e
+                    , isBound g
+                ]
+          isBound g = case g of {v:_ ->  elem v (map fst bs) ; _ -> False }
           esv = map (isUniqueEq fvs) es
           removed = mapMaybe fst esv
           needed = map head fvs L.\\ removed
@@ -368,6 +364,7 @@ simplifyKVar freeVars = go
       in
           PExist bs' $ PAnd $ [ei | (Nothing, ei) <- esv]
     go e = e
+
 -- | Determine if the expression is an equality that sets the value of
 -- a variable that doesn't occur elsewhere.
 --

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -187,7 +187,7 @@ solveNative !cfg !fi0 = solveNative' cfg fi0
                              (return . crashResult (errorMap fi0))
 
 crashResult :: (PPrint a) => ErrorMap a -> Error -> Result (Integer, a)
-crashResult m err' = Result res mempty mempty mempty
+crashResult m err' = Result res mempty mempty mempty mempty
   where
     res           = Crash es msg
     es            = catMaybes [ findError m e | e <- ers ]

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -305,7 +305,7 @@ saveSolution cfg res = when (save cfg) $ do
   writeFile f $ unlines $
     [ ""
     , "Solution:"
-    , showpp (resSolution  res)
+    , scopedRender (resSolution  res)
     ] ++
     ( if gradual cfg then
         ["", "", showpp $ gresSolution res]
@@ -316,17 +316,13 @@ saveSolution cfg res = when (save cfg) $ do
     , ""
     , "Non-cut kvars:"
     , ""
-    , PJ.render nonCutsDoc
+    , scopedRender (resNonCutsSolution res)
     ]
     where
-      nonCutsDoc = PJ.vcat (ncDoc <$> nonCuts')
-      nonCuts = HashMap.toList ({- HashMap.map unElab $  -} resNonCutsSolution res)
-      nonCuts' = [ (k, scope k, e) | (k, e) <- nonCuts]
-      scope k = case HashMap.lookup k (resSorts res) of
-                  Just xts -> L.sortBy (comparing fst) xts
-                  Nothing -> []
-      ncDoc :: (KVar, [(Symbol, Sort)], Expr) -> PJ.Doc
-      ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> PJ.parens (pprint xts), ":=", pprint e ]
+      scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
+      scoped sol = [ (k, scope k, e) | (k, e) <- HashMap.toList sol]
+      scope k = L.sortBy (comparing fst) $ HashMap.lookupDefault [] k $ resSorts res
+      ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> pprint xts, ":=", pprint e ]
 
 simplifyResult :: Result a -> Result a
 simplifyResult res =

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -358,11 +358,8 @@ applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
     msg     = "applyKVar: " ++ show (ceCid g)
 
 mkNonCutsExpr :: CombinedEnv ann -> Sol.Sol a Sol.QBind -> F.KVar -> Sol.Hyp -> ElabM F.Expr
-mkNonCutsExpr ce s k cs = do
-  bcps <- traverse (bareCubePred ce s k) cs
-  pure $ F.notracepp msg (F.pOr bcps)
-  where
-    msg = "nonCutsExpr for k = " ++ F.showpp k
+mkNonCutsExpr ce s k cs = do bcps <- traverse (bareCubePred ce s k) cs
+                             pure $ F.pOr bcps
 
 nonCutsResult :: F.BindEnv ann -> Sol.Sol a Sol.QBind -> ElabM (M.HashMap F.KVar F.Expr)
 nonCutsResult be s = M.traverseWithKey (mkNonCutsExpr g s) $ Sol.sHyp s

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -358,8 +358,11 @@ applyKVar g s ksu = case Sol.lookup s (F.ksuKVar ksu) of
     msg     = "applyKVar: " ++ show (ceCid g)
 
 mkNonCutsExpr :: CombinedEnv ann -> Sol.Sol a Sol.QBind -> F.KVar -> Sol.Hyp -> ElabM F.Expr
-mkNonCutsExpr ce s k cs = do bcps <- traverse (bareCubePred ce s k) cs
-                             pure $ F.pOr bcps
+mkNonCutsExpr ce s k cs = do
+  bcps <- traverse (bareCubePred ce s k) cs
+  pure $ F.notracepp msg (F.pOr bcps)
+  where
+    msg = "nonCutsExpr for k = " ++ F.showpp k
 
 nonCutsResult :: F.BindEnv ann -> Sol.Sol a Sol.QBind -> ElabM (M.HashMap F.KVar F.Expr)
 nonCutsResult be s = M.traverseWithKey (mkNonCutsExpr g s) $ Sol.sHyp s
@@ -384,11 +387,16 @@ nonCutsResult be s = M.traverseWithKey (mkNonCutsExpr g s) $ Sol.sHyp s
 --    particular use of the KVar. Thus @cubePred@ produces a different
 --    expression for every use site of the kvar, while here we produce one
 --    expression for all the uses.
+-- NOTE: In this case, we *keep* the `xts` "free" in the final predicate. as
+-- That is, we only quantify out the `yts` as, in this use-case, the `xts`
+-- are the "parameters" of the KVar that we want to leave in to make
+-- explicit what equalities those parameters have in each cube.
+
 bareCubePred :: CombinedEnv ann -> Sol.Sol a Sol.QBind -> F.KVar -> Sol.Cube -> ElabM F.Expr
 bareCubePred g s k c =
-  do (xts, psu) <- substElim (Sol.sEnv s) sEnv g' k su
+  do (_xts, psu) <- substElim (Sol.sEnv s) sEnv g' k su
      (p, _kI) <- apply g' s bs'
-     pure $ F.pExist (xts ++ yts) (psu &.& p)
+     pure $ F.pExist yts (psu &.& p)
   where
     bs = Sol.cuBinds c
     su = Sol.cuSubst c

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -40,6 +40,7 @@ import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
 import qualified Language.Fixpoint.Types.Config as C
 import Language.Fixpoint.Solver.Interpreter (instInterpreter)
 import Language.Fixpoint.Solver.Instantiate (instantiate)
+import Data.Maybe (maybeToList)
 -- import Debug.Trace                      (trace)
 
 mytrace :: String -> a -> a
@@ -128,7 +129,7 @@ solve_ cfg fi s0 ks wkl = do
   (s3, res0) <- sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
     -- let s3   = solveEbinds fi s2
     s3       <- {- SCC "sol-refine" -} refine bindingsInSmt s2 wkl
-    res0     <- {- SCC "sol-result" -} result bindingsInSmt cfg wkl s3
+    res0     <- {- SCC "sol-result" -} result bindingsInSmt cfg fi wkl s3
     return (s3, res0)
 
   (fi1, s4, res1) <- case resStatus res0 of  {- first run the interpreter -}
@@ -142,7 +143,7 @@ solve_ cfg fi s0 ks wkl = do
       clearApplys
       (s4, res1) <- sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s4    <- {- SCC "sol-refine" -} refine bindingsInSmt s3 wkl
-        res1  <- {- SCC "sol-result" -} result bindingsInSmt cfg wkl s4
+        res1  <- {- SCC "sol-result" -} result bindingsInSmt cfg fi1 wkl s4
         return (s4, res1)
       return (fi1, s4, res1)
     _ -> return  (fi, s3, mytrace "all checked before interpreter" res0)
@@ -154,7 +155,7 @@ solve_ cfg fi s0 ks wkl = do
       clearApplys
       sendConcreteBindingsToSMT F.emptyIBindEnv $ \bindingsInSmt -> do
         s5    <- {- SCC "sol-refine" -} refine bindingsInSmt s4 wkl
-        result bindingsInSmt cfg wkl s5
+        result bindingsInSmt cfg fi1 wkl s5
     _ -> return $ mytrace "all checked with interpreter" res1
 
   st      <- stats
@@ -252,26 +253,35 @@ result
   :: (F.Fixpoint a, F.Loc a, NFData a)
   => F.IBindEnv
   -> Config
+  -> F.SInfo a
   -> W.Worklist a
   -> Sol.Solution
   -> SolveM a (F.Result (Integer, a))
 --------------------------------------------------------------------------------
-result bindingsInSmt cfg wkl s =
+result bindingsInSmt cfg fi wkl s =
   sendConcreteBindingsToSMT bindingsInSmt $ \bindingsInSmt2 -> do
-    lift    $ writeLoud "Computing Result"
-    stat   <- result_ bindingsInSmt2 cfg wkl s
-    lift    $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
-    F.Result (ci <$> stat) <$> solResult cfg s <*> solNonCutsResult s <*> return mempty <*> resultSorts s
+    lift       $ writeLoud "Computing Result"
+    stat      <- result_ bindingsInSmt2 cfg wkl s
+    lift       $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
+    resCut    <- solResult cfg s
+    resNonCut <- solNonCutsResult s
+    resSorts  <- resultSorts fi (M.keys resCut ++ M.keys resNonCut) <$> getBinds
+    return     $ F.Result (ci <$> stat) resCut resNonCut mempty resSorts
   where
     ci c = (F.subcId c, F.sinfo c)
 
-resultSorts :: Sol.Solution -> SolveM a F.ResultSorts
-resultSorts s = do
-  be <- getBinds
-  return  (kvarScope be <$> Sol.sScp s)
+resultSorts :: F.SInfo a -> [F.KVar] -> F.BindEnv a -> F.ResultSorts
+resultSorts fi ks be = M.fromList
+  [(k, xts)
+    | k <- ks
+    , xts <- maybeToList (kvarScope fi be k) ]
 
-kvarScope :: F.BindEnv a -> F.IBindEnv -> [(F.Symbol, F.Sort)]
-kvarScope be bs = bindInfo be <$> F.elemsIBindEnv bs
+kvarScope :: F.SInfo a -> F.BindEnv a -> F.KVar -> Maybe [(F.Symbol, F.Sort)]
+kvarScope fi be k = do
+  w <- M.lookup k (F.ws fi)
+  let bs = F.wenv w
+  let (v, t, _) = F.wrft w
+  return $ (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
 
 bindInfo :: F.BindEnv a -> F.BindId -> (F.Symbol, F.Sort)
 bindInfo be i = (x, F.sr_sort sr)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -258,24 +258,25 @@ result
 --------------------------------------------------------------------------------
 result bindingsInSmt cfg wkl s =
   sendConcreteBindingsToSMT bindingsInSmt $ \bindingsInSmt2 -> do
-    lift $ writeLoud "Computing Result"
-    stat    <- result_ bindingsInSmt2 cfg wkl s
-    lift $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
-
+    lift    $ writeLoud "Computing Result"
+    stat   <- result_ bindingsInSmt2 cfg wkl s
+    lift    $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
     F.Result (ci <$> stat) <$> solResult cfg s <*> solNonCutsResult s <*> return mempty <*> resultSorts s
   where
     ci c = (F.subcId c, F.sinfo c)
 
 resultSorts :: Sol.Solution -> SolveM a F.ResultSorts
 resultSorts s = do
-  _be <- getBinds
-  error "TBD: kvarSorts" -- undefined
-  -- ef <- T.ctxElabF <$> getContext
-  -- let kvs = M.keys (Sol.result s)
-  -- let go k = runReader (S.kvarSort be k s) ef
-  -- sorts <- mapM go kvs
-  -- return $ M.fromListWith L.union [(k, [sort]) | (k, sort) <- zip kvs sorts, not (F.isTauto sort)]
+  be <- getBinds
+  return  (kvarScope be <$> Sol.sScp s)
 
+kvarScope :: F.BindEnv a -> F.IBindEnv -> [(F.Symbol, F.Sort)]
+kvarScope be bs = bindInfo be <$> F.elemsIBindEnv bs
+
+bindInfo :: F.BindEnv a -> F.BindId -> (F.Symbol, F.Sort)
+bindInfo be i = (x, F.sr_sort sr)
+  where
+    (x, sr, _) = F.lookupBindEnv i be
 
 solResult :: Config -> Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
 solResult cfg = minimizeResult cfg . Sol.result

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -171,7 +171,11 @@ tidyResult :: F.Result a -> F.Result a
 tidyResult r = r
   { F.resSolution = tidySolution (F.resSolution r)
   , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
+  , F.resSorts = tidyBind <$>  F.resSorts r
   }
+
+tidyBind :: [(F.Symbol, F.Sort)] -> [(F.Symbol, F.Sort)]
+tidyBind xts = [ (F.tidySymbol x, t) | (x, t) <- xts ]
 
 tidySolution :: F.FixSolution -> F.FixSolution
 tidySolution = fmap tidyPred
@@ -281,8 +285,7 @@ kvarScope fi be k = do
   w <- M.lookup k (F.ws fi)
   let bs = F.wenv w
   let (v, t, _) = F.wrft w
-  let xts = (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
-  return $ [ (F.tidySymbol x, t) | (x, t) <- xts ]
+  return $ (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
 
 bindInfo :: F.BindEnv a -> F.BindId -> (F.Symbol, F.Sort)
 bindInfo be i = (x, F.sr_sort sr)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -262,9 +262,20 @@ result bindingsInSmt cfg wkl s =
     stat    <- result_ bindingsInSmt2 cfg wkl s
     lift $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
 
-    F.Result (ci <$> stat) <$> solResult cfg s <*> solNonCutsResult s <*> return mempty
+    F.Result (ci <$> stat) <$> solResult cfg s <*> solNonCutsResult s <*> return mempty <*> resultSorts s
   where
     ci c = (F.subcId c, F.sinfo c)
+
+resultSorts :: Sol.Solution -> SolveM a F.ResultSorts
+resultSorts s = do
+  _be <- getBinds
+  error "TBD: kvarSorts" -- undefined
+  -- ef <- T.ctxElabF <$> getContext
+  -- let kvs = M.keys (Sol.result s)
+  -- let go k = runReader (S.kvarSort be k s) ef
+  -- sorts <- mapM go kvs
+  -- return $ M.fromListWith L.union [(k, [sort]) | (k, sort) <- zip kvs sorts, not (F.isTauto sort)]
+
 
 solResult :: Config -> Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
 solResult cfg = minimizeResult cfg . Sol.result

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -281,7 +281,8 @@ kvarScope fi be k = do
   w <- M.lookup k (F.ws fi)
   let bs = F.wenv w
   let (v, t, _) = F.wrft w
-  return $ (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
+  let xts = (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
+  return $ [ (F.tidySymbol x, t) | (x, t) <- xts ]
 
 bindInfo :: F.BindEnv a -> F.BindId -> (F.Symbol, F.Sort)
 bindInfo be i = (x, F.sr_sort sr)

--- a/src/Language/Fixpoint/Types.hs
+++ b/src/Language/Fixpoint/Types.hs
@@ -5,6 +5,7 @@
 
 module Language.Fixpoint.Types (module X) where
 
+import Language.Fixpoint.Types.SMTPrint      as X
 import Language.Fixpoint.Types.PrettyPrint      as X
 import Language.Fixpoint.Types.Names            as X
 import Language.Fixpoint.Types.Errors           as X

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -92,11 +92,15 @@ module Language.Fixpoint.Types.Constraints (
   , lookupRewrite
   , lookupLocalRewrites
   , insertRewrites
+  , eqnToHornSMT
 
   -- * Misc  [should be elsewhere but here due to dependencies]
   , substVars
   , sortVars
   , gSorts
+
+  -- * ScopedResult
+  , ScopedResult (..), ScopedExpr (..)
   , scopedResult
   ) where
 
@@ -112,6 +116,7 @@ import           Data.Maybe                (catMaybes)
 import           Control.DeepSeq
 import           Control.Monad             (when, void)
 import           Language.Fixpoint.Types.PrettyPrint
+import           Language.Fixpoint.Types.SMTPrint
 import qualified Language.Fixpoint.Types.Config as C
 import           Language.Fixpoint.Types.Triggers
 import           Language.Fixpoint.Types.Names
@@ -310,6 +315,10 @@ data ScopedExpr = MkScopedExpr
   }
   deriving (Generic, Show)
 
+instance ToHornSMT ScopedExpr where
+  toHornSMT (MkScopedExpr xts p) = toHornWithBinders "lambda" xts p
+
+
 scopedResult :: Result a -> ScopedResult
 scopedResult res = MkScopedResult cuts  nonCuts
   where
@@ -318,14 +327,17 @@ scopedResult res = MkScopedResult cuts  nonCuts
     scoped sol = M.fromList [ (k, MkScopedExpr (scope k) e) | (k, e) <- M.toList sol]
     scope k = L.sortBy (comparing fst) $ M.lookupDefault [] k $ resSorts res
 
-
 instance ToJSON a => ToJSON (Result a) where
-  toJSON (Result {..}) = object
+  toJSON r@(Result {..}) = object
     [ "status"            .= resStatus
-    , "solution"          .= resSolution
-    , "nonCutsSolution"   .= resNonCutsSolution
-    , "sorts"             .= resSorts
+    , "solution"          .= scCuts scopedSolution
+    , "nonCutsSolution"   .= scNonCuts scopedSolution
     ]
+    where
+      scopedSolution = scopedResult r
+
+instance ToJSON ScopedExpr where
+  toJSON = toJSON . render . toHornSMT
 
 instance Semigroup (Result a) where
   r1 <> r2  = Result stat soln nonCutsSoln gsoln sorts
@@ -540,6 +552,10 @@ data QualParam = QP
   }
   deriving (Eq, Ord, Show, Data, Typeable, Generic)
 
+instance ToHornSMT QualParam where
+  toHornSMT qp = toHornSMT (qpSym qp, qpSort qp)
+
+
 data QualPattern
   = PatNone                 -- ^ match everything
   | PatPrefix !Symbol !Int  -- ^ str . $i  i.e. match prefix 'str' with suffix bound to $i
@@ -558,6 +574,11 @@ instance FromJSON Equation    where
 instance ToJSON   Rewrite     where
 instance FromJSON Rewrite     where
 
+instance ToHornSMT Qualifier where
+  toHornSMT (Q n qps p _) =  toHornWithBinders name xts p
+    where
+      name = "qualif" <+> pprint n
+      xts =  [(qpSym qp, qpSort qp) | qp <- qps]
 
 trueQual :: Qualifier
 trueQual = Q (symbol ("QTrue" :: String)) [] PTrue (dummyPos "trueQual")
@@ -1046,6 +1067,10 @@ data EquationV v = Equ
   }
   deriving (Data, Eq, Ord, Show, Generic, Functor)
 
+eqnToHornSMT :: Doc -> Equation -> Doc
+eqnToHornSMT keyword (Equ f xs e s _) = parens (keyword <+> pprint f <+> toHornSMT xs <+> toHornSMT s <+> toHornSMT e)
+
+
 mkEquation :: Symbol -> [(Symbol, Sort)] -> Expr -> Sort -> Equation
 mkEquation f xts e out = Equ f xts e out (f `elem` syms e)
 
@@ -1108,6 +1133,11 @@ data Rewrite  = SMeasure
   , smBody  :: Expr           -- eg. e[xs]
   }
   deriving (Data, Eq, Ord, Show, Generic)
+
+instance ToHornSMT Rewrite where
+  toHornSMT (SMeasure f d xs e) =  parens ("match" <+> toHornSMT f <+> toHornSMT (d:xs) <+> toHornSMT e)
+
+
 
 instance Fixpoint AxiomEnv where
   toFix axe = vcat ((toFix <$> L.sort (aenvEqs axe)) ++ (toFix <$> L.sort (aenvSimpl axe)))

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -97,6 +97,7 @@ module Language.Fixpoint.Types.Constraints (
   , substVars
   , sortVars
   , gSorts
+  , scopedResult
   ) where
 
 import qualified Data.Store as S
@@ -131,6 +132,7 @@ import qualified Data.ByteString           as B
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Binary as B
+import Data.Ord (comparing)
 
 --------------------------------------------------------------------------------
 -- | Constraints ---------------------------------------------------------------
@@ -295,6 +297,26 @@ data Result a = Result
   deriving (Generic, Show, Functor)
 
 type ResultSorts = M.HashMap KVar [(Symbol, Sort)]
+
+data ScopedResult = MkScopedResult
+  { scCuts    :: M.HashMap KVar ScopedExpr
+  , scNonCuts :: M.HashMap KVar ScopedExpr
+  }
+  deriving (Generic, Show)
+
+data ScopedExpr = MkScopedExpr
+  { seParams :: [(Symbol, Sort)]
+  , seBody :: !Expr
+  }
+  deriving (Generic, Show)
+
+scopedResult :: Result a -> ScopedResult
+scopedResult res = MkScopedResult cuts  nonCuts
+  where
+    cuts = scoped (resSolution res)
+    nonCuts = scoped (resNonCutsSolution res)
+    scoped sol = M.fromList [ (k, MkScopedExpr (scope k) e) | (k, e) <- M.toList sol]
+    scope k = L.sortBy (comparing fst) $ M.lookupDefault [] k $ resSorts res
 
 
 instance ToJSON a => ToJSON (Result a) where

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE PatternGuards              #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing     #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | This module contains the top-level QUERY data types and elements,
 --   including (Horn) implication & well-formedness constraints and sets.
@@ -64,7 +65,7 @@ module Language.Fixpoint.Types.Constraints (
   -- * Results
   , FixSolution
   , GFixSolution, toGFixSol
-  , Result (..)
+  , Result (..), ResultSorts
   , unsafe, isUnsafe, isSafe ,safe
 
   -- * Cut KVars
@@ -289,24 +290,31 @@ data Result a = Result
   , resSolution  :: !FixSolution
   , resNonCutsSolution :: !FixSolution
   , gresSolution :: !GFixSolution
+  , resSorts     :: !ResultSorts
   }
   deriving (Generic, Show, Functor)
 
-
+type ResultSorts = M.HashMap KVar [(Symbol, Sort)]
 
 instance ToJSON a => ToJSON (Result a) where
-  toJSON = toJSON . resStatus
+  toJSON (Result {..}) = object
+    [ "status"            .= resStatus
+    , "solution"          .= resSolution
+    , "nonCutsSolution"   .= resNonCutsSolution
+    , "sorts"             .= resSorts
+    ]
 
 instance Semigroup (Result a) where
-  r1 <> r2  = Result stat soln nonCutsSoln gsoln
+  r1 <> r2  = Result stat soln nonCutsSoln gsoln sorts
     where
       stat  = resStatus r1    <> resStatus r2
       soln  = resSolution r1  <> resSolution r2
       nonCutsSoln = resNonCutsSolution r1 <> resNonCutsSolution r2
       gsoln = gresSolution r1 <> gresSolution r2
+      sorts = M.unionWith L.union (resSorts r1) (resSorts r2)
 
 instance Monoid (Result a) where
-  mempty        = Result mempty mempty mempty mempty
+  mempty        = Result mempty mempty mempty mempty mempty
   mappend       = (<>)
 
 unsafe, safe :: Result a
@@ -734,7 +742,7 @@ allowHOquals = hoQuals . hoInfo
 data GInfo c a = FI
   { cm       :: !(M.HashMap SubcId (c a))  -- ^ cst id |-> Horn Constraint
   , ws       :: !(M.HashMap KVar (WfC a))  -- ^ Kvar  |-> WfC defining its scope/args
-  , bs       :: !(BindEnv a)               -- ^ Bind  |-> (Symbol, SortedReft)
+  , bs       :: !(BindEnv a)               -- ^ BindId  |-> (Symbol, SortedReft)
   , ebinds   :: ![BindId]                  -- ^ Subset of existential binders
   , gLits    :: !(SEnv Sort)               -- ^ Global Constant symbols
   , dLits    :: !(SEnv Sort)               -- ^ Distinct Constant symbols

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -296,6 +296,7 @@ data Result a = Result
 
 type ResultSorts = M.HashMap KVar [(Symbol, Sort)]
 
+
 instance ToJSON a => ToJSON (Result a) where
   toJSON (Result {..}) = object
     [ "status"            .= resStatus

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -249,6 +249,8 @@ refaConjuncts p = [p' | p' <- conjuncts p, not $ isTautoPred p']
 newtype KVar = KV { kv :: Symbol }
                deriving (Eq, Ord, Data, Typeable, Generic, IsString, ToJSON, FromJSON)
 
+instance ToJSONKey KVar
+
 intKvar :: Integer -> KVar
 intKvar = KV . intSymbol "k_"
 

--- a/src/Language/Fixpoint/Types/SMTPrint.hs
+++ b/src/Language/Fixpoint/Types/SMTPrint.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE CPP                #-}
+{-# LANGUAGE FlexibleContexts   #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Language.Fixpoint.Types.SMTPrint where
+
+
+import qualified Language.Fixpoint.Misc  as Misc
+import qualified Text.PrettyPrint.HughesPJ.Compat as P
+import qualified Language.Fixpoint.Types.PrettyPrint as F
+import qualified Language.Fixpoint.Types.Names as F
+import qualified Language.Fixpoint.Types.Sorts as F
+import qualified Language.Fixpoint.Types.Spans as F
+import qualified Language.Fixpoint.Types.Refinements as F
+-- import qualified Language.Fixpoint.Types.Constraints as F
+
+-----------------------------------------------------------------------------------------------------------------
+-- Human readable but robustly parseable SMT-LIB format pretty printer
+-----------------------------------------------------------------------------------------------------------------
+class ToHornSMT a where
+  toHornSMT :: a -> P.Doc
+
+
+instance ToHornSMT F.Symbol where
+  toHornSMT s = F.pprint s
+
+
+
+toHornWithBinders :: (ToHornSMT a, ToHornSMT t) => P.Doc -> [(F.Symbol, t)] -> a -> P.Doc
+toHornWithBinders name xts p =  P.parens (name P.<+> toHornSMT xts P.<+> toHornSMT p)
+
+instance ToHornSMT a => ToHornSMT (F.Symbol, a) where
+  toHornSMT (x, t) = P.parens $ F.pprint x P.<+> toHornSMT t
+
+instance ToHornSMT a => ToHornSMT [a] where
+  toHornSMT = toHornMany . fmap toHornSMT
+
+toHornMany :: [P.Doc] -> P.Doc
+toHornMany = P.parens . P.sep -- Misc.intersperse " "
+
+toHornAnd :: (a -> P.Doc) -> [a] -> P.Doc
+toHornAnd f xs = P.parens (P.vcat ("and" : (P.nest 1 . f <$> xs)))
+
+
+instance ToHornSMT F.DataDecl where
+  toHornSMT (F.DDecl tc n ctors) =
+    P.parens $ P.vcat [
+      P.text "datatype" P.<+> P.parens (toHornSMT tc P.<+> P.int n)
+    , P.parens (P.vcat (toHornSMT <$> ctors))
+    ]
+
+instance ToHornSMT F.FTycon where
+  toHornSMT c
+    | c == F.listFTyCon = "list"
+    | otherwise         = toHornSMT (F.symbol c)
+
+instance ToHornSMT a => ToHornSMT (F.Located a) where
+  toHornSMT = toHornSMT . F.val
+
+instance ToHornSMT F.DataCtor where
+  toHornSMT (F.DCtor x flds) = P.parens (toHornSMT x P.<+> toHornSMT flds)
+
+instance ToHornSMT F.DataField where
+  toHornSMT (F.DField x t) = toHornSMT (F.val x, t)
+
+instance ToHornSMT F.Sort where
+  toHornSMT = toHornSort
+
+toHornSort :: F.Sort -> P.Doc
+toHornSort (F.FVar i)     = "@" P.<-> P.parens (P.int i)
+toHornSort F.FInt         = "Int"
+toHornSort F.FReal        = "Real"
+toHornSort F.FFrac        = "Frac"
+toHornSort (F.FObj x)     = toHornSMT x -- P.parens ("obj" P.<+> toHornSMT x)
+toHornSort F.FNum         = "num"
+toHornSort t@(F.FAbs _ _) = toHornAbsApp t
+toHornSort t@(F.FFunc _ _)= toHornAbsApp t
+toHornSort (F.FTC c)      = toHornSMT c
+toHornSort t@(F.FApp _ _) = toHornFApp (F.unFApp t)
+
+toHornAbsApp :: F.Sort -> P.Doc
+toHornAbsApp (F.functionSort -> Just (vs, ss, s)) = P.parens ("func" P.<+> P.int (length vs) P.<+> toHornSMT ss P.<+> toHornSMT s )
+toHornAbsApp _                                    = error "Unexpected nothing function sort"
+
+toHornFApp     :: [F.Sort] -> P.Doc
+toHornFApp [t] = toHornSMT t
+toHornFApp ts  = toHornSMT ts
+
+instance ToHornSMT F.Subst where
+  toHornSMT (F.Su m) = toHornSMT (Misc.hashMapToAscList m)
+
+
+
+instance ToHornSMT F.KVar where
+  toHornSMT (F.KV k) = "$" P.<-> toHornSMT k
+
+instance ToHornSMT F.Expr where
+  toHornSMT = toHornExpr
+
+toHornExpr :: F.Expr -> P.Doc
+toHornExpr (F.ESym c)        = F.pprint c
+toHornExpr (F.ECon c)        = F.pprint c
+toHornExpr (F.EVar s)        = toHornSMT s
+toHornExpr (F.ENeg e)        = P.parens ("-" P.<+> toHornExpr e)
+toHornExpr (F.EApp e1 e2)    = toHornSMT [e1, e2]
+toHornExpr (F.EBin o e1 e2)  = toHornOp   (F.toFix o) [e1, e2]
+toHornExpr (F.ELet x e1 e2)  = toHornMany ["let", toHornSMT [(x, e1)], toHornSMT e2]
+toHornExpr (F.EIte e1 e2 e3) = toHornOp "if"  [e1, e2, e3]
+toHornExpr (F.ECst e t)      = toHornMany ["cast", toHornSMT e, toHornSMT t]
+toHornExpr (F.PNot p)        = toHornOp "not"  [p]
+toHornExpr (F.PImp e1 e2)    = toHornOp "=>"   [e1, e2]
+toHornExpr (F.PIff e1 e2)    = toHornOp "<=>"  [e1, e2]
+toHornExpr e@F.PTrue         = F.pprint e
+toHornExpr e@F.PFalse        = F.pprint e
+toHornExpr (F.PAnd es)       = toHornOp "and" es
+toHornExpr (F.POr  es)       = toHornOp "or"  es
+toHornExpr (F.PAtom r e1 e2) = toHornOp (F.toFix r) [e1, e2]
+toHornExpr (F.PAll xts p)    = toHornMany ["forall", toHornSMT xts, toHornSMT p]
+toHornExpr (F.PExist xts p)  = toHornMany ["exists", toHornSMT xts, toHornSMT p]
+toHornExpr (F.ELam b e)      = toHornMany ["lam", toHornSMT b, toHornSMT e]
+toHornExpr (F.ECoerc a t e)  = toHornMany ["coerce", toHornSMT a, toHornSMT t, toHornSMT e]
+toHornExpr (F.PKVar k su)    = toHornMany [toHornSMT k, toHornSMT su]
+toHornExpr (F.ETApp e s)     = toHornMany ["ETApp" , toHornSMT e, toHornSMT s]
+toHornExpr (F.ETAbs e s)     = toHornMany ["ETAbs" , toHornSMT e, toHornSMT s]
+toHornExpr (F.PGrad k _ _ e) = toHornMany ["&&", toHornSMT e, toHornSMT k]
+
+toHornOp :: ToHornSMT a => P.Doc -> [a] -> P.Doc
+toHornOp op es = toHornMany (op : (toHornSMT <$> es))

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 {-# OPTIONS_GHC -Wno-orphans   #-}
+{-# LANGUAGE InstanceSigs #-}
 
 -- | This module contains the various instances for Subable,
 --   which (should) depend on the visitors, and hence cannot
@@ -126,6 +127,7 @@ captureAvoiding x f y = if y == x then EVar x else f y
 instance Subable Expr where
   syms                     = exprSymbols
   substa f                 = substf (EVar . f)
+  substf :: (Symbol -> Expr) -> Expr -> Expr
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
   substf f (ELam (x,t) e)  = ELam (x, t) (substf (captureAvoiding x f) e)
   substf f (ECoerc a t e)  = ECoerc a t (substf f e)
@@ -144,6 +146,7 @@ instance Subable Expr where
   substf f (PKVar k (Su su)) = PKVar k (Su $ M.map (substf f) su)
   substf _ (PAll _ _)      = errorstar "substf: FORALL"
   substf f (PGrad k su i e)= PGrad k su i (substf f e)
+  substf f (PExist xts e)  = PExist xts (substf f e)
   substf _  p              = p
 
 

--- a/tests/horn/pos/icfp17-ex2.smt2
+++ b/tests/horn/pos/icfp17-ex2.smt2
@@ -1,4 +1,4 @@
-; (fixpoint "--eliminate=horn")
+(fixpoint "--eliminate=horn")
 
 
 

--- a/tests/horn/pos/icfp17-ex2.smt2
+++ b/tests/horn/pos/icfp17-ex2.smt2
@@ -1,14 +1,14 @@
-(fixpoint "--eliminate=horn")
- 
- 
- 
+; (fixpoint "--eliminate=horn")
+
+
+
 (var $kx (Int))
 (var $ky (Int))
- 
- 
- 
- 
- 
+
+
+
+
+
 (constraint
   (and
     (forall ((x Int) ((>= x 0)))

--- a/tests/horn/pos/mod00.smt2
+++ b/tests/horn/pos/mod00.smt2
@@ -17,7 +17,7 @@
     )
     (forall ((a2 int) (true))
     ; sprinkle sprinkle
-      (forall ((_ int) (and ($k0 a2) ((>= a2 4)) ((>= a2 10))))
+      (forall ((_ int) ($k0 a2))
         (tag ((= ((mod a2 2)) 0)) "0")  ; lets stick a comment here too!
       )
     )

--- a/tests/horn/pos/sum-rec.smt2
+++ b/tests/horn/pos/sum-rec.smt2
@@ -1,4 +1,5 @@
 (qualif Bar ((v Int)) (>= v 0))
+(qualif Baz ((v Int) (a Int)) (>= v a))
 (var $k1 (Int Int))
 (constraint
   (and


### PR DESCRIPTION
This PR makes a few related changes

- Make the `--json` also dump out the `Solution` as part of the result,
- Add the "params" of each `KVar` as a part of the `Solution`,

Note that this requires 

1. *not* quantifying out the `xts` that come from the params of the `KVar` in `cubePred`
2. *not* removing the equalities due to the above (which are now "free" in the solution).

@facundominguez would be most grateful for any comments if you have time!

So now, we get

```
$ cabal run fixpoint -- tests/horn/pos/sum-rec.smt2 --save
$ more tests/horn/pos/.liquid/sum-rec.smt2.fqout

Solution:
$k1[$k1##0 : int, $k1##1 : int] := $k1##0 >= 0
                                   && $k1##0 >= $k1##1


Non-cut kvars:

```

and 

```
$ cabal run fixpoint -- tests/horn/pos/mod00.smt2 --save
...
$ more tests/horn/pos/.liquid/mod00.smt2.fqout

Solution:



Non-cut kvars:

$k0[$k0##0 : int] := exists [a1##2 : int]
                       . $k0##0 == a1##2
                         && a1##2 == 10
                     || exists [a0##1 : int]
                          . $k0##0 == a0##1
                            && a0##1 == 4
```