### PR TITLE
Various changes to support extracting solutions

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -328,7 +328,7 @@ simplifyResult :: Result a -> Result a
 simplifyResult res =
     res
       { resSolution = HashMap.map simplifyKVar' (resSolution res)
-      , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
+      , resNonCutsSolution = HashMap.map simplifyKVar' (tracepp "pre-simplify" $ resNonCutsSolution res)
       }
   where
     simplifyKVar' = unElab . simplifyKVar
@@ -353,20 +353,30 @@ simplifyKVar = go
   where
     go (POr es) = POr $ map go es
     go (PExist bs e@(PAnd es)) =
-      let -- existential bindings that occur only once in the body of the
+      let -- Count occurrences of each variable
+          allOccurrences = L.group $ L.sort $ collectFreeVarOccurrences e
+
+          -- existential bindings that occur only once in the body of the
           -- existential
           singleOccurrenceBindings =
             filter isExistentialBinding $
-              concat $ filter occursExactlyOnce $
-                L.group $ L.sort $ collectFreeVarOccurrences e
+              concat $ filter occursExactlyOnce allOccurrences
+
+          -- existential bindings that occur more than once
+          multipleOccurrenceBindings =
+            filter isExistentialBinding $
+              map head $ filter occursMoreThanOnce allOccurrences
+
           isExistentialBinding = (`elem` map fst bs)
           occursExactlyOnce [_] = True
           occursExactlyOnce _   = False
+          occursMoreThanOnce (_:_:_) = True
+          occursMoreThanOnce _ = False
 
           esv = map (isUniqueEq singleOccurrenceBindings) es
           removed = mapMaybe fst esv
-          needed = singleOccurrenceBindings L.\\ removed
-          bs' = filter ((`elem` needed) . fst) bs
+          needed = (singleOccurrenceBindings L.\\ removed) ++ multipleOccurrenceBindings
+          bs' = tracepp ("bs=" ++ show (bs, removed, needed)) $ filter ((`elem` needed) . fst) bs
       in
           PExist bs' $ PAnd $ [ei | (Nothing, ei) <- esv]
     go e = e

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -393,7 +393,7 @@ simplifyKVarOccurrences = go
           esv = map (isUniqueEq singleOccurrenceBindings) es
           removed = mapMaybe fst esv
           needed = (singleOccurrenceBindings L.\\ removed) ++ multipleOccurrenceBindings
-          bs' = tracepp ("bs=" ++ show (bs, removed, needed)) $ filter ((`elem` needed) . fst) bs
+          bs' = filter ((`elem` needed) . fst) bs
       in
           pExist bs' $ pAnd [ei | (Nothing, ei) <- esv]
     go e = e

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -331,18 +331,18 @@ simplifyResult cfg res =
       , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
       }
   where
-    simplifyKVar' = unElab . simplifyKVar cfg
+    simplifyKVar' = unElabSets . unElab . simplifyKVar cfg
+    sets          = elabSetBag . solverFlags . solver $ cfg
+    unElabSets    = if sets then unElabFSetBagZ3 else id
+
 
     --   (if Cfg.elabSetBag ef then elabFSetBagZ3 else id)
 simplifyKVar :: Config -> Expr -> Expr
 simplifyKVar cfg
-  | full        = unElabSets . simplifyKVarTrivial
+  | full        = simplifyKVarTrivial
   | otherwise   = simplifyKVarOccurrences
   where
     full        = fullSolution cfg
-    sets        = elabSetBag . solverFlags . solver $ cfg
-    unElabSets  = if sets then unElabFSetBagZ3 else id
-
 
 simplifyKVarTrivial :: Expr -> Expr
 simplifyKVarTrivial = go

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -328,7 +328,7 @@ simplifyResult :: Result a -> Result a
 simplifyResult res =
     res
       { resSolution = HashMap.map simplifyKVar' (resSolution res)
-      , resNonCutsSolution = HashMap.map simplifyKVar' (tracepp "pre-simplify" $ resNonCutsSolution res)
+      , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
       }
   where
     simplifyKVar' = unElab . simplifyKVar
@@ -378,7 +378,7 @@ simplifyKVar = go
           needed = (singleOccurrenceBindings L.\\ removed) ++ multipleOccurrenceBindings
           bs' = tracepp ("bs=" ++ show (bs, removed, needed)) $ filter ((`elem` needed) . fst) bs
       in
-          PExist bs' $ PAnd $ [ei | (Nothing, ei) <- esv]
+          pExist bs' $ pAnd [ei | (Nothing, ei) <- esv]
     go e = e
 
 

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -40,7 +40,7 @@ import           Language.Fixpoint.Solver.EnvironmentReduction
 import           Language.Fixpoint.Solver.Sanitize  (symbolEnv, sanitize)
 import           Language.Fixpoint.Solver.UniqifyBinds (renameAll)
 import           Language.Fixpoint.Defunctionalize (defunctionalize)
