### PR TITLE
KVar simplification with floating conjuncts and alpha equivalence

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -22,5 +22,5 @@ jobs:
     - uses: haskell-actions/hlint-run@v2
       name: hlint
       with:
-        path: '["src/", "tests/", "unix/", "win/"]'
+        path: '["src/", "unix/", "win/"]'
         fail-on: suggestion

--- a/liquid-fixpoint.cabal
+++ b/liquid-fixpoint.cabal
@@ -234,10 +234,15 @@ test-suite tasty
                     ShareMapReference
                     ShareMapTests
                     SimplifyInterpreter
+                    SimplifyKVarTests
                     SimplifyPLE
                     SimplifyTests
                     UndoANFTests
                     Paths_liquid_fixpoint
+  if impl(ghc>=9.12.1)
+    hs-source-dirs: tests/tasty/ghc-9.12.1
+  else
+    hs-source-dirs: tests/tasty/ghc-before-9.12.1
   autogen-modules:  Paths_liquid_fixpoint
   hs-source-dirs:   tests/tasty
   ghc-options:      -threaded

--- a/src/Language/Fixpoint/Graph/Types.hs
+++ b/src/Language/Fixpoint/Graph/Types.hs
@@ -66,13 +66,11 @@ import GHC.Stack
 
 data CVertex = KVar  !KVar    -- ^ real kvar vertex
              | DKVar !KVar    -- ^ dummy to ensure each kvar has a successor
-             | EBind !F.Symbol  -- ^ existentially bound "ghost paramter" to solve for
              | Cstr  !Integer -- ^ constraint-id which creates a dependency
                deriving (Eq, Ord, Show, Generic)
 
 instance PPrint CVertex where
   pprintTidy _ (KVar k)  = doubleQuotes $ pprint $ kv k
-  pprintTidy _ (EBind s)  = doubleQuotes $ pprint s
   pprintTidy _ (Cstr i)  = text "id_" <-> pprint i
   pprintTidy _ (DKVar k) = pprint k   <-> text "*"
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1127,13 +1127,12 @@ predP  = pred0P
 
 existP :: ParseableV v => ParserV v (ExprV v)
 existP = do
-    allow <- allowExists <$> get
+    allow <- gets allowExists
     if allow then do
       reserved "exists"
       bs <- brackets $ sepBy ((,) <$> bindP <*> sortP) comma
       _ <- dot
