### PR TITLE
Fix order of kvar outputs for > 10 args

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -321,7 +321,7 @@ saveSolution cfg res = when (save cfg) $ do
     where
       scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
       scoped sol = [ (k, scope k, e) | (k, e) <- HashMap.toList sol]
-      scope k = L.sortBy (comparing fst) $ HashMap.lookupDefault [] k $ resSorts res
+      scope k = map (\(_bid, name, sort) -> (name, sort)) $ L.sortBy (comparing (\(bid, _, _) -> bid)) $ HashMap.lookupDefault [] k $ resSorts res
       ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> pprint xts, ":=", pprint e ]
 
 simplifyResult :: Config -> Result a -> Result a

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -177,14 +177,14 @@ tidyResult _ r = r
 tidySolution :: F.FixSolution -> F.FixSolution
 tidySolution = fmap tidyPred
 
-tidyBind :: (F.Symbol, F.Sort) -> (F.Symbol, F.Sort)
-tidyBind (x, t) = (F.tidySymbol x, t)
+tidyBind :: (F.BindId, F.Symbol, F.Sort) -> (F.BindId, F.Symbol, F.Sort)
+tidyBind (i, x, t) = (i, F.tidySymbol x, t)
 
 tidyPred :: F.Expr -> F.Expr
 tidyPred =  go
   where
     ts = F.tidySymbol
-    tb = tidyBind
+    tb (x, t) = (F.tidySymbol x, t)
     go (F.EApp s e)      = F.EApp (go s) (go e)
     go (F.ELam (x,t) e)  = F.ELam (ts x, t) (go e)
     go (F.ECoerc a t e)  = F.ECoerc a t (go e)
@@ -301,15 +301,15 @@ resultSorts fi ks be = M.fromList
     | k <- ks
     , xts <- maybeToList (kvarScope fi be k) ]
 
-kvarScope :: F.SInfo a -> F.BindEnv a -> F.KVar -> Maybe [(F.Symbol, F.Sort)]
+kvarScope :: F.SInfo a -> F.BindEnv a -> F.KVar -> Maybe [(F.BindId, F.Symbol, F.Sort)]
 kvarScope fi be k = do
   w <- M.lookup k (F.ws fi)
   let bs = F.wenv w
   let (v, t, _) = F.wrft w
-  return $ (v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
+  return $ (0, v, t) : [ bindInfo be i | i <- F.elemsIBindEnv bs ]
 
-bindInfo :: F.BindEnv a -> F.BindId -> (F.Symbol, F.Sort)
-bindInfo be i = (x, F.sr_sort sr)
+bindInfo :: F.BindEnv a -> F.BindId -> (F.BindId, F.Symbol, F.Sort)
+bindInfo be i = (i, x, F.sr_sort sr)
   where
     (x, sr, _) = F.lookupBindEnv i be
 

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -301,7 +301,7 @@ data Result a = Result
   }
   deriving (Generic, Show, Functor)
 
-type ResultSorts = M.HashMap KVar [(Symbol, Sort)]
+type ResultSorts = M.HashMap KVar [(BindId, Symbol, Sort)]
 
 data ScopedResult = MkScopedResult
   { scCuts    :: KVarMap ScopedExpr
@@ -330,7 +330,7 @@ scopedResult res = MkScopedResult cuts  nonCuts
     cuts = scoped (resSolution res)
     nonCuts = scoped (resNonCutsSolution res)
     scoped sol = MkKVarMap $ M.fromList [ (k, MkScopedExpr (scope k) e) | (k, e) <- M.toList sol]
-    scope k = L.sortBy (comparing fst) $ M.lookupDefault [] k $ resSorts res
+    scope k = map (\(_bid, name, sort) -> (name, sort)) $ L.sortBy (comparing (\(bid, _, _) -> bid)) $ M.lookupDefault [] k $ resSorts res
 
 instance ToJSON a => ToJSON (Result a) where
   toJSON r@(Result {..}) = object


### PR DESCRIPTION
It's lexicographic ordering...

Not sure how tests work here, but if there are tests for the pretty printer I have a test file I can share with expected output.

# Before

```
$k0[$k0##0 : int,
    $k0##1 : int,
    $k0##10 : int,
    $k0##2 : int,
    $k0##3 : int,
    $k0##4 : int,
    $k0##5 : int,
    $k0##6 : int,
    $k0##7 : int,
    $k0##8 : int,
    $k0##9 : int] :=  ...
```

# After

```
$k0[$k0##0 : int,
    $k0##1 : int,
    $k0##2 : int,
    $k0##3 : int,
    $k0##4 : int,
    $k0##5 : int,
    $k0##6 : int,
    $k0##7 : int,
    $k0##8 : int,
    $k0##9 : int,
    $k0##10 : int] :=  ...
```

# N.B.

You could argue that downstream consumers of these solutions should parse the arguments and reorder them since we do number them, but that seems cruel. Better to keep the order as intended.