-import           Language.Fixpoint.SortCheck            (ElabParam (..), Elaborate (..), unElab)
+import           Language.Fixpoint.SortCheck            (ElabParam (..), Elaborate (..), unElab, unElabFSetBagZ3)
 import           Language.Fixpoint.Solver.Extensionality (expand)
 import           Language.Fixpoint.Solver.Prettify (savePrettifiedQuery)
 import           Language.Fixpoint.Solver.UniqifyKVars (wfcUniqify)
@@ -333,10 +333,15 @@ simplifyResult cfg res =
   where
     simplifyKVar' = unElab . simplifyKVar cfg
 
+    --   (if Cfg.elabSetBag ef then elabFSetBagZ3 else id)
 simplifyKVar :: Config -> Expr -> Expr
 simplifyKVar cfg
-  | fullSolution cfg = simplifyKVarTrivial
-  | otherwise        = simplifyKVarOccurrences
+  | full        = unElabSets . simplifyKVarTrivial
+  | otherwise   = simplifyKVarOccurrences
+  where
+    full        = fullSolution cfg
+    sets        = elabSetBag . solverFlags . solver $ cfg
+    unElabSets  = if sets then unElabFSetBagZ3 else id
 
 
 simplifyKVarTrivial :: Expr -> Expr

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -331,25 +331,10 @@ simplifyResult cfg res =
       , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
       }
   where
-    simplifyKVar' = unElabSets . unElab . simplifyKVar cfg
+    simplifyKVar' = unElabSets . unElab . simplifyKVar
     sets          = elabSetBag . solverFlags . solver $ cfg
     unElabSets    = if sets then unElabFSetBagZ3 else id
 
-simplifyKVar :: Config -> Expr -> Expr
-simplifyKVar _cfg = simplifyKVarOccurrences
-  -- | False && fullSolution cfg = simplifyKVarTrivial
-  -- | otherwise        = simplifyKVarOccurrences
-
--- _simplifyKVarTrivial :: Expr -> Expr
--- _simplifyKVarTrivial = go
---   where
---     go (POr es)      = POr (go <$> es)
---     go (PAnd es)     = PAnd (go <$> es)
---     go (PExist bs e) = pExist bs' e
---       where
---         fvs = collectFreeVarOccurrences e
---         bs' = filter (\(b, _) -> b `elem` fvs) bs
---     go e = e
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.
 --
@@ -366,8 +351,8 @@ simplifyKVar _cfg = simplifyKVarOccurrences
 --
 -- We require that relevant variables occur more than once, or that
 -- they occur in some other place than as an argument to @==@.
-simplifyKVarOccurrences :: Expr -> Expr
-simplifyKVarOccurrences = go
+simplifyKVar :: Expr -> Expr
+simplifyKVar = go
   where
     go (POr es) = POr $ map go es
     go (PExist bs e@(PAnd es)) =

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -273,7 +273,7 @@ reduceFInfo cfg fi = do
 solveNative' !cfg !fi0 = do
   si6 <- simplifyFInfo cfg fi0
   res0 <- {- SCC "Sol.solve" -} Sol.solve cfg $!! si6
-  let res = simplifyResult res0
+  let res = simplifyResult cfg res0
   -- rnf soln `seq` donePhase Loud "Solve2"
   --let stat = resStatus res
   -- saveSolution cfg res
@@ -324,14 +324,31 @@ saveSolution cfg res = when (save cfg) $ do
       scope k = L.sortBy (comparing fst) $ HashMap.lookupDefault [] k $ resSorts res
       ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> pprint xts, ":=", pprint e ]
 
-simplifyResult :: Result a -> Result a
-simplifyResult res =
+simplifyResult :: Config -> Result a -> Result a
+simplifyResult cfg res =
     res
       { resSolution = HashMap.map simplifyKVar' (resSolution res)
       , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
       }
   where
-    simplifyKVar' = unElab . simplifyKVar
+    simplifyKVar' = unElab . simplifyKVar cfg
+
+simplifyKVar :: Config -> Expr -> Expr
+simplifyKVar cfg
+  | fullSolution cfg = simplifyKVarTrivial
+  | otherwise        = simplifyKVarOccurrences
+
+
+simplifyKVarTrivial :: Expr -> Expr
+simplifyKVarTrivial = go
+  where
+    go (POr es)      = POr (go <$> es)
+    go (PAnd es)     = PAnd (go <$> es)
+    go (PExist bs e) = pExist bs' e
+      where
+        fvs = collectFreeVarOccurrences e
+        bs' = filter (\(b, _) -> b `elem` fvs) bs
+    go e = e
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.
 --