-      p <- predP
-      return (PExist bs p)
+      PExist bs <$> exprP
      else
       empty
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -91,6 +91,7 @@ module Language.Fixpoint.Parse (
 
   -- * Parsing Function
   , doParse'
+  , doParse''
   , parseTest'
   , parseFromFile
   , parseFromStdIn
@@ -228,6 +229,7 @@ data PStateV v = PState { fixityTable :: OpTable v
                      , supply      :: !Integer
                      , layoutStack :: LayoutStack
                      , numTyCons   :: !(S.HashSet Symbol)
+                     , allowExists :: !Bool
                      }
 type PState = PStateV Symbol
 
@@ -791,7 +793,7 @@ expr0P =
         botP
     <|> try (reserved "not") *> fmap PNot appliableExprP -- built-in prefix not
     <|> funAppP
-    <|> appliableExprP
+    <|> existP
     <|> fastIfP EIte exprP -- "if-then-else", starts with "if"
     <|> try (coerceP exprP) -- coercion, starts with "coerce"
     <|> litP
@@ -968,9 +970,6 @@ bops cmpFun = List.foldl' (flip addOperator) initOpTable builtinOps
     applyCompose = (\f lop x y -> f lop `eApps` [x,y]) <$> cmpFun
 
 -- | Parser for function applications.
---
--- Andres, TODO: Why is this so complicated?
---
 funAppP :: ParseableV v => ParserV v (ExprV v)
 funAppP = do
     f <- appliableExprP
@@ -1125,6 +1124,18 @@ predsP = brackets $ sepBy predP semi
 --
 predP  :: ParseableV v => ParserV v (ExprV v)
 predP  = pred0P
+
+existP :: ParseableV v => ParserV v (ExprV v)
+existP = do
+    allow <- allowExists <$> get
+    if allow then do
+      reserved "exists"
+      bs <- brackets $ sepBy ((,) <$> bindP <*> sortP) comma
+      _ <- dot
+      p <- predP
+      return (PExist bs p)
+     else
+      empty
 
 --------------------------------------------------------------------------------
 -- | BareTypes -----------------------------------------------------------------
@@ -1474,6 +1485,7 @@ initPState cmpFun = PState { fixityTable = bops cmpFun
                            , supply      = 0
                            , layoutStack = Empty
                            , numTyCons   = S.empty
+                           , allowExists = False
                            }
 
 -- | Entry point for parsing, for testing.
@@ -1482,8 +1494,11 @@ initPState cmpFun = PState { fixityTable = bops cmpFun
 -- Fails with an exception on a parse error.
 --
 doParse' :: Parser a -> SourceName -> String -> a
-doParse' parser fileName input =
-  case runParser (evalStateT (spaces *> parser <* eof) (initPState Nothing)) fileName input of
+doParse' = doParse'' False
+
+doParse'' :: Bool -> Parser a -> SourceName -> String -> a
+doParse'' allowEx parser fileName input =
+  case runParser (evalStateT (spaces *> parser <* eof) ((initPState Nothing) { allowExists = allowEx})) fileName input of
     Left peb@(ParseErrorBundle errors posState) -> -- parse errors; we extract the first error from the error bundle
       let
         ((_, pos) :| _, _) = attachSourcePos errorOffset errors posState

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -420,9 +420,9 @@ alphaEq = go (mkSubst [])
       let su' = List.foldl' (\s (v1, v2) -> extendSubst s v1 (EVar v2)) su (zip (map fst bs1) (map fst bs2))
        in go su' x1 x2
     go su (PAnd es1) (PAnd es2) =
-      length es1 == length es2 && all (\(e1, e2) -> go su e1 e2) (zip es1 es2)
+      length es1 == length es2 && and (zipWith (go su) es1 es2)
     go su (POr es1) (POr es2) =
-      length es1 == length es2 && all (\(e1, e2) -> go su e1 e2) (zip es1 es2)
+      length es1 == length es2 && and (zipWith (go su) es1 es2)
     go su e1 e2 =
       subst su e1 == e2
 

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -28,6 +28,7 @@ module Language.Fixpoint.Solver (
 import           Control.Concurrent                 (setNumCapabilities)
 import qualified Data.HashMap.Strict              as HashMap
 import qualified Data.HashSet                     as S
+import qualified Data.List                        as List
 import qualified Data.Store                       as S
 import           Data.Aeson                         (ToJSON, encode)
 import qualified Data.Text.Lazy.IO                as LT
@@ -360,15 +361,15 @@ simplifyResult cfg res =
 -- > "exists y. (P && Q y)[x:=C]"
 --
 simplifyKVar :: Expr -> Expr
-simplifyKVar = go
+simplifyKVar = pAnd . dedupByAlphaEq . floatPExistConjuncts . go
   where
-    go (POr es) = pOr $ map go es
-    go (PAnd es) = pAnd $ map go es
+    go (POr es) = pOr $ map (pAnd . floatPExistConjuncts . go) es
+    go (PAnd es) = pAnd $ dedupByAlphaEq $ concatMap (floatPExistConjuncts . go) es
     go (PExist bs0 (PExist bs1 p)) =
       let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
        in go (PExist (bs0' ++ bs1) p)
     go (PExist bs e0) =
-      let es = map go (conjuncts e0)
+      let es = concatMap (floatPExistConjuncts . go) (conjuncts e0)
           esv = map (isVarEq (map fst bs)) es
           -- Eliminating multiple variables at once can be difficult if the
           -- equalities define cyclic dependencies, so we only eliminate one
@@ -379,8 +380,45 @@ simplifyKVar = go
           bs' = filter ((`S.member` exprSymbolsSet e') . fst) bs
           e'' = pExist bs' e'
       in
-         if null esvElim then e'' else go e''
+          if null esvElim then e'' else go e''
     go e = e
+
+    dedupByAlphaEq :: [Expr] -> [Expr]
+    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
+
+-- | Float out conjuncts from an existential expression that does not
+-- depend on the existentially bound variables.
+floatPExistConjuncts :: Expr -> [Expr]
+floatPExistConjuncts e0@(PExist bs (PAnd es)) =
+    let (floatable, nonFloatable) =
+           List.partition (isFloatableConjunct (S.fromList (map fst bs))) es
+     in
+        if null floatable then
+          [e0]
+        else
+          PExist bs (pAndNoDedup nonFloatable) : floatable
+  where
+    isFloatableConjunct :: S.HashSet Symbol -> Expr -> Bool
+    isFloatableConjunct s e = S.null $ S.intersection (exprSymbolsSet e) s
+floatPExistConjuncts e = [e]
+
+-- | Determine if two expressions are alpha-equivalent.
+--
+-- Doesn't handle all cases, just enough for simplifying KVars which requires
+-- alpha-equivalence checking of existentially quantified expressions.
+alphaEq :: Expr -> Expr -> Bool
+alphaEq = go (mkSubst [])
+  where
+    go :: Subst -> Expr -> Expr -> Bool
+    go su (PExist bs1 x1) (PExist bs2 x2) =
+      let su' = foldl (\s (v1, v2) -> extendSubst s v1 (EVar v2)) su (zip (map fst bs1) (map fst bs2))
+       in go su' x1 x2
+    go su (PAnd es1) (PAnd es2) =
+      length es1 == length es2 && all (\(e1, e2) -> go su e1 e2) (zip es1 es2)
+    go su (POr es1) (POr es2) =
+      length es1 == length es2 && all (\(e1, e2) -> go su e1 e2) (zip es1 es2)
+    go su e1 e2 =
+      subst su e1 == e2
 
 -- | Determine if the expression is an equality that sets the value of
 -- a variable in the given set.

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -65,7 +65,7 @@ import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
 import           Language.Fixpoint.Solver.PLE as PLE (instantiate)
 import           Control.DeepSeq
 import qualified Data.ByteString as B
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, isJust)
 import qualified Text.PrettyPrint.HughesPJ as PJ
 
 ---------------------------------------------------------------------------
@@ -378,8 +378,11 @@ simplifyKVar = pAnd . dedupByAlphaEq . floatPExistConjuncts . go
           -- equalities define cyclic dependencies, so we only eliminate one
           -- variable at a time.
           esvElim = take 1 [ (x, v) | (Just (x, v), _) <- esv ]
+          esvKeep =
+            let (xs, ys) = break (isJust . fst) esv
+             in map snd (xs ++ drop 1 ys)
           su = mkSubst esvElim
-          e' = rapierSubstExpr (substSymbolsSet su) su $ pAnd [ei | (Nothing, ei) <- esv]
+          e' = rapierSubstExpr (substSymbolsSet su) su $ pAnd esvKeep
           bs' = filter ((`S.member` exprSymbolsSet e') . fst) bs
           e'' = pExist bs' e'
       in

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -417,7 +417,7 @@ alphaEq = go (mkSubst [])
   where
     go :: Subst -> Expr -> Expr -> Bool
     go su (PExist bs1 x1) (PExist bs2 x2) =
