### PR TITLE
Provide stack traces for more crashes

### DIFF
--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -56,6 +56,7 @@ flag devel
 library
   import: warnings
   exposed-modules:  Data.ShareMap
+                    Control.Exception.Compat
                     Language.Fixpoint.Conditional.Z3
                     Language.Fixpoint.Defunctionalize
                     Language.Fixpoint.Graph

--- a/src/Control/Exception/Compat.hs
+++ b/src/Control/Exception/Compat.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+module Control.Exception.Compat
+  ( ExceptionWithContext(..)
+  , displayExceptionContext
+  , wrapExceptionWithContext
+  ) where
+
+#if MIN_VERSION_base(4,20,0)
+
+import Control.Exception (ExceptionWithContext(..))
+import Control.Exception.Context (displayExceptionContext)
+
+wrapExceptionWithContext :: ExceptionWithContext a -> ExceptionWithContext a
+wrapExceptionWithContext = id
+
+#else
+
+data ExceptionWithContext a = ExceptionWithContext ExceptionContext a
+
+data ExceptionContext = ExceptionContext
+
+displayExceptionContext :: ExceptionContext -> String
+displayExceptionContext _ = "Exception context not available in this version of ghc."
+
+wrapExceptionWithContext :: a -> ExceptionWithContext a
+wrapExceptionWithContext = ExceptionWithContext ExceptionContext
+#endif
+

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -35,6 +35,8 @@ import           System.Exit                        (ExitCode (..))
 import           System.Console.CmdArgs.Verbosity   (whenNormal, whenLoud)
 import           Control.Monad                      (mplus, when)
 import           Control.Exception                  (catch)
+import           Control.Exception.Compat
+    (ExceptionWithContext(..), displayExceptionContext, wrapExceptionWithContext)
 import           Language.Fixpoint.Solver.EnvironmentReduction
   (reduceEnvironments, simplifyBindings)
 import           Language.Fixpoint.Solver.Sanitize  (symbolEnv, sanitize)
@@ -184,22 +186,18 @@ solveNative, solveNative' :: (NFData a, Fixpoint a, Show a, Loc a, PPrint a) => 
 --------------------------------------------------------------------------------
 solveNative !cfg !fi0 = solveNative' cfg fi0
                           `catch`
-                             (return . crashResult (errorMap fi0))
+                             (return . crashResult (errorMap fi0). wrapExceptionWithContext)
 
-crashResult :: (PPrint a) => ErrorMap a -> Error -> Result (Integer, a)
-crashResult m err' = Result res mempty mempty mempty
+crashResult :: (PPrint a) => ErrorMap a -> ExceptionWithContext Error -> Result (Integer, a)
+crashResult m (ExceptionWithContext ectx ex) = Result res mempty mempty mempty
   where
-    res           = Crash es msg
-    es            = catMaybes [ findError m e | e <- ers ]
-    ers           = errs err'
-    msg | null ers = "Sorry, unexpected panic in liquid-fixpoint!"
-        --  {-dbgFalse-} True  = "Sorry, unexpected panic in liquid-fixpoint!\n" ++ crashMessage es
-        | otherwise = showpp err'
-
-_crashMessage :: [((Integer, a), Maybe String) ] -> String
-_crashMessage es = L.intercalate "\n" [ msg i s | ((i,_), Just s) <- es ]
-  where
-    msg i s = "Error in constraint " ++ show i ++ ":\n" ++ s
+    res = Crash es msg
+    es  = catMaybes [ findError m e | e <- ers ]
+    ers = errs ex
+    msg = displayExceptionContext ectx ++ "\n" ++ msg0
+    msg0 | null ers = "Sorry, unexpected panic in liquid-fixpoint!\n"
+                       ++ showpp ex
+         | otherwise = showpp ex
 
 -- | Unpleasant hack to save meta-data that can be recovered from SrcSpan
 type ErrorMap a = HashMap.HashMap SrcSpan a

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -33,6 +33,7 @@ import qualified Data.List                                         as L
 import qualified Data.Text                                         as T
 import           Data.Maybe          (isNothing, mapMaybe, fromMaybe)
 import           Control.Monad       ((>=>))
+import           GHC.Stack           (HasCallStack)
 import           Text.PrettyPrint.HughesPJ hiding ((<>))
 import qualified Language.Fixpoint.SortCheck as SortCheck
 
@@ -356,7 +357,7 @@ badRhs1 (i, c) = E.err E.dummySpan $ vcat [ "Malformed RHS for constraint id" <+
 --   function definitions inside the `AxiomEnv` which cannot be elaborated as
 --   it makes it hard to actually find the fundefs within (breaking PLE.)
 --------------------------------------------------------------------------------
-symbolEnv :: Config -> F.SInfo a -> F.SymEnv
+symbolEnv :: HasCallStack => Config -> F.SInfo a -> F.SymEnv
 symbolEnv cfg si = F.symEnv sEnv thyEnv ds lits (ts ++ ts')
   where
     ts'          = applySorts ae'
@@ -375,7 +376,7 @@ symbolEnv cfg si = F.symEnv sEnv thyEnv ds lits (ts ++ ts')
 litsAEnv :: F.AxiomEnv -> [(F.Symbol, F.Sort)]
 litsAEnv ae = zip (F.symbol <$> symConsts ae) (repeat F.strSort)
 
-symbolSorts :: Config -> F.GInfo c a -> [(F.Symbol, F.Sort)]
+symbolSorts :: HasCallStack => Config -> F.GInfo c a -> [(F.Symbol, F.Sort)]
 symbolSorts cfg fi = either E.die id $ symbolSorts' cfg fi
 
 symbolSorts' :: Config -> F.GInfo c a -> SanitizeM [(F.Symbol, F.Sort)]

--- a/src/Language/Fixpoint/Types/Errors.hs
+++ b/src/Language/Fixpoint/Types/Errors.hs
@@ -62,6 +62,7 @@ import           Control.DeepSeq
 -- import           Data.Hashable
 import qualified Data.Store                   as S
 import           GHC.Generics                  (Generic)
+import           GHC.Stack                     (HasCallStack)
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Misc
@@ -145,7 +146,7 @@ panicMsg :: String
 panicMsg = "PANIC: Please file an issue at https://github.com/ucsd-progsys/liquid-fixpoint \n"
 
 ---------------------------------------------------------------------
-die :: Error -> a
+die :: HasCallStack => Error -> a
 ---------------------------------------------------------------------
 die = throw
 


### PR DESCRIPTION
With this PR, crashes now start with a partial stack trace

```
**** LIQUID: ERROR *************************************************************
<no location info>: error:
    HasCallStack backtrace:                 
  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in ghc-internal:GHC.Internal.Exception
  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:89:42 in ghc-internal:GHC.Internal.Exception
  throw, called at src/Language/Fixpoint/Types/Errors.hs:151:7 in liquid-fixpoint-0.9.6.3.3-inplace:Language.Fixpoint.Types.Errors
  die, called at src/Language/Fixpoint/Solver/Sanitize.hs:380:29 in liquid-fixpoint-0.9.6.3.3-inplace:Language.Fixpoint.Solver.Sanitize
  symbolSorts, called at src/Language/Fixpoint/Solver/Sanitize.hs:372:20 in liquid-fixpoint-0.9.6.3.3-inplace:Language.Fixpoint.Solver.Sanitize
  symbolEnv, called at src/Language/Fixpoint/Solver/Eliminate.hs:47:22 in liquid-fixpoint-0.9.6.3.3-inplace:Language.Fixpoint.Solver.Eliminate
                                                 
:1:1-1:1: Error                             
...
```