### PR TITLE
Simplify the solver further

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -366,7 +366,7 @@ simplifyKVar = go
     go (PAnd es) = PAnd $ map go es
     go (PExist bs0 (PExist bs1 p)) =
       let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
-       in PExist (bs0' ++ bs1) p
+       in go (PExist (bs0' ++ bs1) p)
     go (PExist bs e0) =
       let es = map go (conjuncts e0)
           esv = map (isVarEq (map fst bs)) es

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -362,8 +362,8 @@ simplifyResult cfg res =
 simplifyKVar :: Expr -> Expr
 simplifyKVar = go
   where
-    go (POr es) = POr $ map go es
-    go (PAnd es) = PAnd $ map go es
+    go (POr es) = pOr $ map go es
+    go (PAnd es) = pAnd $ map go es
     go (PExist bs0 (PExist bs1 p)) =
       let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
        in go (PExist (bs0' ++ bs1) p)

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -22,6 +22,7 @@ module Language.Fixpoint.Solver.Solution
 import           Control.Arrow (second, (***))
 import           Control.Monad                  (guard)
 import           Control.Monad.Reader
+import           Data.Either                    (partitionEithers)
 import qualified Data.HashSet                   as S
 import qualified Data.HashMap.Strict            as M
 import           Data.Maybe                     (maybeToList, isJust, isNothing)
@@ -412,53 +413,53 @@ cubePred g s ksu c    =
 cubePredExc :: CombinedEnv ann -> Sol.Sol Sol.QBind -> Sol.Cube -> F.IBindEnv
             -> (F.Pred, KInfo)
 cubePredExc g s c bs' =
-    let (_  , psu') = substElim g' su'
+    let (psu', su'@(F.Su m)) = substElim (map fst yts) su
         (p', kI) = apply g' s bs'
-        cubeE = F.pExist yts' (F.pAndNoDedup [p', psu'])
-     in (cubeE, extendKInfo kI (Sol.cuTag c))
+        p'' = F.rapierSubstExpr (F.substSymbolsSet su') su'
+                (F.pAndNoDedup [p', psu'])
+     in (F.pExist (filter (not . (`M.member` m) . fst) yts) p'', extendKInfo kI (Sol.cuTag c))
   where
-    yts'            = symSorts g bs'
-    g'              = addCEnv  g bs
-    su'             = Sol.cuSubst c
-    bs              = Sol.cuBinds c
+    yts = symSorts g bs'
+    g' = addCEnv  g bs
+    su = dropUnsortedExprs g' (Sol.cuSubst c)
+    bs = Sol.cuBinds c
 
--- TODO: SUPER SLOW! Decorate all substitutions with Sorts in a SINGLE pass.
 
-{- | @substElim@ returns the binders that must be existentially quantified,
-     and the equality predicate relating the kvar-"parameters" and their
-     actual values. i.e. given
+{- | @substElim@ returns the equalities that a substitution implies, and a
+     substitution that can be applied without losing information.
 
-        K[x1 := e1]...[xn := en]
+     e.g.
+       exists u v. K=e && K[x1:=u][x2:=p v]
 
-     where e1 ... en have types t1 ... tn
-     we want to quantify out
+     is equivalent to
 
-       x1:t1 ... xn:tn
+     > exists u v x1 x2. K=e && e && x1 = u && x2 = p v
 
-     and generate the equality predicate && [x1 ~~ e1, ... , xn ~~ en]
-     we use ~~ because the param and value may have different sorts, see:
+     which we can compress to
 
-        tests/pos/kvar-param-poly-00.hs
+     > exists v x1 x2. K=e && e[u:=x1] && x2 = p v
 
-     Finally, we filter out binders if they are
+     More generally,
 
-     1. "free" in e1...en i.e. in the outer environment.
-        (Hmm, that shouldn't happen...?)
+     @substElim [v1..vm] [x1:=e1;..;xn:=en]@ computes @(p, su)@ 
+     such that
 
-     2. are binders corresponding to sorts (e.g. `a : num`, currently used
-        to hack typeclasses current.)
+     > exists v1..vm. K=e && x1 = e1 && ... && xn = en
+
+     is equivalent to
+
+     > exists w1..wk. K=e && e[su] && p
+
+     where @w1..wk@ is a subset of @v1..vm@, and @p@ contains a subset
+     of the equalities in @x1 = e1 && ... && xn = en@.
  -}
-substElim :: CombinedEnv a -> F.Subst -> ([(F.Symbol, F.Sort)], F.Pred)
-substElim g (F.Su m) =
-    (xts, F.pAnd [ F.EEq (F.expr x) e | (x, e, _) <- xets ])
+substElim :: [F.Symbol] -> F.Subst -> (F.Pred, F.Subst)
+substElim exBinds (F.Su m) =
+    (F.pAnd [ F.EEq (F.expr x) e | (x, e) <- xesNV ], F.mkSubst xesV)
   where
-    xts    = [ (x, t)    | (x, _, t) <- xets, not (S.member x frees) ]
-    xets   = [ (x, e, t) | (x, e)    <- xes, t <- sortOf e, not (isClass t)]
-    frees  = S.fromList (concatMap (F.syms . snd) xes)
-    sortOf = maybeToList . So.checkSortExpr sp env
-    sp     = ceSpan g
-    xes    = M.toList m
-    env    = combinedSEnv g
+    (xesNV, xesV) = partitionEithers $ map eitherEBind $ M.toList m
+    eitherEBind (x, F.EVar v) | elem v exBinds = Right (v, F.expr x)
+    eitherEBind (x, e) = Left (x, e)
 
 isClass :: F.Sort -> Bool
 isClass F.FNum  = True

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -409,56 +409,30 @@ cubePred g s ksu c    =
     su = dropUnsortedExprs g (F.ksuSubst  ksu)
 
 -- | @cubePredExc@ computes the predicate for the subset of binders bs'.
+--
+-- Schematically, the result is
+--
+-- > Exists (bindsOf bs'). (pAnd (predicatesOf bs'))[Sol.cuSubst c]
+--
+-- but we also preserve the information about which variables are being
+-- substituted:
+--
+-- > Exists (bindsOf bs'). pAnd (predicatesOf bs') && x1=e1 && ... && xn=en
+--
+-- where @Sol.cuSubst c = [x1:=e1;...;xn:=en]@.
+--
 cubePredExc :: CombinedEnv ann -> Sol.Sol Sol.QBind -> Sol.Cube -> F.IBindEnv
             -> (F.Pred, KInfo)
 cubePredExc g s c bs' =
-    let (_  , psu') = substElim g' su'
+    let psu' = F.pAnd [ F.EEq (F.expr x) e | (x, e) <- M.toList m ]
         (p', kI) = apply g' s bs'
         cubeE = F.pExist yts' (F.pAndNoDedup [p', psu'])
      in (cubeE, extendKInfo kI (Sol.cuTag c))
   where
-    yts'            = symSorts g bs'
-    g'              = addCEnv  g bs
-    su'             = Sol.cuSubst c
-    bs              = Sol.cuBinds c
-
--- TODO: SUPER SLOW! Decorate all substitutions with Sorts in a SINGLE pass.
-
-{- | @substElim@ returns the binders that must be existentially quantified,
-     and the equality predicate relating the kvar-"parameters" and their
-     actual values. i.e. given
-
-        K[x1 := e1]...[xn := en]
-
-     where e1 ... en have types t1 ... tn
-     we want to quantify out
-
-       x1:t1 ... xn:tn
-
-     and generate the equality predicate && [x1 ~~ e1, ... , xn ~~ en]
-     we use ~~ because the param and value may have different sorts, see:
-
-        tests/pos/kvar-param-poly-00.hs
-
-     Finally, we filter out binders if they are
-
-     1. "free" in e1...en i.e. in the outer environment.
-        (Hmm, that shouldn't happen...?)
-
-     2. are binders corresponding to sorts (e.g. `a : num`, currently used
-        to hack typeclasses current.)
- -}
-substElim :: CombinedEnv a -> F.Subst -> ([(F.Symbol, F.Sort)], F.Pred)
-substElim g (F.Su m) =
-    (xts, F.pAnd [ F.EEq (F.expr x) e | (x, e, _) <- xets ])
-  where
-    xts    = [ (x, t)    | (x, _, t) <- xets, not (S.member x frees) ]
-    xets   = [ (x, e, t) | (x, e)    <- xes, t <- sortOf e, not (isClass t)]
-    frees  = S.fromList (concatMap (F.syms . snd) xes)
-    sortOf = maybeToList . So.checkSortExpr sp env
-    sp     = ceSpan g
-    xes    = M.toList m
-    env    = combinedSEnv g
+    yts' = symSorts g bs'
+    g' = addCEnv  g bs
+    F.Su m = dropUnsortedExprs g' (Sol.cuSubst c)
+    bs = Sol.cuBinds c
 
 isClass :: F.Sort -> Bool
 isClass F.FNum  = True

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -22,7 +22,6 @@ module Language.Fixpoint.Solver.Solution
 import           Control.Arrow (second, (***))
 import           Control.Monad                  (guard)
 import           Control.Monad.Reader
-import           Data.Either                    (partitionEithers)
 import qualified Data.HashSet                   as S
 import qualified Data.HashMap.Strict            as M
 import           Data.Maybe                     (maybeToList, isJust, isNothing)
@@ -413,53 +412,53 @@ cubePred g s ksu c    =
 cubePredExc :: CombinedEnv ann -> Sol.Sol Sol.QBind -> Sol.Cube -> F.IBindEnv
             -> (F.Pred, KInfo)
 cubePredExc g s c bs' =
-    let (psu', su'@(F.Su m)) = substElim (map fst yts) su
+    let (_  , psu') = substElim g' su'
         (p', kI) = apply g' s bs'
-        p'' = F.rapierSubstExpr (F.substSymbolsSet su') su'
-                (F.pAndNoDedup [p', psu'])
-     in (F.pExist (filter (not . (`M.member` m) . fst) yts) p'', extendKInfo kI (Sol.cuTag c))
+        cubeE = F.pExist yts' (F.pAndNoDedup [p', psu'])
+     in (cubeE, extendKInfo kI (Sol.cuTag c))
   where
-    yts = symSorts g bs'
-    g' = addCEnv  g bs
-    su = dropUnsortedExprs g' (Sol.cuSubst c)
-    bs = Sol.cuBinds c
+    yts'            = symSorts g bs'
+    g'              = addCEnv  g bs
+    su'             = Sol.cuSubst c
+    bs              = Sol.cuBinds c
 
+-- TODO: SUPER SLOW! Decorate all substitutions with Sorts in a SINGLE pass.
 
-{- | @substElim@ returns the equalities that a substitution implies, and a
-     substitution that can be applied without losing information.
+{- | @substElim@ returns the binders that must be existentially quantified,
+     and the equality predicate relating the kvar-"parameters" and their
+     actual values. i.e. given
 
-     e.g.
-       exists u v. K=e && K[x1:=u][x2:=p v]
+        K[x1 := e1]...[xn := en]
 
-     is equivalent to
+     where e1 ... en have types t1 ... tn
+     we want to quantify out
 
-     > exists u v x1 x2. K=e && e && x1 = u && x2 = p v
+       x1:t1 ... xn:tn
 
-     which we can compress to
+     and generate the equality predicate && [x1 ~~ e1, ... , xn ~~ en]
+     we use ~~ because the param and value may have different sorts, see:
 
-     > exists v x1 x2. K=e && e[u:=x1] && x2 = p v
+        tests/pos/kvar-param-poly-00.hs
 
-     More generally,
+     Finally, we filter out binders if they are
 
-     @substElim [v1..vm] [x1:=e1;..;xn:=en]@ computes @(p, su)@ 
-     such that
+     1. "free" in e1...en i.e. in the outer environment.
+        (Hmm, that shouldn't happen...?)
 
-     > exists v1..vm. K=e && x1 = e1 && ... && xn = en
-
-     is equivalent to
-
-     > exists w1..wk. K=e && e[su] && p
-
-     where @w1..wk@ is a subset of @v1..vm@, and @p@ contains a subset
-     of the equalities in @x1 = e1 && ... && xn = en@.
+     2. are binders corresponding to sorts (e.g. `a : num`, currently used
+        to hack typeclasses current.)
  -}
-substElim :: [F.Symbol] -> F.Subst -> (F.Pred, F.Subst)
-substElim exBinds (F.Su m) =
-    (F.pAnd [ F.EEq (F.expr x) e | (x, e) <- xesNV ], F.mkSubst xesV)
+substElim :: CombinedEnv a -> F.Subst -> ([(F.Symbol, F.Sort)], F.Pred)
+substElim g (F.Su m) =
+    (xts, F.pAnd [ F.EEq (F.expr x) e | (x, e, _) <- xets ])
   where
-    (xesNV, xesV) = partitionEithers $ map eitherEBind $ M.toList m
-    eitherEBind (x, F.EVar v) | elem v exBinds = Right (v, F.expr x)
-    eitherEBind (x, e) = Left (x, e)
+    xts    = [ (x, t)    | (x, _, t) <- xets, not (S.member x frees) ]
+    xets   = [ (x, e, t) | (x, e)    <- xes, t <- sortOf e, not (isClass t)]
+    frees  = S.fromList (concatMap (F.syms . snd) xes)
+    sortOf = maybeToList . So.checkSortExpr sp env
+    sp     = ceSpan g
+    xes    = M.toList m
+    env    = combinedSEnv g
 
 isClass :: F.Sort -> Bool
 isClass F.FNum  = True


### PR DESCRIPTION
This PR eliminates `substElim` replacing it with more obvious code.

There is an attempt to produce smaller kvar solutions as well, which I reverted, because the code was not too obvious, didn't win any speedup, and the user would still not see smaller kvars since the simplification routine for `.fqout` files obtains similar results.

But I'm keeping the attempt in the git history for the record.