-      let su' = foldl (\s (v1, v2) -> extendSubst s v1 (EVar v2)) su (zip (map fst bs1) (map fst bs2))
+      let su' = List.foldl' (\s (v1, v2) -> extendSubst s v1 (EVar v2)) su (zip (map fst bs1) (map fst bs2))
        in go su' x1 x2
     go su (PAnd es1) (PAnd es2) =
       length es1 == length es2 && all (\(e1, e2) -> go su e1 e2) (zip es1 es2)

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -23,6 +23,9 @@ module Language.Fixpoint.Solver (
 
     -- * Simplified Info
   , simplifyFInfo
+
+    -- * Simplify KVar solutions
+  , simplifyKVar
 ) where
 
 import           Control.Concurrent                 (setNumCapabilities)

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -570,9 +570,9 @@ instance (Ord v, Fixpoint v) => Fixpoint (ExprV v) where
   toFix (POr  ps)      = text "||" <+> toFix ps
   toFix (PAtom r e1 e2)  = parens $ sep [ toFix e1 <+> toFix r, nest 2 (toFix e2)]
   toFix (PKVar k su)     = toFix k <-> toFix su
-  toFix (PAll xts p)     = "forall" <+> (toFix xts
+  toFix (PAll xts p)     = parens $ "forall" <+> (toFix xts
                                         $+$ ("." <+> toFix p))
-  toFix (PExist xts p)   = "exists" <+> (toFix xts
+  toFix (PExist xts p)   = parens $ "exists" <+> (toFix xts
                                         $+$ ("." <+> toFix p))
   toFix (ETApp e s)      = text "tapp" <+> toFix e <+> toFix s
   toFix (ETAbs e s)      = text "tabs" <+> toFix e <+> toFix s
@@ -770,8 +770,8 @@ instance (Ord v, Fixpoint v, PPrint v) => PPrint (ExprV v) where
                                    pprintTidy k r         <+>
                                    pprintPrec (za+1) k e2
     where za = 4
-  pprintPrec _ k (PAll xts p)    = pprintQuant k "forall" xts p
-  pprintPrec _ k (PExist xts p)  = pprintQuant k "exists" xts p
+  pprintPrec z k (PAll xts p)    = parensIf (z > 0) $ pprintQuant k "forall" xts p
+  pprintPrec z k (PExist xts p)  = parensIf (z > 0) $ pprintQuant k "exists" xts p
   pprintPrec _ k (ELam (x,t) e)  = "lam" <+> toFix x <+> ":" <+> toFix t <+> text "." <+> pprintTidy k e
   pprintPrec _ k (ECoerc a t e)  = parens $ "coerce" <+> toFix a <+> "~" <+> toFix t <+> text "in" <+> pprintTidy k e
   pprintPrec _ _ p@PKVar{}    = toFix p

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -19,6 +19,7 @@ module Language.Fixpoint.Types.Substitutions (
   , filterSubst
   , catSubst
   , exprSymbolsSet
+  , extendSubst
   , meetReft
   , pprReft
   ) where
@@ -247,13 +248,13 @@ rapierSubstExpr s su e0 =
     maybeFresh x =
       if x `S.member` s then Right (x, fresh x) else Left x
 
-    extendSubst :: Subst -> Symbol -> Expr -> Subst
-    extendSubst (Su m) x e = Su $ M.insert x e m
-
     catSubstGo :: Subst -> Subst -> Subst
     catSubstGo (Su s1) su2@(Su s2) = Su $ M.union s1' s2
       where
         s1' = rapierSubstExpr s su2 <$> s1
+
+extendSubst :: Subst -> Symbol -> Expr -> Subst
+extendSubst (Su m) x e = Su $ M.insert x e m
 
 disjoint :: Subst -> [(Symbol, Sort)] -> Bool
 disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms

--- a/tests/tasty/Main.hs
+++ b/tests/tasty/Main.hs
@@ -5,6 +5,7 @@ module Main where
 import qualified ParserTests
 import qualified ShareMapTests
 import qualified SimplifyTests
+import qualified SimplifyKVarTests
 import qualified InterpretTests
 import qualified UndoANFTests
 import Test.Tasty
@@ -14,6 +15,7 @@ main = defaultMain $ testGroup "Tests"
   [ ParserTests.tests
   , ShareMapTests.tests
   , SimplifyTests.tests
+  , SimplifyKVarTests.tests
   , InterpretTests.tests
   , UndoANFTests.tests
   ]

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -1,0 +1,395 @@
+{-# LANGUAGE MultilineStrings #-}
+
+module SimplifyKVarTests (tests) where
+
+import Control.Monad (when)
+import Language.Fixpoint.Parse
+import qualified Language.Fixpoint.Types as F
+import qualified Language.Fixpoint.Solver as F
+import Test.Tasty
+import Test.Tasty.HUnit
+
+
+tests :: TestTree
+tests =
+  testGroup "simplifyKVar" $ map simplificationTest 
+    [ SimplificationTest
+        { name = "single elimination"
+        , expected = """
+            exists [y : int] . P C y
+          """
+        , input = """
+            exists [x : int, y : int] . x == C && P x y
+          """
+        }
+
+    , SimplificationTest
+        { name = "full elimination"
+        , expected = """
+            P C D
+          """
+        , input = """
+            exists [x : int, y : int] . x == C && P x y && y == D
+          """
+        }
+
+    , SimplificationTest
+        { name = "alpha equivalence"
+        , expected = """
+            exists [w : int, z : int] . P w z
+            && exists [w : int, z : int] . Q w z
+          """
+        , input = """
+            (exists [w : int, z : int] . Q w z) &&
+            (exists [w : int, z : int] . P w z) &&
+            exists [x : int, y : int] . P x y
+          """
+        }
+
+    , SimplificationTest
+        { name = "floating"
+        , expected = """
+            A == C && exists [x : int, y : int] . P x y
+          """
+        , input = """
+            exists [x : int, y : int] . A == C && P x y
+          """
+        }
+
+    , SimplificationTest
+        { name = "inner floating"
+        , expected = """
+            exists [x : int] . P x && Q x && exists [y : int] . P y
+          """
+        , input = """
+            exists [x : int] . P x && exists [ y : int] . P y && Q x
+          """
+        }
+
+    , largeSimplificationTest
+    ]
+
+data SimplificationTest = SimplificationTest
+  { input :: String
+  , expected :: String
+  , name :: String
+  }
+
+simplificationTest :: SimplificationTest -> TestTree
+simplificationTest test =
+  testCase (name test) $ do
+    let actual = F.showpp (F.simplifyKVar (doParse'' True predP (name test) (input test)))
+    when (unwords (words actual) /= unwords (words (expected test))) $ do
+      assertFailure $ unlines
+        [ "output is not as expected"
+        , "Expected:"
+        , expected test
+        , ""
+        , "Actual:"
+        , actual
+        ]
+
+largeSimplificationTest :: SimplificationTest
+largeSimplificationTest =
+  SimplificationTest
+    { name = "large simplification"
+    , expected = """
+        exists [w : int] . Test.gt0xy w i##aS7
+      """
+    , input = """
+        exists [VV##1821##k_ : int,
+                i##aS7##k_ : int,
+                lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                lq_tmpx##1823##k_ : int,
+                lq_tmpx##1824##k_ : int]
+              . (exists [w : int,
+                         w2 : int,
+                         x : int,
+                         y : Tuple0,
+                         VV##F##13 : int]
+                   . VV##1821##k_ == VV##F##13
+                     && i##aS7##k_ == i##aS7
+                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                     && lq_tmpx##1823##k_ == w
+                     && lq_tmpx##1824##k_ == x
+                     && (exists [VV##1829 : int,
+                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                 VV##1805##k_ : int,
+                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                 i##aS7##k_ : int]
+                           . VV##1829 == w
+                             && VV##1805##k_ == w
+                             && i##aS7##k_ == i##aS7
+                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                             && (exists [VV##F##3 : int]
+                                   . Test.gt0xy VV##F##3 i##aS7
+                                     && VV##1805##k_ == VV##F##3
+                                     && i##aS7##k_ == i##aS7
+                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                     && (exists [VV##1830 : int,
+                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                 i##aS7##k_ : int,
+                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                 VV##1807##k_ : int]
+                           . VV##1830 == w2
+                             && VV##1807##k_ == w2
+                             && i##aS7##k_ == i##aS7
+                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                             && (exists [w : int,
+                                         VV##F##14 : int,
+                                         lq_rnmx##255 : Tuple0]
+                                   . (exists [VV##1828 : int,
+                                              lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                              lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                              VV##1805##k_ : int,
+                                              lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                              i##aS7##k_ : int]
+                                        . VV##1828 == w
+                                          && VV##1805##k_ == w
+                                          && i##aS7##k_ == i##aS7
+                                          && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                          && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                          && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                          && (exists [VV##F##3 : int]
+                                                . Test.gt0xy VV##F##3 i##aS7
+                                                  && VV##1805##k_ == VV##F##3
+                                                  && i##aS7##k_ == i##aS7
+                                                  && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                  && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                  && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                                     && (exists [lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                 i##aS7##k_ : int,
+                                                 lq_tmpx##1812##k_ : Tuple0,
+                                                 VV##1809##k_ : int,
+                                                 lq_tmpx##1811##k_ : int,
+                                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int)]
+                                           . VV##1809##k_ == VV##F##14
+                                             && i##aS7##k_ == i##aS7
+                                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                             && lq_tmpx##1811##k_ == w
+                                             && lq_tmpx##1812##k_ == lq_rnmx##255
+                                             && (exists [VV##F##12 : int,
+                                                         lq_tmpx##1811 : int,
+                                                         lq_tmpx##1812 : Tuple0,
+                                                         lq_tmpdb##43 : int,
+                                                         lq_tmpdb##44 : Tuple0]
+                                                   . VV##F##12 == i##aS7
+                                                     && VV##1809##k_ == VV##F##12
+                                                     && i##aS7##k_ == i##aS7
+                                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                     && lq_tmpx##1811##k_ == lq_tmpx##1811
+                                                     && lq_tmpx##1812##k_ == lq_tmpx##1812))
+                                     && (exists [i##aS7##k_ : int,
+                                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                                 lq_tmpx##1801 : Tuple0,
+                                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                 VV##1799##k_ : Tuple0]
+                                           . VV##1799##k_ == lq_rnmx##255
+                                             && i##aS7##k_ == i##aS7
+                                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                             && lq_tmpx##1801 == lq_rnmx##255
+                                             && (exists [VV##F##10 : Tuple0]
+                                                   . VV##1799##k_ == VV##F##10
+                                                     && i##aS7##k_ == i##aS7
+                                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                                     && VV##1807##k_ == VV##F##14
+                                     && i##aS7##k_ == i##aS7
+                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                     && (exists [i##aS7##k_ : int,
+                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                 lq_tmpx##1801 : Tuple0,
+                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                 VV##1799##k_ : Tuple0]
+                           . VV##1799##k_ == y
+                             && i##aS7##k_ == i##aS7
+                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                             && lq_tmpx##1801 == y
+                             && (exists [VV##F##10 : Tuple0]
+                                   . VV##1799##k_ == VV##F##10
+                                     && i##aS7##k_ == i##aS7
+                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                     && (exists [i##aS7##k_ : int,
+                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                 lq_tmpx##1804 : int,
+                                 lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                 VV##1802##k_ : int]
+                           . VV##1802##k_ == x
+                             && i##aS7##k_ == i##aS7
+                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                             && lq_tmpx##1804 == x
+                             && (exists [VV##F##6 : int]
+                                   . (exists [i##aS7##k_ : int,
+                                              lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                              lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                              VV##1796##k_ : int]
+                                        . VV##1796##k_ == VV##F##6
+                                          && i##aS7##k_ == i##aS7
+                                          && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                          && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                          && (exists [VV##F##7 : int]
+                                                . (exists [lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                           lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                           i##aS7##k_ : int,
+                                                           lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                                           VV##1807##k_ : int]
+                                                     . VV##1807##k_ == VV##F##7
+                                                       && i##aS7##k_ == i##aS7
+                                                       && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                       && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                       && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                       && (exists [w : int,
+                                                                   VV##F##14 : int,
+                                                                   lq_rnmx##255 : Tuple0]
+                                                             . (exists [VV##1828 : int,
+                                                                        lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                                        lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                                                        VV##1805##k_ : int,
+                                                                        lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                                        i##aS7##k_ : int]
+                                                                  . VV##1828 == w
+                                                                    && VV##1805##k_ == w
+                                                                    && i##aS7##k_ == i##aS7
+                                                                    && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                    && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                    && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                                    && (exists [VV##F##3 : int]
+                                                                          . Test.gt0xy VV##F##3 i##aS7
+                                                                            && VV##1805##k_ == VV##F##3
+                                                                            && i##aS7##k_ == i##aS7
+                                                                            && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                            && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                            && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                                                               && (exists [lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                                           lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                                           i##aS7##k_ : int,
+                                                                           lq_tmpx##1812##k_ : Tuple0,
+                                                                           VV##1809##k_ : int,
+                                                                           lq_tmpx##1811##k_ : int,
+                                                                           lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int)]
+                                                                     . VV##1809##k_ == VV##F##14
+                                                                       && i##aS7##k_ == i##aS7
+                                                                       && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                       && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                       && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                                       && lq_tmpx##1811##k_ == w
+                                                                       && lq_tmpx##1812##k_ == lq_rnmx##255
+                                                                       && (exists [VV##F##12 : int,
+                                                                                   lq_tmpx##1811 : int,
+                                                                                   lq_tmpx##1812 : Tuple0,
+                                                                                   lq_tmpdb##43 : int,
+                                                                                   lq_tmpdb##44 : Tuple0]
+                                                                             . VV##F##12 == i##aS7
+                                                                               && VV##1809##k_ == VV##F##12
+                                                                               && i##aS7##k_ == i##aS7
+                                                                               && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                               && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                               && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                                               && lq_tmpx##1811##k_ == lq_tmpx##1811
+                                                                               && lq_tmpx##1812##k_ == lq_tmpx##1812))
+                                                               && (exists [i##aS7##k_ : int,
+                                                                           lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                                           lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                                                           lq_tmpx##1801 : Tuple0,
+                                                                           lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                                           VV##1799##k_ : Tuple0]
+                                                                     . VV##1799##k_ == lq_rnmx##255
+                                                                       && i##aS7##k_ == i##aS7
+                                                                       && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                       && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                       && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                                                       && lq_tmpx##1801 == lq_rnmx##255
+                                                                       && (exists [VV##F##10 : Tuple0]
+                                                                             . VV##1799##k_ == VV##F##10
+                                                                               && i##aS7##k_ == i##aS7
+                                                                               && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                                               && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                                               && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                                                               && VV##1807##k_ == VV##F##14
+                                                               && i##aS7##k_ == i##aS7
+                                                               && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                               && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                                               && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                                                  && VV##1796##k_ == VV##F##7
+                                                  && i##aS7##k_ == i##aS7
+                                                  && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                  && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb))
+                                     && (exists [i##aS7##k_ : int,
+                                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                                 VV##1793##k_ : int]
+                                           . VV##1793##k_ == VV##F##6
+                                             && i##aS7##k_ == i##aS7
+                                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                             && (exists [VV##F##5 : int]
+                                                   . VV##1793##k_ == VV##F##5
+                                                     && i##aS7##k_ == i##aS7
+                                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb))
+                                     && VV##1802##k_ == VV##F##6
+                                     && i##aS7##k_ == i##aS7
+                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc))
+                     && (exists [lq_anf##7205759403792798200##d1cc##k_ : (Test.State int int),
+                                 lq_tmpx##1818##k_ : int,
+                                 lq_anf##7205759403792798198##d1ca##k_ : (GHC.Internal.Base.Monad (Test.State int)),
+                                 lq_tmpx##1817##k_ : int,
+                                 VV##1815##k_ : int,
+                                 lq_anf##7205759403792798199##d1cb##k_ : (Test.State int Tuple0),
+                                 i##aS7##k_ : int]
+                           . VV##1815##k_ == VV##F##13
+                             && i##aS7##k_ == i##aS7
+                             && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                             && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                             && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                             && lq_tmpx##1817##k_ == w2
+                             && lq_tmpx##1818##k_ == x
+                             && (exists [VV##F##8 : int,
+                                         lq_tmpx##1817 : int,
+                                         lq_tmpx##1818 : int,
+                                         lq_tmpdb##47 : int,
+                                         lq_tmpdb##48 : int]
+                                   . lq_tmpx##1818 == VV##F##8
+                                     && VV##F##8 == lq_tmpx##1817
+                                     && VV##1815##k_ == VV##F##8
+                                     && i##aS7##k_ == i##aS7
+                                     && lq_anf##7205759403792798198##d1ca##k_ == lq_anf##7205759403792798198##d1ca
+                                     && lq_anf##7205759403792798199##d1cb##k_ == lq_anf##7205759403792798199##d1cb
+                                     && lq_anf##7205759403792798200##d1cc##k_ == lq_anf##7205759403792798200##d1cc
+                                     && lq_tmpx##1817##k_ == lq_tmpx##1817
+                                     && lq_tmpx##1818##k_ == lq_tmpx##1818)))
+        """
+    }

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -36,20 +36,20 @@ tests =
     , SimplificationTest
         { name = "alpha equivalence"
         , expected = """
-            exists [w : int, z : int] . P w z
-            && exists [w : int, z : int] . Q w z
+            (exists [w : int, z : int] . P w z) &&
+            (exists [w : int, z : int] . Q w z)
           """
         , input = """
             (exists [w : int, z : int] . Q w z) &&
             (exists [w : int, z : int] . P w z) &&
-            exists [x : int, y : int] . P x y
+            (exists [x : int, y : int] . P x y)
           """
         }
 
     , SimplificationTest
         { name = "floating"
         , expected = """
-            A == C && exists [x : int, y : int] . P x y
+            A == C && (exists [x : int, y : int] . P x y)
           """
         , input = """
             exists [x : int, y : int] . A == C && P x y
@@ -59,10 +59,10 @@ tests =
     , SimplificationTest
         { name = "inner floating"
         , expected = """
-            exists [x : int] . P x && Q x && exists [y : int] . P y
+            (exists [x : int] . P x && Q x) && (exists [y : int] . P y)
           """
         , input = """
-            exists [x : int] . P x && exists [ y : int] . P y && Q x
+            exists [x : int] . P x && (exists [ y : int] . P y && Q x)
           """
         }
 

--- a/tests/tasty/ghc-before-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-before-9.12.1/SimplifyKVarTests.hs
@@ -1,0 +1,12 @@
+
+module SimplifyKVarTests (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+tests :: TestTree
+tests =
+  testGroup "simplifyKVar"
+    [ testCase "Disabled because it needs MultilineStrings (ghc >= 9.12.1)" $
+        return ()
+    ]


### PR DESCRIPTION
This PR adds some capability to float conjuncts from existentials in kvar simplification.

```
exists x . P x && (exists y . P y)
```
becomes
```
(exists x . P x) && (exists y . P y)
```
which then simplifies to 
```
exists x . P x
```
via a rudimentary implementation of alpha equivalence.

Notably, the PR also adds
* the ability to parse existential quantification
* some unit tests for simplification of kvars