@@ -348,8 +365,8 @@ simplifyResult res =
 --
 -- We require that relevant variables occur more than once, or that
 -- they occur in some other place than as an argument to @==@.
-simplifyKVar :: Expr -> Expr
-simplifyKVar = go
+simplifyKVarOccurrences :: Expr -> Expr
+simplifyKVarOccurrences = go
   where
     go (POr es) = POr $ map go es
     go (PExist bs e@(PAnd es)) =

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -335,25 +335,21 @@ simplifyResult cfg res =
     sets          = elabSetBag . solverFlags . solver $ cfg
     unElabSets    = if sets then unElabFSetBagZ3 else id
 
-
-    --   (if Cfg.elabSetBag ef then elabFSetBagZ3 else id)
 simplifyKVar :: Config -> Expr -> Expr
-simplifyKVar cfg
-  | full        = simplifyKVarTrivial
-  | otherwise   = simplifyKVarOccurrences
-  where
-    full        = fullSolution cfg
+simplifyKVar _cfg = simplifyKVarOccurrences
+  -- | False && fullSolution cfg = simplifyKVarTrivial
+  -- | otherwise        = simplifyKVarOccurrences
 
-simplifyKVarTrivial :: Expr -> Expr
-simplifyKVarTrivial = go
-  where
-    go (POr es)      = POr (go <$> es)
-    go (PAnd es)     = PAnd (go <$> es)
-    go (PExist bs e) = pExist bs' e
-      where
-        fvs = collectFreeVarOccurrences e
-        bs' = filter (\(b, _) -> b `elem` fvs) bs
-    go e = e
+-- _simplifyKVarTrivial :: Expr -> Expr
+-- _simplifyKVarTrivial = go
+--   where
+--     go (POr es)      = POr (go <$> es)
+--     go (PAnd es)     = PAnd (go <$> es)
+--     go (PExist bs e) = pExist bs' e
+--       where
+--         fvs = collectFreeVarOccurrences e
+--         bs' = filter (\(b, _) -> b `elem` fvs) bs
+--     go e = e
 
 -- | Simplifies existential expressions with unused or inconsequential bindings.
 --

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -325,7 +325,7 @@ solNonCutsResult cfg s
   | otherwise = pure mempty
 
 cfgNonCuts :: Config -> Bool
-cfgNonCuts cfg = save cfg || (json cfg {- && fullSolution cfg -})
+cfgNonCuts cfg = save cfg || json cfg
 
 result_
   :: (F.Loc a, NFData a)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -159,7 +159,7 @@ solve_ cfg fi s0 ks wkl = do
     _ -> return $ mytrace "all checked with interpreter" res1
 
   st      <- stats
-  let res3 = {- SCC "sol-tidy" -} tidyResult res2
+  let res3 = {- SCC "sol-tidy" -} tidyResult cfg res2
   return $!! (res3, st)
 
 
@@ -167,21 +167,43 @@ solve_ cfg fi s0 ks wkl = do
 -- | tidyResult ensures we replace the temporary kVarArg names introduced to
 --   ensure uniqueness with the original names in the given WF constraints.
 --------------------------------------------------------------------------------
-tidyResult :: F.Result a -> F.Result a
-tidyResult r = r
-  { F.resSolution = tidySolution (F.resSolution r)
-  , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
-  , F.resSorts = tidyBind <$>  F.resSorts r
-  }
-
-tidyBind :: [(F.Symbol, F.Sort)] -> [(F.Symbol, F.Sort)]
-tidyBind xts = [ (F.tidySymbol x, t) | (x, t) <- xts ]
+tidyResult :: Config -> F.Result a -> F.Result a
+tidyResult cfg r
+  | fullSolution cfg = r
+  | otherwise = r { F.resSolution = tidySolution (F.resSolution r)
+                  , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
+                  , F.resSorts = fmap tidyBind <$>  F.resSorts r
+                }
 
 tidySolution :: F.FixSolution -> F.FixSolution
 tidySolution = fmap tidyPred
 
+tidyBind :: (F.Symbol, F.Sort) -> (F.Symbol, F.Sort)
+tidyBind (x, t) = (F.tidySymbol x, t)
+
 tidyPred :: F.Expr -> F.Expr
