### PR TITLE
Apply kvar solutions to LHSs before PLE

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -256,7 +256,7 @@ simplifyFInfo !cfg !fi0 = do
   let si6 = if extensionality cfg then {- SCC "expand" -} expand cfg si5 else si5
   if rewriteAxioms cfg && noLazyPLE cfg
     then do
-      bs <- PLE.instantiate cfg si6 $!! Nothing
+      bs <- PLE.instantiate cfg si6 Nothing Nothing
       return si6 { Types.bs = bs }
     else return si6
 

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -30,7 +30,7 @@ module Language.Fixpoint.Solver.PLE
 
 import           Language.Fixpoint.Types hiding (simplify)
 import           Language.Fixpoint.Types.Config  as FC
-import           Language.Fixpoint.Types.Solutions (CMap)
+import           Language.Fixpoint.Types.Solutions (CMap, Solution)
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import qualified Language.Fixpoint.Misc          as Misc
 import qualified Language.Fixpoint.Smt.Interface as SMT
@@ -45,6 +45,7 @@ import           Language.Fixpoint.Graph.Deps             (isTarget)
 import           Language.Fixpoint.Solver.Common          (askSMT, toSMT)
 import           Language.Fixpoint.Solver.Sanitize        (symbolEnv)
 import           Language.Fixpoint.Solver.Simplify
+import           Language.Fixpoint.Solver.Solution (CombinedEnv(..), applyInSortedReft)
 import           Language.Fixpoint.Solver.Rewrite as Rewrite
 
 import Language.REST.OCAlgebra as OC
@@ -54,6 +55,7 @@ import Language.REST.SMT (withZ3, SolverHandle)
 
 import           Control.Exception.Base (bracket)
 import           Control.Monad (filterM, foldM, forM_, when, replicateM)
+import           Control.Monad.Reader (runReader)
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
 import           Data.Bifunctor (second)
@@ -78,8 +80,8 @@ mytracepp = notracepp
 -- unfoldings discovered by PLE on the constraints in @subcIds@ (or all
 -- constraints if @subcIds == Nothing@).
 {-# SCC instantiate #-}
-instantiate :: (Loc a) => Config -> SInfo a -> Maybe [SubcId] -> IO (BindEnv a)
-instantiate cfg fi' subcIds = do
+instantiate :: (Loc a) => Config -> SInfo a -> Maybe Solution -> Maybe [SubcId] -> IO (BindEnv a)
+instantiate cfg fi' mSol subcIds = do
     let cs = M.filterWithKey
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
                (cm info)
@@ -87,7 +89,7 @@ instantiate cfg fi' subcIds = do
     res   <- withRESTSolver $ \solver ->
                withProgress (1 + M.size cs) $
                withCtx cfg file sEnv (defns fi') $
-               do env <- instEnv cfg info cs solver
+               do env <- instEnv cfg info mSol cs solver
                   pleTrie t env                                             -- 2. TRAVERSE Trie to compute InstRes
     liftIO $ savePLEEqualities cfg info sEnv res
     return $ resSInfo cfg sEnv info res                                     -- 3. STRENGTHEN SInfo using InstRes
@@ -128,8 +130,15 @@ savePLEEqualities cfg info sEnv res = when (save cfg) $ do
 
 -------------------------------------------------------------------------------
 -- | Step 1a: @instEnv@ sets up the incremental-PLE environment
-instEnv :: (Loc a) => Config -> SInfo a -> CMap (SimpC a) -> Maybe SolverHandle -> SmtM (InstEnv a)
-instEnv cfg info cs restSolver = do
+instEnv
+  :: Loc a
+  => Config
+  -> SInfo a
+  -> Maybe Solution
+  -> CMap (SimpC a)
+  -> Maybe SolverHandle
+  -> SmtM (InstEnv a)
+instEnv cfg info s cs restSolver = do
     ctx <- get
     refRESTCache <- liftIO $ newIORef mempty
     refRESTSatCache <- liftIO $ newIORef mempty
@@ -171,6 +180,7 @@ instEnv cfg info cs restSolver = do
        , ieKnowl = knowledge cfg info
        , ieEvEnv = s0
        , ieLRWs  = lrws info
+       , ieSol  = s
        }
   where
     ef = solverFlags $ solver cfg
@@ -219,7 +229,7 @@ mkCTrie ics  = T.fromList [ (cBinds c, i) | (i, c) <- ics ]
 
 ----------------------------------------------------------------------------------------------
 -- | Step 2: @pleTrie@ walks over the @CTrie@ to actually do the incremental-PLE
-pleTrie :: CTrie -> InstEnv a -> SmtM InstRes
+pleTrie :: Loc a => CTrie -> InstEnv a -> SmtM InstRes
 pleTrie t env = loopT env ctx0 diff0 Nothing res0 t
   where
     diff0        = []
@@ -232,13 +242,15 @@ pleTrie t env = loopT env ctx0 diff0 Nothing res0 t
       , icSubcId             = Nothing
       , icANFs               = []
       , icLRWs               = mempty
+      , icBindIds            = mempty
       , icEtaBetaFlag        = etabeta        $ ieCfg env
       , icExtensionalityFlag = extensionality $ ieCfg env
       , icLocalRewritesFlag  = localRewrites  $ ieCfg env
       }
 
 loopT
