### PR TITLE
Document some more functions and eliminate redundant cut kvar computation

### DIFF
--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -205,6 +205,11 @@ edgeGraph :: [CEdge] -> KVGraph
 edgeGraph es = KVGraph [(v, v, vs) | (v, vs) <- groupList es ]
 
 -- need to plumb list of ebinds
+
+-- | Compute dependencies between constraints and kvars.
+--
+-- @(k, c)@ means that constraint @c@ uses kvar @k@ on the LHS.
+-- @(c, k)@ means that constraint @c@ uses kvar @k@ on the RHS.
 {-# SCC kvEdges #-}
 kvEdges :: (F.TaggedC c a) => F.GInfo c a -> [CEdge]
 kvEdges fi = selfes ++ concatMap (subcEdges bs) cs ++ concatMap (ebindEdges ebs bs) cs
@@ -307,8 +312,10 @@ dNonCut v = Deps S.empty (S.singleton v)
 dCut    v = Deps (S.singleton v) S.empty
 
 --------------------------------------------------------------------------------
--- | Compute Dependencies and Cuts ---------------------------------------------
---------------------------------------------------------------------------------
+-- | Compute Dependencies and Cuts
+--
+-- Computes greedily a set of kvars that make the dependency graph acyclic when
+-- removed. Also yields the edges of the dependency graph.
 {-# SCC elimVars #-}
 elimVars :: (F.TaggedC c a) => Config -> F.GInfo c a -> ([CEdge], Elims F.KVar)
 --------------------------------------------------------------------------------
@@ -581,9 +588,8 @@ graphStats cfg si = Stats {
     nlks          = nonLinearKVars si
     d             = snd $ elimVars cfg si
 
---------------------------------------------------------------------------------
+-- | KVars used more than once in the LHS of some constraint
 nonLinearKVars :: (F.TaggedC c a) => F.GInfo c a -> S.HashSet F.KVar
---------------------------------------------------------------------------------
 nonLinearKVars fi = S.unions $ nlKVarsC bs <$> cs
   where
     bs            = F.bs fi

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -256,7 +256,9 @@ simplifyFInfo !cfg !fi0 = do
   loudDump 3 cfg si5
   let si6 = if extensionality cfg then {- SCC "expand" -} expand cfg si5 else si5
   if rewriteAxioms cfg && noLazyPLE cfg
-    then instantiate cfg si6 $!! Nothing
+    then do
+      bs <- instantiate cfg si6 $!! Nothing
+      return si6 { Types.bs = bs }
     else return si6
 
 reduceFInfo :: Fixpoint a => Config -> FInfo a -> IO (FInfo a)

--- a/src/Language/Fixpoint/Solver/Eliminate.hs
+++ b/src/Language/Fixpoint/Solver/Eliminate.hs
@@ -48,7 +48,9 @@ kvScopes sI es = is2env <$> kiM
                      [(k, i) | (KVar k, Cstr i) <- es ]
 
 --------------------------------------------------------------------------------
-
+-- | @cutSInfo si kI cKs@ drops well-formed constraints that don't refer to the
+-- KVars in @cKs@. Also drops subtyping constraints that don't refer in their
+-- RHS to any of the KVars in @cKs@ or which aren't concrete.
 cutSInfo :: SInfo a -> KIndex -> S.HashSet KVar -> SInfo a
 cutSInfo si kI cKs = si { ws = ws', cm = cm' }
   where
@@ -57,13 +59,17 @@ cutSInfo si kI cKs = si { ws = ws', cm = cm' }
     cs    = S.fromList      (concatMap kCs cKs)
     kCs k = M.lookupDefault [] k kI
 
+-- | Compute Dependencies and Cuts
+--
+-- Yields the edges of the dependency graph, then the set of KVars whose removal
+-- makes the graph acyclic (cuts), and finally the rest of the KVars.
 kutVars :: Config -> SInfo a -> ([CEdge], S.HashSet KVar, S.HashSet KVar)
 kutVars cfg si   = (es, depCuts ds, depNonCuts ds)
   where
     (es, ds)     = elimVars cfg si
 
 --------------------------------------------------------------------------------
--- | Map each `KVar` to the list of constraints on which it appears on RHS
+-- | Map each 'KVar' to the list of constraints on which it appears on RHS
 --------------------------------------------------------------------------------
 type KIndex = M.HashMap KVar [Integer]
 

--- a/src/Language/Fixpoint/Solver/Instantiate.hs
+++ b/src/Language/Fixpoint/Solver/Instantiate.hs
@@ -53,7 +53,7 @@ mytracepp = notracepp
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE
 --------------------------------------------------------------------------------
-instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
+instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
 instantiate cfg info subcIds
   | not (oldPLE cfg)
   = PLE.instantiate cfg info subcIds
@@ -77,7 +77,7 @@ instantiate cfg info subcIds
  -}
 
 -------------------------------------------------------------------------------
-incrInstantiate' :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
+incrInstantiate' :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
 -------------------------------------------------------------------------------
 incrInstantiate' cfg info subcIds = do
     let cs = [ (i, c) | (i, c) <- M.toList (cm info), isPleCstr aEnv i c
@@ -182,7 +182,7 @@ evalCandsLoop cfg γ s0 = go []
 ----------------------------------------------------------------------------------------------
 -- | Step 3: @resSInfo@ uses incremental PLE result @InstRes@ to produce the strengthened SInfo
 
-resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> SInfo a
+resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> BindEnv a
 resSInfo cfg env info res = strengthenBinds info res'
   where
     res'     = M.fromList $ mytracepp  "ELAB-INST:  " $ zip is ps''
@@ -300,7 +300,7 @@ getCstr env cid = Misc.safeLookup "Instantiate.getCstr" cid env
 --------------------------------------------------------------------------------
 -- | "Old" GLOBAL PLE
 --------------------------------------------------------------------------------
-instantiate' :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
+instantiate' :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
 instantiate' cfg info subcIds = sInfo cfg env info <$> withCtx cfg file env (defns info) act
   where
     act             = forM cstrs $ \(i, c) ->
@@ -311,7 +311,7 @@ instantiate' cfg info subcIds = sInfo cfg env info <$> withCtx cfg file env (def
     env             = symbolEnv cfg info
     aenv            = {- mytracepp  "AXIOM-ENV" -} ae info
 
-sInfo :: Config -> SymEnv -> SInfo a -> [((SubcId, SrcSpan), Expr)] -> SInfo a
+sInfo :: Config -> SymEnv -> SInfo a -> [((SubcId, SrcSpan), Expr)] -> BindEnv a
 sInfo cfg env info ips = strengthenHyp info (mytracepp  "ELAB-INST:  " $ zip (fst <$> is) ps'')
   where
     (is, ps)         = unzip ips

--- a/src/Language/Fixpoint/Solver/Interpreter.hs
+++ b/src/Language/Fixpoint/Solver/Interpreter.hs
@@ -57,7 +57,7 @@ mytracepp = notracepp
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE
 --------------------------------------------------------------------------------
-instInterpreter :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
+instInterpreter :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
 instInterpreter cfg fi' subcIds = do
     let cs = M.filterWithKey
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
@@ -178,7 +178,7 @@ rewriteTop e rw
 -- | Step 3: @resSInfo@ uses incremental PLE result @InstRes@ to produce the strengthened SInfo
 ----------------------------------------------------------------------------------------------
 
-resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> SInfo a
+resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> BindEnv a
 resSInfo cfg env info res = strengthenBinds info res'
   where
     res'     = M.fromList $ zip is ps''

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -73,9 +73,12 @@ mytracepp = notracepp
 
 --------------------------------------------------------------------------------
 -- | Strengthen Constraint Environments via PLE
---------------------------------------------------------------------------------
+--
+-- @instantiate cfg fi subcIds@ yields @F.bs fi@ strengthened with the
+-- unfoldings discovered by PLE on the constraints in @subcIds@ (or all
+-- constraints if @subcIds == Nothing@).
 {-# SCC instantiate #-}
-instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (SInfo a)
+instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
 instantiate cfg fi' subcIds = do
     let cs = M.filterWithKey
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
@@ -359,7 +362,7 @@ evalCandsLoop cfg ictx0 γ = go ictx0 0
 -- | Step 3: @resSInfo@ uses incremental PLE result @InstRes@ to produce the strengthened SInfo
 ----------------------------------------------------------------------------------------------
 
-resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> SInfo a
+resSInfo :: Config -> SymEnv -> SInfo a -> InstRes -> BindEnv a
 resSInfo cfg env info res = strengthenBinds info res'
   where
     res'     = M.fromList $ zip is ps''

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -99,8 +99,7 @@ doInterpret cfg fi0 subcIds = do
   where
     update' fi ss = ss{ssBinds = F.bs fi'}
       where
-        fi' = (siQuery sI) {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
-        sI  = solverInfo cfg fi
+        fi' = fi {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
 
 {-# SCC doPLE #-}
 doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a ()
@@ -110,8 +109,7 @@ doPLE cfg fi0 subcIds = do
   where
     update' fi ss = ss{ssBinds = F.bs fi'}
       where
-        fi' = (siQuery sI) {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
-        sI  = solverInfo cfg fi
+        fi' = fi {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
 
 --------------------------------------------------------------------------------
 {-# SCC solve_ #-}

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -37,7 +37,6 @@ import qualified Data.HashSet        as S
 -- import qualified Data.Maybe          as Mb
 import qualified Data.List           as L
 import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
-import qualified Language.Fixpoint.Types.Config as C
 import Language.Fixpoint.Solver.Interpreter (instInterpreter)
 import Language.Fixpoint.Solver.Instantiate (instantiate)
 import Data.Maybe (maybeToList)
@@ -94,22 +93,14 @@ siKvars = S.fromList . M.keys . F.ws
 doInterpret :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a (F.SInfo a)
 doInterpret cfg fi0 subcIds = do
   fi <- liftIO $ instInterpreter cfg fi0 (Just subcIds)
-  modify $ update' fi
+  modify $ \ss -> ss{ssBinds = F.bs fi}
   return fi
-  where
-    update' fi ss = ss{ssBinds = F.bs fi'}
-      where
-        fi' = fi {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
 
 {-# SCC doPLE #-}
 doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a ()
 doPLE cfg fi0 subcIds = do
   fi <- liftIO $ instantiate cfg fi0 (Just subcIds)
-  modify $ update' fi
-  where
-    update' fi ss = ss{ssBinds = F.bs fi'}
-      where
-        fi' = fi {F.hoInfo = F.HOI (C.allowHO cfg) (C.allowHOqs cfg)}
+  modify $ \ss -> ss{ssBinds = F.bs fi}
 
 --------------------------------------------------------------------------------
 {-# SCC solve_ #-}

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -91,16 +91,16 @@ siKvars :: F.SInfo a -> S.HashSet F.KVar
 siKvars = S.fromList . M.keys . F.ws
 
 doInterpret :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a (F.SInfo a)
-doInterpret cfg fi0 subcIds = do
-  fi <- liftIO $ instInterpreter cfg fi0 (Just subcIds)
-  modify $ \ss -> ss{ssBinds = F.bs fi}
-  return fi
+doInterpret cfg fi subcIds = do
+  bs <- liftIO $ instInterpreter cfg fi (Just subcIds)
+  modify $ \ss -> ss{ssBinds = bs}
+  return fi { F.bs = bs }
 
 {-# SCC doPLE #-}
 doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a ()
 doPLE cfg fi0 subcIds = do
-  fi <- liftIO $ instantiate cfg fi0 (Just subcIds)
-  modify $ \ss -> ss{ssBinds = F.bs fi}
+  bs <- liftIO $ instantiate cfg fi0 (Just subcIds)
+  modify $ \ss -> ss{ssBinds = bs}
 
 --------------------------------------------------------------------------------
 {-# SCC solve_ #-}

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -208,7 +208,7 @@ data SimpC a = SimpC
 instance Loc a => Loc (SimpC a) where
   srcSpan = srcSpan . _cinfo
 
-strengthenHyp :: SInfo a -> [(Integer, Expr)] -> SInfo a
+strengthenHyp :: SInfo a -> [(Integer, Expr)] -> BindEnv a
 strengthenHyp si ies = strengthenBinds si bindExprs
   where
     bindExprs        = safeFromList "strengthenHyp" [ (subcBind si i, e) | (i, e) <- ies ]
@@ -221,8 +221,8 @@ subcBind si i
   = errorstar $ "Unknown subcId in subcBind: " ++ show i
 
 
-strengthenBinds :: SInfo a -> M.HashMap BindId Expr -> SInfo a
-strengthenBinds si m = si { bs = mapBindEnv f (bs si) }
+strengthenBinds :: SInfo a -> M.HashMap BindId Expr -> BindEnv a
+strengthenBinds si m = mapBindEnv f (bs si)
   where
     f i (x, sr, l)   = case M.lookup i m of
                          Nothing -> (x, sr, l)

--- a/src/Language/Fixpoint/Types/Solutions.hs
+++ b/src/Language/Fixpoint/Types/Solutions.hs
@@ -289,7 +289,7 @@ instance Show Cube where
 --------------------------------------------------------------------------------
 result :: Sol a QBind -> M.HashMap KVar Expr
 --------------------------------------------------------------------------------
-result s = sMap $ pAnd . fmap eqPred . qbEQuals <$> s
+result s = pAnd . fmap eqPred . qbEQuals <$> sMap s
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Types/Solutions.hs
+++ b/src/Language/Fixpoint/Types/Solutions.hs
@@ -100,8 +100,13 @@ import           Language.Fixpoint.SortCheck (ElabM, ElabParam(..), elaborate)
 import           Text.PrettyPrint.HughesPJ.Compat
 
 --------------------------------------------------------------------------------
--- | Update Solution -----------------------------------------------------------
---------------------------------------------------------------------------------
+-- | Update Solution
+--
+-- @update s ks kqs@ sets in @s@ each KVar in @kqs@ to the corresponding EQuals.
+-- KVars in @ks@ which are not in @kqs@ are set to the empty list of EQuals.
+--
+-- Yields a pair @(b, s')@ where @b@ is true if the mapping of any KVar was
+-- changed.
 update :: Sol a QBind -> [KVar] -> [(KVar, EQual)] -> (Bool, Sol a QBind)
 --------------------------------------------------------------------------------
 update s ks kqs = {- tracepp msg -} (or bs, s')
@@ -117,6 +122,10 @@ folds f b = L.foldl' step ([], b)
        where
          (c, x')      = f acc x
 
+-- | @groupKs ks kqs@ groups the EQuals by KVar, ensuring that each KVar in @ks@
+-- is present (even if it has no associated EQuals).
+--
+-- Each KVar occurs only once in the output list.
 groupKs :: [KVar] -> [(KVar, EQual)] -> [(KVar, QBind)]
 groupKs ks kqs = [ (k, QB eqs) | (k, eqs) <- M.toList $ groupBase m0 kqs ]
   where
@@ -381,8 +390,8 @@ type Cand a   = [(Expr, a)]
 --------------------------------------------------------------------------------
 data EQual = EQL
   { eqQual :: !Qualifier
-  , eqPred  :: !Expr
-  , _eqArgs :: ![Expr]
+  , eqPred  :: !Expr      -- ^ predicate obtained by instantiating the qualifier
+  , _eqArgs :: ![Expr]    -- ^ actual arguments used to instantiate the qualifier
   } deriving (Eq, Show, Data, Typeable, Generic)
 
 instance Loc EQual where
@@ -396,7 +405,7 @@ instance PPrint EQual where
 
 instance NFData EQual
 
-{- EQL :: q:_ -> p:_ -> ListX F.Expr {q_params q} -> _ @-}
+-- | @eQual q xs@ instantiates @q@ with the arguments in @xs@
 eQual :: Qualifier -> [Symbol] -> EQual
 eQual q xs = {- tracepp "eQual" $ -} EQL q p es
   where


### PR DESCRIPTION
Besides the documentation additions, this PR removes the computation of cut kvars done immediately after PLE.

As PLE doesn't change the dependency graph of kvars, it is useless to recompute the cut set. Moreover, the result of the kvars computation is immediately discarded.