-tidyPred = F.substf (F.eVar . F.tidySymbol)
+tidyPred =  go
+  where
+    ts = F.tidySymbol
+    tb = tidyBind
+    go (F.EApp s e)      = F.EApp (go s) (go e)
+    go (F.ELam (x,t) e)  = F.ELam (ts x, t) (go e)
+    go (F.ECoerc a t e)  = F.ECoerc a t (go e)
+    go (F.ENeg e)        = F.ENeg (go e)
+    go (F.EBin op e1 e2) = F.EBin op (go e1) (go e2)
+    go (F.ELet x e1 e2)  = F.ELet (ts x) (go e1) (go e2)
+    go (F.EIte p e1 e2)  = F.EIte (go p) (go e1) (go e2)
+    go (F.ECst e so)     = F.ECst (go e) so
+    go (F.EVar x)        = F.EVar (ts x)
+    go (F.PAnd ps)       = F.PAnd $ map go ps
+    go (F.POr  ps)       = F.POr  $ map go ps
+    go (F.PNot p)        = F.PNot $ go p
+    go (F.PImp p1 p2)    = F.PImp (go p1) (go p2)
+    go (F.PIff p1 p2)    = F.PIff (go p1) (go p2)
+    go (F.PAtom r e1 e2) = F.PAtom r (go e1) (go e2)
+    go (F.PExist xts e)  = F.PExist (tb <$> xts) (go e)
+    go (F.PAll xts e)    = F.PAll   (tb <$> xts) (go e)
+    go  p                = p
 
 --------------------------------------------------------------------------------
 {-# SCC refine #-}
@@ -268,7 +290,7 @@ result bindingsInSmt cfg fi wkl s =
     stat      <- result_ bindingsInSmt2 cfg wkl s
     lift       $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
     resCut    <- solResult cfg s
-    resNonCut <- solNonCutsResult s
+    resNonCut <- solNonCutsResult cfg s
     resSorts  <- resultSorts fi (M.keys resCut ++ M.keys resNonCut) <$> getBinds
     return     $ F.Result (ci <$> stat) resCut resNonCut mempty resSorts
   where
@@ -295,11 +317,16 @@ bindInfo be i = (x, F.sr_sort sr)
 solResult :: Config -> Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
 solResult cfg = minimizeResult cfg . Sol.result
 
-solNonCutsResult :: Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
-solNonCutsResult s = do
-  be <- getBinds
-  ef <- T.ctxElabF <$> getContext
-  pure $ runReader (S.nonCutsResult be s) ef
+solNonCutsResult :: Config -> Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
+solNonCutsResult cfg s
+  | cfgNonCuts cfg = do
+    be <- getBinds
+    ef <- T.ctxElabF <$> getContext
+    pure $ runReader (S.nonCutsResult be s) ef
+  | otherwise = pure mempty
+
+cfgNonCuts :: Config -> Bool
+cfgNonCuts cfg = save cfg || (json cfg && fullSolution cfg)
 
 result_
   :: (F.Loc a, NFData a)

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -168,12 +168,11 @@ solve_ cfg fi s0 ks wkl = do
 --   ensure uniqueness with the original names in the given WF constraints.
 --------------------------------------------------------------------------------
 tidyResult :: Config -> F.Result a -> F.Result a
-tidyResult cfg r
-  | fullSolution cfg = r
-  | otherwise = r { F.resSolution = tidySolution (F.resSolution r)
-                  , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
-                  , F.resSorts = fmap tidyBind <$>  F.resSorts r
-                }
+tidyResult _ r = r
+  { F.resSolution = tidySolution (F.resSolution r)
+  , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
+  , F.resSorts = fmap tidyBind <$>  F.resSorts r
+  }
 
 tidySolution :: F.FixSolution -> F.FixSolution
 tidySolution = fmap tidyPred
@@ -326,7 +325,7 @@ solNonCutsResult cfg s
   | otherwise = pure mempty
 
 cfgNonCuts :: Config -> Bool
-cfgNonCuts cfg = save cfg || (json cfg && fullSolution cfg)
+cfgNonCuts cfg = save cfg || (json cfg {- && fullSolution cfg -})
 
 result_
   :: (F.Loc a, NFData a)

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -56,6 +56,7 @@ module Language.Fixpoint.SortCheck  (
   , elabNumeric
   , unApply
   , unElab
+  , unElabFSetBagZ3
   , unElabSortedReft
   , unApplySortedReft
   , unApplyAt
@@ -283,49 +284,132 @@ elabFMap (PGrad  k su i e) = PGrad k su i (elabFMap e)
 elabFMap (ECoerc a t e)    = ECoerc a t (elabFMap e)
 elabFMap e                 = e
 
+
 elabFSetBagZ3 :: Expr -> Expr
-elabFSetBagZ3 (EApp h@(EVar f) e)
-  | f == Thy.setEmpty         = EApp (EVar Thy.arrConstS) PFalse
-  | f == Thy.setEmp           = PAtom Eq (EApp (EVar Thy.arrConstS) PFalse) (elabFSetBagZ3 e)
-  | f == Thy.setSng           = EApp (EApp (EApp (EVar Thy.arrStoreS) (EApp (EVar Thy.arrConstS) PFalse)) (elabFSetBagZ3 e)) PTrue
-  | f == Thy.setCom           = EApp (EVar Thy.arrMapNotS) (elabFSetBagZ3 e)
-  | f == Thy.bagEmpty         = EApp (EVar Thy.arrConstB) (ECon (I 0))
-  | otherwise                 = EApp (elabFSetBagZ3 h) (elabFSetBagZ3 e)
-elabFSetBagZ3 (EApp (EApp h@(EVar f) e1) e2)
-  | f == Thy.setMem           = EApp (EApp (EVar Thy.arrSelectS) (elabFSetBagZ3 e2)) (elabFSetBagZ3 e1)
-  | f == Thy.setCup           = EApp (EApp (EVar Thy.arrMapOrS) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | f == Thy.setCap           = EApp (EApp (EVar Thy.arrMapAndS) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | f == Thy.setAdd           = EApp (EApp (EApp (EVar Thy.arrStoreS) (elabFSetBagZ3 e2)) (elabFSetBagZ3 e1)) PTrue
-  -- A \ B == A /\ ~B == ~(A => B)
-  | f == Thy.setDif           = EApp (EApp (EVar Thy.arrMapAndS) (elabFSetBagZ3 e1)) (EApp (EVar Thy.arrMapNotS) (elabFSetBagZ3 e2))
-  | f == Thy.setSub           = PAtom Eq (EApp (EVar Thy.arrConstS) PTrue) (EApp (EApp (EVar Thy.arrMapImpS) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2))
-  | f == Thy.bagCount         = EApp (EApp (EVar Thy.arrSelectB) (elabFSetBagZ3 e2)) (elabFSetBagZ3 e1)
-  | f == Thy.bagSng           = EApp (EApp (EApp (EVar Thy.arrStoreB) (EApp (EVar Thy.arrConstB) (ECon (I 0)))) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | f == Thy.bagCup           = EApp (EApp (EVar Thy.arrMapPlusB) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | f == Thy.bagSub           = PAtom Eq (EApp (EVar Thy.arrConstS) PTrue) (EApp (EApp (EVar Thy.arrMapLeB) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2))
-  | f == Thy.bagMax           = EApp (EApp (EApp (EVar Thy.arrMapIteB) (EApp (EApp (EVar Thy.arrMapGtB) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2))) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | f == Thy.bagMin           = EApp (EApp (EApp (EVar Thy.arrMapIteB) (EApp (EApp (EVar Thy.arrMapLeB) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2))) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-  | otherwise                 = EApp (EApp (elabFSetBagZ3 h) (elabFSetBagZ3 e1)) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (EApp e1 e2)      = EApp (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (ENeg e)          = ENeg (elabFSetBagZ3 e)
-elabFSetBagZ3 (EBin b e1 e2)    = EBin b (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (ELet x e1 e2)    = ELet x (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (EIte e1 e2 e3)   = EIte (elabFSetBagZ3 e1) (elabFSetBagZ3 e2) (elabFSetBagZ3 e3)
-elabFSetBagZ3 (ECst e t)        = ECst (elabFSetBagZ3 e) t
-elabFSetBagZ3 (ELam b e)        = ELam b (elabFSetBagZ3 e)
-elabFSetBagZ3 (ETApp e t)       = ETApp (elabFSetBagZ3 e) t
-elabFSetBagZ3 (ETAbs e t)       = ETAbs (elabFSetBagZ3 e) t
-elabFSetBagZ3 (PAnd es)         = PAnd (elabFSetBagZ3 <$> es)
-elabFSetBagZ3 (POr es)          = POr (elabFSetBagZ3 <$> es)
-elabFSetBagZ3 (PNot e)          = PNot (elabFSetBagZ3 e)
-elabFSetBagZ3 (PImp e1 e2)      = PImp (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (PIff e1 e2)      = PIff (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (PAtom r e1 e2)   = PAtom r (elabFSetBagZ3 e1) (elabFSetBagZ3 e2)
-elabFSetBagZ3 (PAll   bs e)     = PAll bs (elabFSetBagZ3 e)
-elabFSetBagZ3 (PExist bs e)     = PExist bs (elabFSetBagZ3 e)
-elabFSetBagZ3 (PGrad  k su i e) = PGrad k su i (elabFSetBagZ3 e)
-elabFSetBagZ3 (ECoerc a t e)    = ECoerc a t (elabFSetBagZ3 e)
-elabFSetBagZ3 e                 = e
+elabFSetBagZ3 = go
+  where
+    go (EApp h@(EVar f) e)
+      | f == Thy.setEmpty = EApp (EVar Thy.arrConstS) PFalse
+      | f == Thy.setEmp   = PAtom Eq (EApp (EVar Thy.arrConstS) PFalse) (go e)
+      | f == Thy.setSng   = EApp (EApp (EApp (EVar Thy.arrStoreS) (EApp (EVar Thy.arrConstS) PFalse)) (go e)) PTrue
+      | f == Thy.setCom   = EApp (EVar Thy.arrMapNotS) (go e)
+      | f == Thy.bagEmpty = EApp (EVar Thy.arrConstB) (ECon (I 0))
+      | otherwise         = EApp (go h) (go e)
+    go (EApp (EApp h@(EVar f) e1) e2)
+      | f == Thy.setMem   = EApp (EApp (EVar Thy.arrSelectS) (go e2)) (go e1)
+      | f == Thy.setCup   = EApp (EApp (EVar Thy.arrMapOrS) (go e1)) (go e2)
+      | f == Thy.setCap   = EApp (EApp (EVar Thy.arrMapAndS) (go e1)) (go e2)
+      | f == Thy.setAdd   = EApp (EApp (EApp (EVar Thy.arrStoreS) (go e2)) (go e1)) PTrue
+      -- A \ B == A /\ ~B == ~(A => B)
+      | f == Thy.setDif   = EApp (EApp (EVar Thy.arrMapAndS) (go e1)) (EApp (EVar Thy.arrMapNotS) (go e2))
+      | f == Thy.setSub   = PAtom Eq (EApp (EVar Thy.arrConstS) PTrue) (EApp (EApp (EVar Thy.arrMapImpS) (go e1)) (go e2))
+      | f == Thy.bagCount = EApp (EApp (EVar Thy.arrSelectB) (go e2)) (go e1)
+      | f == Thy.bagSng   = EApp (EApp (EApp (EVar Thy.arrStoreB) (EApp (EVar Thy.arrConstB) (ECon (I 0)))) (go e1)) (go e2)
+      | f == Thy.bagCup   = EApp (EApp (EVar Thy.arrMapPlusB) (go e1)) (go e2)
+      | f == Thy.bagSub   = PAtom Eq (EApp (EVar Thy.arrConstS) PTrue) (EApp (EApp (EVar Thy.arrMapLeB) (go e1)) (go e2))
+      | f == Thy.bagMax   = EApp (EApp (EApp (EVar Thy.arrMapIteB) (EApp (EApp (EVar Thy.arrMapGtB) (go e1)) (go e2))) (go e1)) (go e2)
+      | f == Thy.bagMin   = EApp (EApp (EApp (EVar Thy.arrMapIteB) (EApp (EApp (EVar Thy.arrMapLeB) (go e1)) (go e2))) (go e1)) (go e2)
+      | otherwise         = EApp (EApp (go h) (go e1)) (go e2)
+    go (EApp e1 e2)       = EApp   (go e1) (go e2)
+    go (ENeg e)           = ENeg   (go e)
+    go (EBin b e1 e2)     = EBin b (go e1) (go e2)
+    go (ELet x e1 e2)     = ELet x (go e1) (go e2)
+    go (EIte e1 e2 e3)    = EIte   (go e1) (go e2) (go e3)
+    go (ECst e t)         = ECst   (go e) t
+    go (ELam b e)         = ELam b (go e)
+    go (ETApp e t)        = ETApp  (go e) t
+    go (ETAbs e t)        = ETAbs  (go e) t
+    go (PAnd es)          = PAnd   (go <$> es)
+    go (POr es)           = POr    (go <$> es)
+    go (PNot e)           = PNot   (go e)
+    go (PImp e1 e2)       = PImp   (go e1) (go e2)
+    go (PIff e1 e2)       = PIff   (go e1) (go e2)
+    go (PAtom r e1 e2)    = PAtom r (go e1) (go e2)
+    go (PAll   bs e)      = PAll bs (go e)
+    go (PExist bs e)      = PExist bs (go e)
+    go (PGrad  k su i e)  = PGrad k su i (go e)
+    go (ECoerc a t e)     = ECoerc a t (go e)
+    go e                  = e
+
+-- | Reverse transformation of elabFSetBagZ3: converts array representations back to set/bag operations
+unElabFSetBagZ3 :: Expr -> Expr
+unElabFSetBagZ3 = go
+  where
+    -- arr_const_s false -> Set_empty
+    go (EApp (EVar f) PFalse)
+      | f == Thy.arrConstS = EVar Thy.setEmpty
+    -- arr_const_s false == e -> Set_emp e
+    go (PAtom Eq (EApp (EVar f) PFalse) e)
+      | f == Thy.arrConstS = EApp (EVar Thy.setEmp) (go e)
+    -- arr_store_s (arr_const_s false) e true -> Set_sng e
+    go (EApp (EApp (EApp (EVar f1) (EApp (EVar f2) PFalse)) e) PTrue)
+      | f1 == Thy.arrStoreS && f2 == Thy.arrConstS = EApp (EVar Thy.setSng) (go e)
+    -- arr_map_not_s e -> Set_com e
+    go (EApp (EVar f) e)
+      | f == Thy.arrMapNotS = EApp (EVar Thy.setCom) (go e)
+    -- arr_const_b 0 -> Bag_empty
+    go (EApp (EVar f) (ECon (I 0)))
+      | f == Thy.arrConstB = EVar Thy.bagEmpty
+    -- arr_select_s e2 e1 -> Set_mem e1 e2
+    go (EApp (EApp (EVar f) e2) e1)
+      | f == Thy.arrSelectS = EApp (EApp (EVar Thy.setMem) (go e1)) (go e2)
+    -- arr_map_or_s e1 e2 -> Set_cup e1 e2
+    go (EApp (EApp (EVar f) e1) e2)
+      | f == Thy.arrMapOrS = EApp (EApp (EVar Thy.setCup) (go e1)) (go e2)
+    -- arr_map_and_s e1 e2 -> Set_cap e1 e2
+    go (EApp (EApp (EVar f) e1) e2)
+      | f == Thy.arrMapAndS = EApp (EApp (EVar Thy.setCap) (go e1)) (go e2)
+    -- arr_store_s e2 e1 true -> Set_add e1 e2
+    go (EApp (EApp (EApp (EVar f) e2) e1) PTrue)
+      | f == Thy.arrStoreS = EApp (EApp (EVar Thy.setAdd) (go e1)) (go e2)
+    -- arr_map_and_s e1 (arr_map_not_s e2) -> Set_dif e1 e2
+    go (EApp (EApp (EVar f1) e1) (EApp (EVar f2) e2))
+      | f1 == Thy.arrMapAndS && f2 == Thy.arrMapNotS = EApp (EApp (EVar Thy.setDif) (go e1)) (go e2)
+    -- arr_const_s true == arr_map_imp_s e1 e2 -> Set_sub e1 e2
+    go (PAtom Eq (EApp (EVar f1) PTrue) (EApp (EApp (EVar f2) e1) e2))
+      | f1 == Thy.arrConstS && f2 == Thy.arrMapImpS = EApp (EApp (EVar Thy.setSub) (go e1)) (go e2)
+    -- arr_select_b e2 e1 -> Bag_count e1 e2
+    go (EApp (EApp (EVar f) e2) e1)
+      | f == Thy.arrSelectB = EApp (EApp (EVar Thy.bagCount) (go e1)) (go e2)
+    -- arr_store_b (arr_const_b 0) e1 e2 -> Bag_sng e1 e2
+    go (EApp (EApp (EApp (EVar f1) (EApp (EVar f2) (ECon (I 0)))) e1) e2)
+      | f1 == Thy.arrStoreB && f2 == Thy.arrConstB = EApp (EApp (EVar Thy.bagSng) (go e1)) (go e2)
+    -- arr_map_plus_b e1 e2 -> Bag_cup e1 e2
+    go (EApp (EApp (EVar f) e1) e2)
+      | f == Thy.arrMapPlusB = EApp (EApp (EVar Thy.bagCup) (go e1)) (go e2)
+    -- arr_const_s true == arr_map_le_b e1 e2 -> Bag_sub e1 e2
+    go (PAtom Eq (EApp (EVar f1) PTrue) (EApp (EApp (EVar f2) e1) e2))
+      | f1 == Thy.arrConstS && f2 == Thy.arrMapLeB = EApp (EApp (EVar Thy.bagSub) (go e1)) (go e2)
+    -- arr_map_ite_b (arr_map_gt_b e1 e2) e1 e2 -> Bag_max e1 e2
+    go (EApp (EApp (EApp (EVar f1) (EApp (EApp (EVar f2) e1a) e2a)) e1b) e2b)
+      | f1 == Thy.arrMapIteB && f2 == Thy.arrMapGtB && e1a == e1b && e2a == e2b
+      = EApp (EApp (EVar Thy.bagMax) (go e1a)) (go e2a)
+    -- arr_map_ite_b (arr_map_le_b e1 e2) e1 e2 -> Bag_min e1 e2
+    go (EApp (EApp (EApp (EVar f1) (EApp (EApp (EVar f2) e1a) e2a)) e1b) e2b)
+      | f1 == Thy.arrMapIteB && f2 == Thy.arrMapLeB && e1a == e1b && e2a == e2b
+      = EApp (EApp (EVar Thy.bagMin) (go e1a)) (go e2a)
+    -- Recursive cases
+    go (EApp e1 e2)       = EApp   (go e1) (go e2)
+    go (ENeg e)           = ENeg   (go e)
+    go (EBin b e1 e2)     = EBin b (go e1) (go e2)
+    go (ELet x e1 e2)     = ELet x (go e1) (go e2)
+    go (EIte e1 e2 e3)    = EIte   (go e1) (go e2) (go e3)
+    go (ECst e t)         = ECst   (go e) t
+    go (ELam b e)         = ELam b (go e)
+    go (ETApp e t)        = ETApp  (go e) t
+    go (ETAbs e t)        = ETAbs  (go e) t
+    go (PAnd es)          = PAnd   (go <$> es)
+    go (POr es)           = POr    (go <$> es)
+    go (PNot e)           = PNot   (go e)
+    go (PImp e1 e2)       = PImp   (go e1) (go e2)
+    go (PIff e1 e2)       = PIff   (go e1) (go e2)
+    go (PAtom r e1 e2)    = PAtom r (go e1) (go e2)
+    go (PAll   bs e)      = PAll bs (go e)
+    go (PExist bs e)      = PExist bs (go e)
+    go (PGrad  k su i e)  = PGrad k su i (go e)
+    go (ECoerc a t e)     = ECoerc a t (go e)
+    go e                  = e
+
 
 elabSorts :: Cfg.ElabFlags -> Expr -> Expr
 elabSorts ef (EApp e1 e2)      = EApp (elabSorts ef e1) (elabSorts ef e2)

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -121,7 +121,7 @@ data Config = Config
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
-  , fullSolution        :: Bool        -- ^ Do not simplify solutions
+  -- , fullSolution        :: Bool        -- ^ Do not simplify solutions
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -293,7 +293,7 @@ defConfig = Config {
   , fuel                     = Nothing &= help "Maximum fuel (per-function unfoldings) for PLE"
   , restOrdering             = "rpo"   &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"
-  , fullSolution             = False &= help "Do not simplify solution"
+  -- , fullSolution             = False &= help "Do not simplify solution"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -121,6 +121,7 @@ data Config = Config
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
+  , fullSolution        :: Bool        -- ^ Do not simplify solutions
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -292,6 +293,7 @@ defConfig = Config {
   , fuel                     = Nothing &= help "Maximum fuel (per-function unfoldings) for PLE"
   , restOrdering             = "rpo"   &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"
+  , fullSolution             = False &= help "Do not simplify solution"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -121,7 +121,6 @@ data Config = Config
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
-  -- , fullSolution        :: Bool        -- ^ Do not simplify solutions
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -293,7 +292,6 @@ defConfig = Config {
   , fuel                     = Nothing &= help "Maximum fuel (per-function unfoldings) for PLE"
   , restOrdering             = "rpo"   &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"
-  -- , fullSolution             = False &= help "Do not simplify solution"
   }
   &= verbosity
   &= program "fixpoint"

--- a/src/Language/Fixpoint/Types/SMTPrint.hs
+++ b/src/Language/Fixpoint/Types/SMTPrint.hs
@@ -38,7 +38,7 @@ instance ToHornSMT a => ToHornSMT [a] where
   toHornSMT = toHornMany . fmap toHornSMT
 
 toHornMany :: [P.Doc] -> P.Doc
-toHornMany = P.parens . P.sep -- Misc.intersperse " "
+toHornMany = P.parens . P.sep 
 
 toHornAnd :: (a -> P.Doc) -> [a] -> P.Doc
 toHornAnd f xs = P.parens (P.vcat ("and" : (P.nest 1 . f <$> xs)))

--- a/tests/horn/pos/exists_oddity.smt2
+++ b/tests/horn/pos/exists_oddity.smt2
@@ -1,0 +1,12 @@
+(var $k0 (int)) ;; orig: $k0
+
+(constraint
+  (and
+    (forall ((a0 int) ((= a0 0)))
+      ($k0 a0))
+    (forall ((a1 int) (true))
+      (forall ((_$ int) ($k0 a1))
+        (tag ((= a1 0)) "0")))
+    (forall ((a2 int) (true))
+      (forall ((_$ int) ((= a2 0)))
+        ($k0 a2)))))


### PR DESCRIPTION
1. Add a `--fullsolution` flag that disables simplifications, name tidying
2. Add `unElab` passes to revert the lowering of names into Z3 (e.g. for sets/maps)

The current `simplifyKVar` produces incorrect solutions, where there are odd errors with 
- name mangling when we use `tidySymbol` (only applies to expr-body, incorrectly to binders)
- non-equality predicates (e.g. bool) which don't quite fit the equality-occurrence based simplification heuristics.

So I added a `--fullsolution` that only GC's totally dead exists-binds and does nothing else, 
except that we "reverse" the elaboration done to lower to Z3's `map` based operators (as fixpoint 
clients are unaware of those, and only understand the public theory-symbols.)