-  :: InstEnv a
+  :: Loc a
+  => InstEnv a
   -> ICtx
   -> Diff         -- ^ The longest path suffix without forks in reverse order
   -> Maybe BindId -- ^ bind id of the branch ancestor of the trie if any.
@@ -249,12 +261,13 @@ loopT
 loopT env ictx delta i res t = case t of
   T.Node []  -> return res
   T.Node [b] -> loopB env ictx delta i res b
-  T.Node bs  -> withAssms env ictx delta Nothing $ \ictx' -> do
+  T.Node bs  -> withAssms env ictx delta Nothing (Just t) $ \ictx' -> do
                   (ictx'', env'', res') <- ple1 env ictx' i res
                   foldM (loopB env'' ictx'' [] i) res' bs
 
 loopB
-  :: InstEnv a
+  :: Loc a
+  => InstEnv a
   -> ICtx
   -> Diff         -- ^ The longest path suffix without forks in reverse order
   -> Maybe BindId -- ^ bind id of the branch ancestor of the branch if any.
@@ -264,9 +277,16 @@ loopB
   -> SmtM InstRes
 loopB env ictx delta iMb res b = case b of
   T.Bind i t -> loopT env ictx (i:delta) (Just i) res t
-  T.Val cid  -> withAssms env ictx delta (Just cid) $ \ictx' -> do
+  T.Val cid  -> withAssms env ictx delta (Just cid) Nothing $ \ictx' -> do
                   liftIO progressTick
                   (\(_, _, r) -> r) <$> ple1 env ictx' iMb res
+
+collectConstraints :: CTrie -> [SubcId]
+collectConstraints = go
+  where
+    go (T.Node bs) = concatMap goB bs
+    goB (T.Bind _ t) = go t
+    goB (T.Val cid)  = [cid]
 
 -- | Adds to @ctx@ candidate expressions to unfold from the bindings in @delta@
 -- and the rhs of @cidMb@.
@@ -278,10 +298,18 @@ loopB env ictx delta iMb res b = case b of
 -- Pushes assumptions from the modified context to the SMT solver, runs @act@,
 -- and then pops the assumptions.
 --
-withAssms :: InstEnv a -> ICtx -> Diff -> Maybe SubcId -> (ICtx -> SmtM b) -> SmtM b
-withAssms env ctx delta cidMb act = do
+withAssms
+  :: Loc a
+  => InstEnv a
+  -> ICtx
+  -> Diff
+  -> Maybe SubcId
+  -> Maybe CTrie
+  -> (ICtx -> SmtM b)
+  -> SmtM b
+withAssms env ctx delta cidMb mCTrie act = do
   sctx <- get
-  let ictx' = updCtx env sctx ctx delta cidMb
+  let ictx' = updCtx env sctx ctx delta cidMb mCTrie
   let assms = icAssms ictx'
 
   SMT.smtBracket "PLE.withAssms" $ do
@@ -382,6 +410,7 @@ data InstEnv a = InstEnv
   , ieKnowl :: !Knowledge
   , ieEvEnv :: !EvalEnv
   , ieLRWs  :: LocalRewritesEnv
+  , ieSol :: Maybe Solution
   }
 
 ----------------------------------------------------------------------------------------------
@@ -396,6 +425,7 @@ data ICtx    = ICtx
   , icSubcId             :: Maybe SubcId             -- ^ Current subconstraint ID
   , icANFs               :: [[(Symbol, SortedReft)]] -- Hopefully contain only ANF things
   , icLRWs               :: LocalRewrites            -- ^ Local rewrites
+  , icBindIds            :: IBindEnv                 -- ^ Bind Ids in the current context
   , icEtaBetaFlag        :: Bool                     -- ^ True if the etabeta flag is turned on, needed
                                                      -- for the eta expansion reasoning as its going to
                                                      -- generate ho constraints
@@ -436,16 +466,26 @@ updRes res  Nothing _ = res
 --   to the context.
 ----------------------------------------------------------------------------------------------
 
-updCtx :: InstEnv a -> SMT.Context -> ICtx -> Diff -> Maybe SubcId -> ICtx
-updCtx InstEnv{..} ieSMT ictx delta cidMb =
+updCtx
+  :: Loc a
+  => InstEnv a
+  -> SMT.Context
+  -> ICtx
+  -> Diff
+  -> Maybe SubcId
+  -> Maybe CTrie
+  -> ICtx
+updCtx InstEnv{..} ieSMT ictx delta cidMb mCTrie =
   ictx { icAssms  = S.fromList (filter (not . isTautoPred) ctxEqs)
        , icCands  = S.fromList deANFedCands <> icCands ictx
        , icSimpl  = icSimpl ictx <> econsts
        , icSubcId = cidMb
        , icANFs   = anfBinds
        , icLRWs   = mconcat $ icLRWs ictx : newLRWs
+       , icBindIds = ibinds
        }
   where
+    ibinds = insertsIBindEnv delta (icBindIds ictx)
     cands     = rhs:es
     anfBinds  = bs : icANFs ictx
     econsts   = M.fromList $ findConstants ieKnowl es
@@ -455,7 +495,11 @@ updCtx InstEnv{..} ieSMT ictx delta cidMb =
     rhs       = unApply eRhs
     es        = expr <$> bs
     eRhs      = maybe PTrue crhs subMb
-    binds     = [ (x, y) | i <- delta, let (x, y, _) = lookupBindEnv i ieBEnv]
+
+    binds     = [ maybeApplyKVarSolutions (x, y)
+                | i <- delta
+                , let (x, y, _) = lookupBindEnv i ieBEnv
+                ]
     subMb     = getCstr ieCstrs <$> cidMb
     newLRWs   = Mb.mapMaybe (`lookupLocalRewrites` ieLRWs) delta
 
@@ -467,6 +511,22 @@ updCtx InstEnv{..} ieSMT ictx delta cidMb =
         deANF anfBinds cands
       else
         cands
+
+    maybeApplyKVarSolutions xsr =
+      case ieSol of
+        Just sol -> runReader (applyInSortedReft g sol xsr) (SMT.ctxElabF ieSMT)
+        Nothing  -> xsr
+      where
+        gCid = case collectConstraints <$> mCTrie of
+          Just (c:_) -> Just c
+          _ -> Nothing
+        g = CEnv
+          { ceCid = gCid
+          , ceBEnv = ieBEnv
+          , ceIEnv = ibinds
+          , ceSpan = maybe dummySpan srcSpan $ gCid >>= (`M.lookup` ieCstrs)
+          , ceBindingsInSmt = emptyIBindEnv
+          }
 
 
 findConstants :: Knowledge -> [Expr] -> [(Expr, Expr)]

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -296,19 +296,17 @@ apply g s bs      =
   -- Clear the "known" bindings for applyKVars, since it depends on
   -- using the fully expanded representation of the predicates to bind their
   -- variables with quantifiers.
-  do (ps,  ks) <- envConcKVars g s bs
+  do xrs <- traverse (lookupBindEnvExt g s) (F.elemsIBindEnv bs)
+     let (ps,  ks) = envConcKVars xrs
      (pks, kI) <- applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
      pure (F.conj (pks:ps), kI)   -- see [NOTE: pAnd-SLOW]
 
 -- | Produces conjuncts of each sorted reft in the IBindEnv, separated
 -- into concrete conjuncts and kvars.
-envConcKVars :: CombinedEnv ann -> Sol.Sol Sol.QBind -> F.IBindEnv -> ElabM ([F.Expr], [F.KVSub])
-envConcKVars g s bs =
-  do xrs <- traverse (lookupBindEnvExt g s) is
-     let (pss, kss) = unzip [ F.sortedReftConcKVars x sr | (x, sr) <- xrs ]
-     pure (concat pss, concat kss)
-  where
-    is = F.elemsIBindEnv bs
+envConcKVars :: [(F.Symbol, F.SortedReft)] -> ([F.Expr], [F.KVSub])
+envConcKVars xrs =
+  let (pss, kss) = unzip [ F.sortedReftConcKVars x sr | (x, sr) <- xrs ]
+   in (concat pss, concat kss)
 
 lookupBindEnvExt :: CombinedEnv ann -> Sol.Sol Sol.QBind -> F.BindId -> ElabM (F.Symbol, F.SortedReft)
 lookupBindEnvExt g s i =

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -305,6 +305,11 @@ apply g s bs      =
      (pks, kI) <- applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
      pure (F.conj (pks:ps), kI)   -- see [NOTE: pAnd-SLOW]
 
+-- | @applyInSortedReft@ applies the solution to a single sorted reft
+--
+-- At the time of writing this function is used in PLE, where we need the
+-- expression in unelaborated form. Thus the result is not elaborated here.
+--
 applyInSortedReft
   :: CombinedEnv ann
   -> Sol.Sol Sol.QBind
@@ -313,7 +318,7 @@ applyInSortedReft
 applyInSortedReft g s xsr@(x, sr) =
   do let (ps,  ks) = envConcKVars [xsr]
      (pks, _) <- applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
-     pure (x, sr { F.sr_reft = F.Reft (x, F.conj (pks:ps)) })
+     pure (x, sr { F.sr_reft = F.Reft (x, F.conj (So.unElab pks : ps)) })
 
 -- | Produces conjuncts of each sorted reft in the IBindEnv, separated
 -- into concrete conjuncts and kvars.

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -10,6 +10,10 @@ module Language.Fixpoint.Solver.Solution
     -- * Update Solution
   , Sol.update
 
+    -- * Apply Solution
+  , applyInSortedReft
+  , CombinedEnv(..)
+
     -- * Lookup Solution
   , lhsPred
 
@@ -300,6 +304,16 @@ apply g s bs      =
      let (ps,  ks) = envConcKVars xrs
      (pks, kI) <- applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
      pure (F.conj (pks:ps), kI)   -- see [NOTE: pAnd-SLOW]
+
+applyInSortedReft
+  :: CombinedEnv ann
+  -> Sol.Sol Sol.QBind
+  -> (F.Symbol, F.SortedReft)
+  -> ElabM (F.Symbol, F.SortedReft)
+applyInSortedReft g s xsr@(x, sr) =
+  do let (ps,  ks) = envConcKVars [xsr]
+     (pks, _) <- applyKVars g {ceBindingsInSmt = F.emptyIBindEnv} s ks
+     pure (x, sr { F.sr_reft = F.Reft (x, F.conj (pks:ps)) })
 
 -- | Produces conjuncts of each sorted reft in the IBindEnv, separated
 -- into concrete conjuncts and kvars.

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -108,10 +108,6 @@ siKvars = S.fromList . M.keys . F.ws
 doInterpret :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a (F.BindEnv a)
 doInterpret cfg fi subcIds = liftIO $ instInterpreter cfg fi (Just subcIds)
 
-{-# SCC doPLE #-}
-doPLE :: (F.Loc a) =>  Config -> F.SInfo a -> [F.SubcId] -> SolveM a (F.BindEnv a)
-doPLE cfg fi0 subcIds = liftIO $ PLE.instantiate cfg fi0 (Just subcIds)
-
 --------------------------------------------------------------------------------
 {-# SCC solve_ #-}
 solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
@@ -145,7 +141,7 @@ solve_ cfg fi s2 wkl = do
 
   res2  <- case resStatus res1 of  {- then run normal PLE on remaining unsolved constraints -}
     Unsafe _ bads2 | not (noLazyPLE cfg) && rewriteAxioms cfg -> do
-      bs <- doPLE cfg fi1 (map fst $ mytrace ("before PLE " ++ show (length bads2) ++ " constraints remain") bads2)
+      bs <- liftIO $ PLE.instantiate cfg fi1 (Just s3) (Just $ map fst bads2)
       -- TODO reset the ix stack too?
       clearApplys
       -- Check the constraints one last time after PLE

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -76,7 +76,7 @@ import           Control.Exception (Exception, catch, try, throwIO)
 import           Control.Monad
 import           Control.Monad.Reader
 
-import           Data.Bifunctor (first)
+import           Data.Bifunctor (first, second)
 import qualified Data.IntMap.Strict       as M
 import qualified Data.HashSet              as S
 import           Data.IORef
@@ -972,6 +972,7 @@ unApply = Vis.mapExprOnExpr go
     go (ECst (EApp (EApp f e1) e2) _)
       | Just _ <- unApplyAt f = EApp e1 e2
     go (ELam (x,s) e)         = ELam (x, Vis.mapSort go' s) e
+    go (PExist bs e)          = PExist (map (second (Vis.mapSort go')) bs) e
     go e                      = e
 
     go' (FApp (FApp fs t1) t2) | fs == funcSort

--- a/tests/tasty/SimplifyPLE.hs
+++ b/tests/tasty/SimplifyPLE.hs
@@ -40,5 +40,6 @@ simplify' = PLE.simplify emptyKnowledge emptyICtx
           icLRWs = mempty,
           icEtaBetaFlag        = False,
           icExtensionalityFlag = False,
-          icLocalRewritesFlag  = False
+          icLocalRewritesFlag  = False,
+          icBindIds = mempty
         }


### PR DESCRIPTION
This addresses the bug reported in https://github.com/ucsd-progsys/liquidhaskell/issues/2582

As discussed in #780, it is not the best we can do, because we are not looking for unfoldings in kvar solutions, but it is still an improvement.