### PR TITLE
Remove redundant question marks from expression

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -800,7 +800,7 @@ expr0P =
     <|> lamP -- lambda abstraction, starts with backslash
     <|> (reservedOp "&&" >> pAnd <$> predsP) -- built-in prefix and
     <|> (reservedOp "||" >> POr  <$> predsP) -- built-in prefix or
-    <|> try (reservedOp "?") *> predP
+    <|> try (reservedOp "?") *> exprP
 
 emptyListP :: Located () -> ParserV v (ExprV v)
 emptyListP lx = do
@@ -826,7 +826,7 @@ exprCastP
 fastIfP :: ParseableV v => (ExprV v -> a -> a -> a) -> ParserV v a -> ParserV v a
 fastIfP f bodyP
   = do reserved "if"
-       p <- predP
+       p <- exprP
        reserved "then"
        b1 <- bodyP
        reserved "else"
@@ -991,7 +991,7 @@ appliableExprP =
    <|> try (located (brackets (pure ())) >>= emptyListP) -- empty list, start with "["
    <|> try (located (brackets exprP) >>= singletonListP) -- singleton list, starts with "["
    <|> kvarPredP
-   <|> try (reservedOp "?" *> char '(') *> predP <* char ')'
+   <|> try (reservedOp "?" *> char '(') *> exprP <* char ')'
 
 -- | constant bottom, equivalent to "false"
 botP :: ParserV v (ExprV v)
@@ -1086,13 +1086,6 @@ mkFTycon locSymbol = do
 -- | Predicates ----------------------------------------------------------------
 --------------------------------------------------------------------------------
 
--- | Parser for "atomic" predicates.
---
--- This parser is reused by Liquid Haskell.
---
-pred0P :: ParseableV v => ParserV v (ExprV v)
-pred0P =  exprP
-
 -- | Parser for the reserved constant "true".
 trueP :: ParserV v (ExprV v)
 trueP  = reserved "true"  >> return PTrue
@@ -1118,12 +1111,12 @@ substP = mkSu <$> many (brackets $ pairP symbolP aP exprP)
 -- disjunction.
 --
 predsP :: ParseableV v => ParserV v [ExprV v]
-predsP = brackets $ sepBy predP semi
+predsP = brackets $ sepBy exprP semi
 
 -- | Parses a predicate.
 --
 predP  :: ParseableV v => ParserV v (ExprV v)
-predP  = pred0P
+predP  = exprP
 
 existP :: ParseableV v => ParserV v (ExprV v)
 existP = do
@@ -1142,8 +1135,8 @@ existP = do
 
 -- | Refa
 refaP :: ParseableV v => ParserV v (ExprV v)
-refaP =  try (pAnd <$> brackets (sepBy predP semi))
-     <|> predP
+refaP =  try (pAnd <$> brackets (sepBy exprP semi))
+     <|> exprP
 
 
 -- | (Sorted) Refinements with configurable sub-parsers
@@ -1251,9 +1244,7 @@ defineP = do
   name   <- symbolP
   params <- parens        $ sepBy (symBindP sortP) comma
   sort   <- colon        *> sortP
-  body   <- reserved "=" *> braces (
-              if sort == boolSort then predP else exprP
-               )
+  body   <- reserved "=" *> braces exprP
   return  $ mkEquation name params body sort
 
 defineLocalP :: Parser (Int, [(Symbol, Expr)])
@@ -1436,7 +1427,7 @@ crashP pp = do
   return $ Crash [(i, Nothing)] msg
 
 predSolP :: Parser Expr
-predSolP = parens (predP  <* (comma >> iQualP))
+predSolP = parens (exprP  <* (comma >> iQualP))
 
 iQualP :: Parser [Symbol]
 iQualP = upperIdP >> parens (sepBy symbolP comma)
@@ -1541,7 +1532,7 @@ commandP
  <|> (reserved "push"     >> return Push)
  <|> (reserved "pop"      >> return Pop)
  <|> (reserved "check"    >> return CheckSat)
- <|> (reserved "assert"   >> (Assert Nothing <$> predP))
+ <|> (reserved "assert"   >> (Assert Nothing <$> exprP))
  <|> (reserved "distinct" >> (Distinct <$> brackets (sepBy exprP comma)))
 
 cmdVarP :: Parser Command

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -537,7 +537,7 @@ _reservedOpNames =
   , "->"
   , ":="
   , "&", "^", "<<", ">>", "--"
-  , "?", "Bexp"
+  , "Bexp"
   , "'"
   , "_|_"
   , "|"
@@ -800,7 +800,6 @@ expr0P =
     <|> lamP -- lambda abstraction, starts with backslash
     <|> (reservedOp "&&" >> pAnd <$> predsP) -- built-in prefix and
     <|> (reservedOp "||" >> POr  <$> predsP) -- built-in prefix or
-    <|> try (reservedOp "?") *> exprP
 
 emptyListP :: Located () -> ParserV v (ExprV v)
 emptyListP lx = do
@@ -991,7 +990,6 @@ appliableExprP =
    <|> try (located (brackets (pure ())) >>= emptyListP) -- empty list, start with "["
    <|> try (located (brackets exprP) >>= singletonListP) -- singleton list, starts with "["
    <|> kvarPredP
-   <|> try (reservedOp "?" *> char '(') *> exprP <* char ')'
 
 -- | constant bottom, equivalent to "false"
 botP :: ParserV v (ExprV v)

--- a/tests/neg/test00.hs.fq
+++ b/tests/neg/test00.hs.fq
@@ -1,7 +1,7 @@
 qualif Fst(v : @(1), y : @(0)) { v = fst([y])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 29, column 8)
 qualif Snd(v : @(1), y : @(0)) { v = snd([y])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 30, column 8)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) > 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 13, column 8)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) = 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 14, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (Prop([v])) <=> (len([xs]) > 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 13, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (Prop([v])) <=> (len([xs]) = 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 14, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) = 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 16, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) >= 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 17, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) > 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 18, column 8)
@@ -33,16 +33,16 @@ qualif Cmp(v : @(0), x : @(0)) { v >= x  } // "/Users/rjhala/research/stack/liqu
 qualif Cmp(v : @(0), x : @(0)) { v = x  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 20, column 8)
 qualif Cmp(v : @(0), x : @(0)) { v != x  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 21, column 8)
 qualif One(v : int) { v = 1  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 28, column 8)
-qualif True(v : bool) { ? v  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 29, column 8)
-qualif False(v : bool) { ~ ((? v))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 30, column 8)
-qualif True1(v : GHC.Types.Bool) { ? Prop([v])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 31, column 8)
-qualif False1(v : GHC.Types.Bool) { ~ ((? Prop([v])))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 32, column 8)
-qualif Papp(v : @(0), p : (Pred  @(0))) { (? papp1([p;
+qualif True(v : bool) { v  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 29, column 8)
+qualif False(v : bool) { ~ ((v))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 30, column 8)
+qualif True1(v : GHC.Types.Bool) { Prop([v])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 31, column 8)
+qualif False1(v : GHC.Types.Bool) { ~ ((Prop([v])))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 32, column 8)
+qualif Papp(v : @(0), p : (Pred  @(0))) { (papp1([p;
                                                    v])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 35, column 8)
-qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { (? papp2([p;
+qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { (papp2([p;
                                                                     v;
                                                                     x])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 38, column 8)
-qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { (? papp3([p;
+qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { (papp3([p;
                                                                                     v;
                                                                                     x;
                                                                                     y])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 41, column 8)
@@ -137,33 +137,33 @@ bind 2 GHC.Classes.$36$fOrdInt$35$rni : {VV$35$166 : (GHC.Classes.Ord  int) | []
 bind 3 GHC.Types.EQ$35$6U : {VV$35$167 : GHC.Types.Ordering | [(VV$35$167 = GHC.Types.EQ$35$6U)]}
 bind 4 GHC.Types.LT$35$6S : {VV$35$168 : GHC.Types.Ordering | [(VV$35$168 = GHC.Types.LT$35$6S)]}
 bind 5 GHC.Types.GT$35$6W : {VV$35$169 : GHC.Types.Ordering | [(VV$35$169 = GHC.Types.GT$35$6W)]}
-bind 6 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(? Prop([v$35$4]))]}
-bind 7 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((? Prop([v$35$5]))))]}
-bind 8 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((? Prop([v$35$5]))))]}
+bind 6 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(Prop([v$35$4]))]}
+bind 7 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((Prop([v$35$5]))))]}
+bind 8 GHC.Types.False$35$68 : {v$35$5 : GHC.Types.Bool | [(~ ((Prop([v$35$5]))))]}
 bind 9 GHC.Types.$91$$93$$35$6m : {VV : func(1, [[@(0)]]) | []}
-bind 10 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(? Prop([v$35$4]))]}
+bind 10 GHC.Types.True$35$6u : {v$35$4 : GHC.Types.Bool | [(Prop([v$35$4]))]}
 bind 11 GHC.Types.GT$35$6W : {VV$35$214 : GHC.Types.Ordering | [(cmp([VV$35$214]) = GHC.Types.GT$35$6W)]}
 bind 12 GHC.Types.LT$35$6S : {VV$35$215 : GHC.Types.Ordering | [(cmp([VV$35$215]) = GHC.Types.LT$35$6S)]}
 bind 13 GHC.Types.EQ$35$6U : {VV$35$216 : GHC.Types.Ordering | [(cmp([VV$35$216]) = GHC.Types.EQ$35$6U)]}
 bind 14 GHC.Base.Nothing$35$r1d : {VV : func(1, [(GHC.Base.Maybe  @(0))]) | []}
 bind 15 z$35$a10N : {VV$35$221 : int | [$k_$35$222]}
 bind 16 lq_anf$36$_d116 : {lq_tmp$36$x$35$229 : int | [(lq_tmp$36$x$35$229 = (100  :  int))]}
-bind 17 lq_anf$36$_d117 : {lq_tmp$36$x$35$236 : GHC.Types.Bool | [((? Prop([lq_tmp$36$x$35$236])) <=> (z$35$a10N >= lq_anf$36$_d116))]}
+bind 17 lq_anf$36$_d117 : {lq_tmp$36$x$35$236 : GHC.Types.Bool | [((Prop([lq_tmp$36$x$35$236])) <=> (z$35$a10N >= lq_anf$36$_d116))]}
 bind 18 lq_anf$36$_d118 : {lq_tmp$36$x$35$254 : int | [(lq_tmp$36$x$35$254 = (0  :  int))]}
 bind 19 Test0.x$35$rYP : {VV$35$250 : int | [$k_$35$251]}
 bind 20 lq_anf$36$_d119 : {lq_tmp$36$x$35$269 : int | [(lq_tmp$36$x$35$269 = (0  :  int))]}
-bind 21 lq_anf$36$_d11a : {lq_tmp$36$x$35$275 : GHC.Types.Bool | [((? Prop([lq_tmp$36$x$35$275])) <=> (Test0.x$35$rYP > lq_anf$36$_d119))]}
+bind 21 lq_anf$36$_d11a : {lq_tmp$36$x$35$275 : GHC.Types.Bool | [((Prop([lq_tmp$36$x$35$275])) <=> (Test0.x$35$rYP > lq_anf$36$_d119))]}
 bind 22 lq_anf$36$_d11b : {lq_tmp$36$x$35$291 : GHC.Types.Bool | [(lq_tmp$36$x$35$291 = lq_anf$36$_d11a)]}
 bind 23 lq_anf$36$_d11b : {lq_tmp$36$x$35$293 : GHC.Types.Bool | [(lq_tmp$36$x$35$293 = lq_anf$36$_d11a)]}
 bind 24 lq_anf$36$_d11b : {lq_tmp$36$x$35$293 : GHC.Types.Bool | [(lq_tmp$36$x$35$293 = lq_anf$36$_d11a);
-                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))));
-                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))));
-                                                                  (~ ((? Prop([lq_tmp$36$x$35$293]))))]}
+                                                                  (~ ((Prop([lq_tmp$36$x$35$293]))));
+                                                                  (~ ((Prop([lq_tmp$36$x$35$293]))));
+                                                                  (~ ((Prop([lq_tmp$36$x$35$293]))))]}
 bind 25 lq_anf$36$_d11b : {lq_tmp$36$x$35$299 : GHC.Types.Bool | [(lq_tmp$36$x$35$299 = lq_anf$36$_d11a)]}
 bind 26 lq_anf$36$_d11b : {lq_tmp$36$x$35$299 : GHC.Types.Bool | [(lq_tmp$36$x$35$299 = lq_anf$36$_d11a);
-                                                                  (? Prop([lq_tmp$36$x$35$299]));
-                                                                  (? Prop([lq_tmp$36$x$35$299]));
-                                                                  (? Prop([lq_tmp$36$x$35$299]))]}
+                                                                  (Prop([lq_tmp$36$x$35$299]));
+                                                                  (Prop([lq_tmp$36$x$35$299]));
+                                                                  (Prop([lq_tmp$36$x$35$299]))]}
 bind 27 Test0.prop_abs$35$r10h : {VV$35$265 : GHC.Types.Bool | [$k_$35$266]}
 bind 28 VV$35$310 : {VV$35$310 : GHC.Types.Bool | [$k_$35$226[lq_tmp$36$x$35$307:=Test0.x$35$rYP][lq_tmp$36$x$35$305:=VV$35$310][VV$35$225:=VV$35$310][z$35$a10N:=Test0.x$35$rYP]]}
 bind 29 VV$35$310 : {VV$35$310 : GHC.Types.Bool | [$k_$35$226[lq_tmp$36$x$35$307:=Test0.x$35$rYP][lq_tmp$36$x$35$305:=VV$35$310][VV$35$225:=VV$35$310][z$35$a10N:=Test0.x$35$rYP]]}
@@ -183,8 +183,8 @@ bind 42 VV$35$331 : {VV$35$331 : int | [(VV$35$331 = lq_anf$36$_d118)]}
 bind 43 VV$35$331 : {VV$35$331 : int | [(VV$35$331 = lq_anf$36$_d118)]}
 bind 44 VV$35$334 : {VV$35$334 : int | [(VV$35$334 = 0)]}
 bind 45 VV$35$334 : {VV$35$334 : int | [(VV$35$334 = 0)]}
-bind 46 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(? Prop([VV$35$337]))]}
-bind 47 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(? Prop([VV$35$337]))]}
+bind 46 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(Prop([VV$35$337]))]}
+bind 47 VV$35$337 : {VV$35$337 : GHC.Types.Bool | [(Prop([VV$35$337]))]}
 bind 48 VV$35$340 : {VV$35$340 : GHC.Types.Bool | [(VV$35$340 = lq_anf$36$_d117)]}
 bind 49 VV$35$340 : {VV$35$340 : GHC.Types.Bool | [(VV$35$340 = lq_anf$36$_d117)]}
 bind 50 VV$35$343 : {VV$35$343 : int | [(VV$35$343 = lq_anf$36$_d116)]}
@@ -260,7 +260,7 @@ constraint:
        14;
        15]
   lhs {VV$35$F8 : GHC.Types.Bool | [(VV$35$F8 = lq_anf$36$_d117)]}
-  rhs {VV$35$F8 : GHC.Types.Bool | [(? Prop([VV$35$F8]))]}
+  rhs {VV$35$F8 : GHC.Types.Bool | [(Prop([VV$35$F8]))]}
   id 8 tag [1]
   // META constraint id 8 : tests/neg/test00.hs:11:23-35
 

--- a/tests/pos/hex.ts.fq
+++ b/tests/pos/hex.ts.fq
@@ -14,8 +14,8 @@ qualif Cmp(v : int, x : int) { v > x  } // "/Users/rjhala/research/stack/liquid/
 qualif Cmp(v : int, x : int) { v >= x  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
 qualif Cmp(v : a, x : a) { v ~~ x  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
 qualif Cmp(v : a, x : a) { v != x  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
-qualif True1(v : Boolean) { ? Prop([v])  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
-qualif False1(v : Boolean) { ~ ((? Prop([v])))  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
+qualif True1(v : Boolean) { Prop([v])  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
+qualif False1(v : Boolean) { ~ ((Prop([v])))  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
 qualif Tag(v : a, x : Str) { ttag([v]) = x  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
 qualif Len(v : b, w : a) { v < len([w])  } // "/Users/rjhala/research/stack/liquid/refscript/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/refscript-0.1.0.0/include/prelude.ts" (line 1, column 1)
 
@@ -74,139 +74,139 @@ constant lit$36$Window : (Str)
 
 
 bind 0 undefined : {v : Undefined | [(ttag([v]) = lit$36$undefined);
-                                     (~ ((? Prop([v]))))]}
-bind 1 Object : {VV$35$285 : Object | [(? Prop([VV$35$285]));
+                                     (~ ((Prop([v]))))]}
+bind 1 Object : {VV$35$285 : Object | [(Prop([VV$35$285]));
                                        (ttag([VV$35$285]) = lit$36$object)]}
-bind 2 Object.prototype : {VV : (Object  Immutable) | [(? extends_interface([VV;
+bind 2 Object.prototype : {VV : (Object  Immutable) | [(extends_interface([VV;
                                                                              lit$36$Object]));
-                                                       (? Prop([VV]));
+                                                       (Prop([VV]));
                                                        (ttag([VV]) = lit$36$object);
                                                        (VV ~~ offset([Object; lit$36$prototype]))]}
 bind 3 NaN : {v : int | [(ttag([v]) = lit$36$number);
-                         ((? Prop([v])) <=> (v != 0));
+                         ((Prop([v])) <=> (v != 0));
                          (v = numeric_nan)]}
-bind 4 Number : {VV$35$325 : Object | [(? Prop([VV$35$325]));
+bind 4 Number : {VV$35$325 : Object | [(Prop([VV$35$325]));
                                        (ttag([VV$35$325]) = lit$36$object)]}
 bind 5 Number.POSITIVE_INFINITY : {v : int | [(ttag([v]) = lit$36$number);
-                                              ((? Prop([v])) <=> (v != 0));
+                                              ((Prop([v])) <=> (v != 0));
                                               (v ~~ offset([Number; lit$36$POSITIVE_INFINITY]))]}
 bind 6 Number.MIN_VALUE : {v : int | [(ttag([v]) = lit$36$number);
-                                      ((? Prop([v])) <=> (v != 0));
+                                      ((Prop([v])) <=> (v != 0));
                                       (v ~~ offset([Number; lit$36$MIN_VALUE]))]}
-bind 7 Number.prototype : {VV : (Number  Immutable) | [(? extends_interface([VV;
+bind 7 Number.prototype : {VV : (Number  Immutable) | [(extends_interface([VV;
                                                                              lit$36$Number]));
-                                                       (? Prop([VV]));
+                                                       (Prop([VV]));
                                                        (ttag([VV]) = lit$36$object);
                                                        (VV ~~ offset([Number; lit$36$prototype]))]}
 bind 8 Number.NaN : {v : int | [(ttag([v]) = lit$36$number);
-                                ((? Prop([v])) <=> (v != 0));
+                                ((Prop([v])) <=> (v != 0));
                                 (v ~~ offset([Number; lit$36$NaN]))]}
 bind 9 Number.NEGATIVE_INFINITY : {v : int | [(ttag([v]) = lit$36$number);
-                                              ((? Prop([v])) <=> (v != 0));
+                                              ((Prop([v])) <=> (v != 0));
                                               (v ~~ offset([Number; lit$36$NEGATIVE_INFINITY]))]}
 bind 10 Number.MAX_VALUE : {v : int | [(ttag([v]) = lit$36$number);
-                                       ((? Prop([v])) <=> (v != 0));
+                                       ((Prop([v])) <=> (v != 0));
                                        (v ~~ offset([Number; lit$36$MAX_VALUE]))]}
-bind 11 Math : {VV$35$387 : (Math  Immutable) | [(? extends_interface([VV$35$387;
+bind 11 Math : {VV$35$387 : (Math  Immutable) | [(extends_interface([VV$35$387;
                                                                        lit$36$Math]));
-                                                 (? Prop([VV$35$387]));
+                                                 (Prop([VV$35$387]));
                                                  (ttag([VV$35$387]) = lit$36$object)]}
 bind 12 Math.SQRT2 : {v : int | [(ttag([v]) = lit$36$number);
-                                 ((? Prop([v])) <=> (v != 0));
+                                 ((Prop([v])) <=> (v != 0));
                                  (v ~~ offset([Math; lit$36$SQRT2]))]}
 bind 13 Math.LN2 : {v : int | [(ttag([v]) = lit$36$number);
-                               ((? Prop([v])) <=> (v != 0));
+                               ((Prop([v])) <=> (v != 0));
                                (v ~~ offset([Math; lit$36$LN2]))]}
 bind 14 Math.PI : {v : int | [(ttag([v]) = lit$36$number);
-                              ((? Prop([v])) <=> (v != 0));
+                              ((Prop([v])) <=> (v != 0));
                               (v ~~ offset([Math; lit$36$PI]))]}
 bind 15 Math.LOG10E : {v : int | [(ttag([v]) = lit$36$number);
-                                  ((? Prop([v])) <=> (v != 0));
+                                  ((Prop([v])) <=> (v != 0));
                                   (v ~~ offset([Math; lit$36$LOG10E]))]}
 bind 16 Math.LOG2E : {v : int | [(ttag([v]) = lit$36$number);
-                                 ((? Prop([v])) <=> (v != 0));
+                                 ((Prop([v])) <=> (v != 0));
                                  (v ~~ offset([Math; lit$36$LOG2E]))]}
 bind 17 Math.E : {v : int | [(ttag([v]) = lit$36$number);
-                             ((? Prop([v])) <=> (v != 0));
+                             ((Prop([v])) <=> (v != 0));
                              (v ~~ offset([Math; lit$36$E]))]}
 bind 18 Math.SQRT1_2 : {v : int | [(ttag([v]) = lit$36$number);
-                                   ((? Prop([v])) <=> (v != 0));
+                                   ((Prop([v])) <=> (v != 0));
                                    (v ~~ offset([Math; lit$36$SQRT1_2]))]}
 bind 19 Math.LN10 : {v : int | [(ttag([v]) = lit$36$number);
-                                ((? Prop([v])) <=> (v != 0));
+                                ((Prop([v])) <=> (v != 0));
                                 (v ~~ offset([Math; lit$36$LN10]))]}
-bind 20 String : {VV$35$469 : (StringConstructor  Immutable) | [(? extends_interface([VV$35$469;
+bind 20 String : {VV$35$469 : (StringConstructor  Immutable) | [(extends_interface([VV$35$469;
                                                                                       lit$36$StringConstructor]));
-                                                                (? Prop([VV$35$469]));
+                                                                (Prop([VV$35$469]));
                                                                 (ttag([VV$35$469]) = lit$36$object)]}
-bind 21 String.prototype : {VV : (String  Immutable) | [(? extends_interface([VV;
+bind 21 String.prototype : {VV : (String  Immutable) | [(extends_interface([VV;
                                                                               lit$36$String]));
-                                                        (? Prop([VV]));
+                                                        (Prop([VV]));
                                                         (ttag([VV]) = lit$36$object);
                                                         (VV ~~ offset([String; lit$36$prototype]))]}
-bind 22 Array : {VV$35$727 : Object | [(? Prop([VV$35$727]));
+bind 22 Array : {VV$35$727 : Object | [(Prop([VV$35$727]));
                                        (ttag([VV$35$727]) = lit$36$object)]}
-bind 23 Array.prototype : {VV : (Array  Mutable  Top) | [(? extends_interface([VV;
+bind 23 Array.prototype : {VV : (Array  Mutable  Top) | [(extends_interface([VV;
                                                                                lit$36$Array]));
-                                                         (? Prop([VV]));
+                                                         (Prop([VV]));
                                                          (ttag([VV]) = lit$36$object);
                                                          (VV ~~ offset([Array; lit$36$prototype]))]}
-bind 24 Function : {VV$35$762 : Object | [(? Prop([VV$35$762]));
+bind 24 Function : {VV$35$762 : Object | [(Prop([VV$35$762]));
                                           (ttag([VV$35$762]) = lit$36$object)]}
-bind 25 Function.prototype : {VV : (Function  Immutable) | [(? extends_interface([VV;
+bind 25 Function.prototype : {VV : (Function  Immutable) | [(extends_interface([VV;
                                                                                   lit$36$Function]));
-                                                            (? Prop([VV]));
+                                                            (Prop([VV]));
                                                             (ttag([VV]) = lit$36$object);
                                                             (VV ~~ offset([Function;
                                                                            lit$36$prototype]))]}
-bind 26 Console : {VV$35$891 : Object | [(? Prop([VV$35$891]));
+bind 26 Console : {VV$35$891 : Object | [(Prop([VV$35$891]));
                                          (ttag([VV$35$891]) = lit$36$object)]}
-bind 27 Console.prototype : {VV : (Console  Immutable) | [(? extends_interface([VV;
+bind 27 Console.prototype : {VV : (Console  Immutable) | [(extends_interface([VV;
                                                                                 lit$36$Console]));
-                                                          (? Prop([VV]));
+                                                          (Prop([VV]));
                                                           (ttag([VV]) = lit$36$object);
                                                           (VV ~~ offset([Console;
                                                                          lit$36$prototype]))]}
-bind 28 console : {VV$35$893 : (Console  Immutable) | [(? extends_interface([VV$35$893;
+bind 28 console : {VV$35$893 : (Console  Immutable) | [(extends_interface([VV$35$893;
                                                                              lit$36$Console]));
-                                                       (? Prop([VV$35$893]));
+                                                       (Prop([VV$35$893]));
                                                        (ttag([VV$35$893]) = lit$36$object)]}
-bind 29 Error : {VV$35$983 : Object | [(? Prop([VV$35$983]));
+bind 29 Error : {VV$35$983 : Object | [(Prop([VV$35$983]));
                                        (ttag([VV$35$983]) = lit$36$object)]}
-bind 30 Error.prototype : {VV : (Error  Immutable) | [(? extends_interface([VV;
+bind 30 Error.prototype : {VV : (Error  Immutable) | [(extends_interface([VV;
                                                                             lit$36$Error]));
-                                                      (? Prop([VV]));
+                                                      (Prop([VV]));
                                                       (ttag([VV]) = lit$36$object);
                                                       (VV ~~ offset([Error; lit$36$prototype]))]}
-bind 31 Event : {VV$35$1025 : Object | [(? Prop([VV$35$1025]));
+bind 31 Event : {VV$35$1025 : Object | [(Prop([VV$35$1025]));
                                         (ttag([VV$35$1025]) = lit$36$object)]}
 bind 32 Event.CAPTURING_PHASE : {v : int | [(ttag([v]) = lit$36$number);
-                                            ((? Prop([v])) <=> (v != 0));
+                                            ((Prop([v])) <=> (v != 0));
                                             (v ~~ offset([Event; lit$36$CAPTURING_PHASE]))]}
 bind 33 Event.AT_TARGET : {v : int | [(ttag([v]) = lit$36$number);
-                                      ((? Prop([v])) <=> (v != 0));
+                                      ((Prop([v])) <=> (v != 0));
                                       (v ~~ offset([Event; lit$36$AT_TARGET]))]}
-bind 34 Event.prototype : {VV : (Event  Immutable) | [(? extends_interface([VV;
+bind 34 Event.prototype : {VV : (Event  Immutable) | [(extends_interface([VV;
                                                                             lit$36$Event]));
-                                                      (? Prop([VV]));
+                                                      (Prop([VV]));
                                                       (ttag([VV]) = lit$36$object);
                                                       (VV ~~ offset([Event; lit$36$prototype]))]}
 bind 35 Event.BUBBLING_PHASE : {v : int | [(ttag([v]) = lit$36$number);
-                                           ((? Prop([v])) <=> (v != 0));
+                                           ((Prop([v])) <=> (v != 0));
                                            (v ~~ offset([Event; lit$36$BUBBLING_PHASE]))]}
-bind 36 document : {VV$35$1027 : (Document  Immutable) | [(? extends_interface([VV$35$1027;
+bind 36 document : {VV$35$1027 : (Document  Immutable) | [(extends_interface([VV$35$1027;
                                                                                 lit$36$Document]));
-                                                          (? Prop([VV$35$1027]));
+                                                          (Prop([VV$35$1027]));
                                                           (ttag([VV$35$1027]) = lit$36$object)]}
-bind 37 document.documentElement : {VV : (HTMLElement  Immutable) | [(? extends_interface([VV;
+bind 37 document.documentElement : {VV : (HTMLElement  Immutable) | [(extends_interface([VV;
                                                                                            lit$36$HTMLElement]));
-                                                                     (? Prop([VV]));
+                                                                     (Prop([VV]));
                                                                      (ttag([VV]) = lit$36$object);
                                                                      (VV ~~ offset([document;
                                                                                     lit$36$documentElement]))]}
-bind 38 window : {VV$35$1031 : (Window  Immutable) | [(? extends_interface([VV$35$1031;
+bind 38 window : {VV$35$1031 : (Window  Immutable) | [(extends_interface([VV$35$1031;
                                                                             lit$36$Window]));
-                                                      (? Prop([VV$35$1031]));
+                                                      (Prop([VV$35$1031]));
                                                       (ttag([VV$35$1031]) = lit$36$object)]}
 bind 39 lq_tmp_nano_1 : {VV : (BitVec  Size32) | [(VV = (lit "#x00000008" (BitVec  Size32)))]}
 bind 40 a_SSA_0 : {VV : (BitVec  Size32) | [(VV ~~ lq_tmp_nano_1);
@@ -217,7 +217,7 @@ bind 42 b_SSA_1 : {VV : (BitVec  Size32) | [(VV ~~ lq_tmp_nano_2);
 bind 43 lq_tmp_nano_3 : {v : (BitVec  Size32) | [(v = bvor([a_SSA_0;
                                                             a_SSA_0]))]}
 bind 44 lq_tmp_nano_6 : {v : Boolean | [(ttag([v]) = lit$36$boolean);
-                                        ((? Prop([v])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
+                                        ((Prop([v])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
 bind 45 lq_tmp_nano_9 : {VV$35$4 : Void | []}
 
 
@@ -272,8 +272,8 @@ constraint:
   lhs {VV$35$F1 : Boolean | [(ttag([VV$35$F1]) = lit$36$boolean);
                              (VV$35$F1 ~~ lq_tmp_nano_6);
                              (ttag([VV$35$F1]) = lit$36$boolean);
-                             ((? Prop([VV$35$F1])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
-  rhs {VV$35$F1 : Boolean | [(? Prop([VV$35$F1]))]}
+                             ((Prop([VV$35$F1])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
+  rhs {VV$35$F1 : Boolean | [(Prop([VV$35$F1]))]}
   id 1 tag [1]
   // META constraint id 1 : /Users/rjhala/research/stack/liquid/refscript/tests/pos/simple/hex.ts:7:1-7:22
 
@@ -327,8 +327,8 @@ constraint:
   lhs {VV$35$F2 : Boolean | [(ttag([VV$35$F2]) = lit$36$boolean);
                              (VV$35$F2 ~~ lq_tmp_nano_6);
                              (ttag([VV$35$F2]) = lit$36$boolean);
-                             ((? Prop([VV$35$F2])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
-  rhs {VV$35$F2 : Boolean | [(? Prop([VV$35$F2]))]}
+                             ((Prop([VV$35$F2])) <=> (b_SSA_1 ~~ lq_tmp_nano_3))]}
+  rhs {VV$35$F2 : Boolean | [(Prop([VV$35$F2]))]}
   id 2 tag [1]
   // META constraint id 2 : /Users/rjhala/research/stack/liquid/refscript/tests/pos/simple/hex.ts:7:1-7:22
 

--- a/tests/pos/listqual.hs.fq
+++ b/tests/pos/listqual.hs.fq
@@ -2,8 +2,8 @@ qualif Append(v : [@(0)], xs : [@(0)], ys : [@(0)]) { len([v]) = (len([xs]) + le
 qualif Fst(v : @(1), y : @(0)) { v = fst([y])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 29, column 8)
 qualif Snd(v : @(1), y : @(0)) { v = snd([y])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.spec" (line 30, column 8)
 qualif Auto(v : [int]) { len([v]) = 2  } // "tests/pos/listqual.hs" (line 10, column 1)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) > 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 13, column 8)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) = 0)  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 14, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { Prop([v]) <=> len([xs]) > 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 13, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { Prop([v]) <=> len([xs]) = 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 14, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) = 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 16, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) >= 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 17, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) > 0  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/GHC/Base.hquals" (line 18, column 8)
@@ -35,19 +35,19 @@ qualif Cmp(v : @(0), x : @(0)) { v >= x  } // "/Users/rjhala/research/stack/liqu
 qualif Cmp(v : @(0), x : @(0)) { v = x  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 20, column 8)
 qualif Cmp(v : @(0), x : @(0)) { v != x  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 21, column 8)
 qualif One(v : int) { v = 1  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 28, column 8)
-qualif True(v : bool) { ? v  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 29, column 8)
-qualif False(v : bool) { ~ ((? v))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 30, column 8)
-qualif True1(v : GHC.Types.Bool) { ? Prop([v])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 31, column 8)
-qualif False1(v : GHC.Types.Bool) { ~ ((? Prop([v])))  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 32, column 8)
-qualif Papp(v : @(0), p : (Pred  @(0))) { (? papp1([p;
-                                                   v])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 35, column 8)
-qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { (? papp2([p;
+qualif True(v : bool) {  v  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 29, column 8)
+qualif False(v : bool) { ~ v  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 30, column 8)
+qualif True1(v : GHC.Types.Bool) {  Prop([v])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 31, column 8)
+qualif False1(v : GHC.Types.Bool) { ~ Prop([v])  } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 32, column 8)
+qualif Papp(v : @(0), p : (Pred  @(0))) { papp1([p;
+                                                   v]) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 35, column 8)
+qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { papp2([p;
                                                                     v;
-                                                                    x])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 38, column 8)
-qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { (? papp3([p;
+                                                                    x]) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 38, column 8)
+qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { papp3([p;
                                                                                     v;
                                                                                     x;
-                                                                                    y])) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 41, column 8)
+                                                                                    y]) } // "/Users/rjhala/research/stack/liquid/liquidhaskell/.stack-work/install/x86_64-osx/nightly-2015-09-24/7.10.2/share/x86_64-osx-ghc-7.10.2/liquidhaskell-0.5.0.2/include/Prelude.hquals" (line 41, column 8)
 
 
 cut $k__185
@@ -163,10 +163,10 @@ bind 12 lq_anf__dwU : {lq_tmp_x_198 : [a_awA] | [(lq_tmp_x_198 = ds_dwT);
 bind 13 lq_anf__dwU : {lq_tmp_x_198 : [a_awA] | [(lq_tmp_x_198 = ds_dwT);
                                                  (len([lq_tmp_x_198]) >= 0);
                                                  (len([lq_tmp_x_198]) = 0);
-                                                 ((? null([lq_tmp_x_198])) <=> true);
+                                                 (null([lq_tmp_x_198]) <=> true);
                                                  (lq_tmp_x_198 = GHC.Types.$91$$93$$35$6m([]));
                                                  (len([lq_tmp_x_198]) = 0);
-                                                 ((? null([lq_tmp_x_198])) <=> true);
+                                                 (null([lq_tmp_x_198]) <=> true);
                                                  (len([lq_tmp_x_198]) >= 0)]}
 bind 14 lq_anf__dwU : {lq_tmp_x_208 : [a_awA] | [(lq_tmp_x_208 = ds_dwT);
                                                  (len([lq_tmp_x_208]) >= 0);
@@ -176,13 +176,13 @@ bind 16 xs$35$awp : {lq_tmp_x_218 : [a_awA] | [(len([lq_tmp_x_218]) >= 0)]}
 bind 17 lq_anf__dwU : {lq_tmp_x_208 : [a_awA] | [(lq_tmp_x_208 = ds_dwT);
                                                  (len([lq_tmp_x_208]) >= 0);
                                                  (len([lq_tmp_x_208]) = (1 + len([xs$35$awp])));
-                                                 ((? null([lq_tmp_x_208])) <=> false);
+                                                 (null([lq_tmp_x_208]) <=> false);
                                                  (xsListSelector([lq_tmp_x_208]) = xs$35$awp);
                                                  (xListSelector([lq_tmp_x_208]) = x$35$awo);
                                                  (lq_tmp_x_208 = GHC.Types.$58$$35$64([x$35$awo;
                                                                                        xs$35$awp]));
                                                  (len([lq_tmp_x_208]) = (1 + len([xs$35$awp])));
-                                                 ((? null([lq_tmp_x_208])) <=> false);
+                                                 (null([lq_tmp_x_208]) <=> false);
                                                  (xsListSelector([lq_tmp_x_208]) = xs$35$awp);
                                                  (xListSelector([lq_tmp_x_208]) = x$35$awo);
                                                  (len([lq_tmp_x_208]) >= 0)]}
@@ -192,22 +192,22 @@ bind 19 lq_tmp_x_259 : {VV : a_awA | []}
 bind 20 lq_anf__dwW : {lq_tmp_x_264 : int | [(lq_tmp_x_264 = (1  :  int))]}
 bind 21 lq_tmp_x_278 : {VV$35$279 : int | []}
 bind 22 lq_anf__dwX : {lq_tmp_x_270 : [int] | [(len([lq_tmp_x_270]) = 0);
-                                               ((? null([lq_tmp_x_270])) <=> true);
+                                               (null([lq_tmp_x_270]) <=> true);
                                                (len([lq_tmp_x_270]) >= 0)]}
 bind 23 lq_tmp_x_296 : {VV$35$297 : int | []}
 bind 24 lq_anf__dwY : {lq_tmp_x_284 : [int] | [(len([lq_tmp_x_284]) = (1 + len([lq_anf__dwX])));
-                                               ((? null([lq_tmp_x_284])) <=> false);
+                                               (null([lq_tmp_x_284]) <=> false);
                                                (xsListSelector([lq_tmp_x_284]) = lq_anf__dwX);
                                                (xListSelector([lq_tmp_x_284]) = lq_anf__dwW);
                                                (len([lq_tmp_x_284]) >= 0)]}
 bind 25 lq_anf__dwZ : {lq_tmp_x_305 : int | [(lq_tmp_x_305 = (2  :  int))]}
 bind 26 lq_tmp_x_319 : {VV$35$320 : int | []}
 bind 27 lq_anf__dx0 : {lq_tmp_x_311 : [int] | [(len([lq_tmp_x_311]) = 0);
-                                               ((? null([lq_tmp_x_311])) <=> true);
+                                               (null([lq_tmp_x_311]) <=> true);
                                                (len([lq_tmp_x_311]) >= 0)]}
 bind 28 lq_tmp_x_337 : {VV$35$338 : int | []}
 bind 29 lq_anf__dx1 : {lq_tmp_x_325 : [int] | [(len([lq_tmp_x_325]) = (1 + len([lq_anf__dx0])));
-                                               ((? null([lq_tmp_x_325])) <=> false);
+                                               (null([lq_tmp_x_325]) <=> false);
                                                (xsListSelector([lq_tmp_x_325]) = lq_anf__dx0);
                                                (xListSelector([lq_tmp_x_325]) = lq_anf__dwZ);
                                                (len([lq_tmp_x_325]) >= 0)]}
@@ -269,12 +269,12 @@ bind 71 VV$35$424 : {VV$35$424 : int | [(VV$35$424 = lq_anf__dwW)]}
 bind 72 VV$35$427 : {VV$35$427 : int | [(VV$35$427 = 1)]}
 bind 73 VV$35$427 : {VV$35$427 : int | [(VV$35$427 = 1)]}
 bind 74 VV$35$430 : {VV$35$430 : [a_awA] | [(len([VV$35$430]) = (1 + len([lq_anf__dwV])));
-                                            ((? null([VV$35$430])) <=> false);
+                                            (null([VV$35$430]) <=> false);
                                             (xsListSelector([VV$35$430]) = lq_anf__dwV);
                                             (xListSelector([VV$35$430]) = x$35$awo);
                                             (len([VV$35$430]) >= 0)]}
 bind 75 VV$35$430 : {VV$35$430 : [a_awA] | [(len([VV$35$430]) = (1 + len([lq_anf__dwV])));
-                                            ((? null([VV$35$430])) <=> false);
+                                            (null([VV$35$430]) <=> false);
                                             (xsListSelector([VV$35$430]) = lq_anf__dwV);
                                             (xListSelector([VV$35$430]) = x$35$awo);
                                             (len([VV$35$430]) >= 0)]}
@@ -384,7 +384,7 @@ constraint:
 constraint:
   env [0; 16; 1; 17; 2; 18; 3; 4; 5; 6; 7; 8; 9; 10; 74; 11; 14; 15]
   lhs {VV$35$F18 : [a_awA] | [(len([VV$35$F18]) = (1 + len([lq_anf__dwV])));
-                              ((? null([VV$35$F18])) <=> false);
+                              (null([VV$35$F18]) <=> false);
                               (xsListSelector([VV$35$F18]) = lq_anf__dwV);
                               (xListSelector([VV$35$F18]) = x$35$awo);
                               (len([VV$35$F18]) >= 0)]}

--- a/tests/pos/sets.fq
+++ b/tests/pos/sets.fq
@@ -2,6 +2,6 @@
 
 constraint:
   env []
-  lhs {v : Set_Set a_aTp | [(? Set_emp([v]))]}
+  lhs {v : Set_Set a_aTp | [(Set_emp([v]))]}
   rhs {v : Set_Set a_aTp | [(v = Set_empty([0]))]}
   id 3 tag [2]

--- a/tests/pos/test00.hs.fq
+++ b/tests/pos/test00.hs.fq
@@ -34,8 +34,8 @@ qualif Cmp(v:a, x:a) { v  = x }
 qualif Cmp(v:a, x:a) { v != x }
 
 qualif One(v:int)      { v = 1 }
-qualif True(v:bool)    { ? v  }
-qualif False(v:bool)   { ~ (? v)  }
+qualif True(v:bool)    { v  }
+qualif False(v:bool)   { ~ (v)  }
 qualif True1(v:GHC.Types.Bool) { Prop(v) }
 qualif False1(v:GHC.Types.Bool) { ~ Prop(v) }
 qualif Papp(v:a, p:Pred a)  { papp1 p v }
@@ -138,8 +138,8 @@ bind 6 Language.Haskell.Liquid.Prelude.choose#rpK : {VV : func(0, [int;
 bind 7 GHC.Types.EQ#6U : {VV#179 : GHC.Types.Ordering | []}
 bind 8 GHC.Types.LT#6S : {VV#180 : GHC.Types.Ordering | []}
 bind 9 GHC.Types.GT#6W : {VV#181 : GHC.Types.Ordering | []}
-bind 10 GHC.Types.True#6u : {v : GHC.Types.Bool | [(? Prop([v]))]}
-bind 11 GHC.Types.False#68 : {v : GHC.Types.Bool | [(~ ((? Prop([v]))))]}
+bind 10 GHC.Types.True#6u : {v : GHC.Types.Bool | [(Prop([v]))]}
+bind 11 GHC.Types.False#68 : {v : GHC.Types.Bool | [(~ ((Prop([v]))))]}
 bind 12 Language.Haskell.Liquid.Prelude.plus#rou : {VV : func(0, [int;
                                                                   int;
                                                                   int]) | []}
@@ -206,25 +206,25 @@ bind 38 a_a164 : {VV : num | []}
 bind 39 gooberding#a15N : {VV#234 : a_a164 | [$k_235]}
 bind 40 lq_anf__d16w : {lq_tmp_x241 : int | [(lq_tmp_x241 = 0)]}
 bind 41 lq_anf__d16x : {VV : a_a164 | [(VV = lq_anf__d16w)]}
-bind 42 lq_anf__d16y : {lq_tmp_x254 : GHC.Types.Bool | [((? Prop([lq_tmp_x254])) <=> (gooberding#a15N >= lq_anf__d16x))]}
+bind 42 lq_anf__d16y : {lq_tmp_x254 : GHC.Types.Bool | [((Prop([lq_tmp_x254])) <=> (gooberding#a15N >= lq_anf__d16x))]}
 bind 43 lq_anf__d16z : {lq_tmp_x276 : int | [(lq_tmp_x276 = (0  :  int))]}
 bind 44 Test0.x#r12i : {VV#272 : int | [$k_273]}
 bind 45 lq_anf__d16A : {lq_tmp_x291 : int | [(lq_tmp_x291 = (0  :  int))]}
-bind 46 lq_anf__d16B : {lq_tmp_x297 : GHC.Types.Bool | [((? Prop([lq_tmp_x297])) <=> (Test0.x#r12i > lq_anf__d16A))]}
-bind 47 lq_anf__d16C : {lq_tmp_x313 : GHC.Types.Bool | [((? Prop([lq_tmp_x313])) <=> (Test0.x#r12i > lq_anf__d16A));
+bind 46 lq_anf__d16B : {lq_tmp_x297 : GHC.Types.Bool | [((Prop([lq_tmp_x297])) <=> (Test0.x#r12i > lq_anf__d16A))]}
+bind 47 lq_anf__d16C : {lq_tmp_x313 : GHC.Types.Bool | [((Prop([lq_tmp_x313])) <=> (Test0.x#r12i > lq_anf__d16A));
                                                         (lq_tmp_x313 = lq_anf__d16B)]}
-bind 48 lq_anf__d16C : {lq_tmp_x315 : GHC.Types.Bool | [((? Prop([lq_tmp_x315])) <=> (Test0.x#r12i > lq_anf__d16A));
+bind 48 lq_anf__d16C : {lq_tmp_x315 : GHC.Types.Bool | [((Prop([lq_tmp_x315])) <=> (Test0.x#r12i > lq_anf__d16A));
                                                         (lq_tmp_x315 = lq_anf__d16B)]}
-bind 49 lq_anf__d16C : {lq_tmp_x315 : GHC.Types.Bool | [((? Prop([lq_tmp_x315])) <=> (Test0.x#r12i > lq_anf__d16A));
+bind 49 lq_anf__d16C : {lq_tmp_x315 : GHC.Types.Bool | [((Prop([lq_tmp_x315])) <=> (Test0.x#r12i > lq_anf__d16A));
                                                         (lq_tmp_x315 = lq_anf__d16B);
-                                                        (~ ((? Prop([lq_tmp_x315]))));
-                                                        (~ ((? Prop([lq_tmp_x315]))))]}
-bind 50 lq_anf__d16C : {lq_tmp_x321 : GHC.Types.Bool | [((? Prop([lq_tmp_x321])) <=> (Test0.x#r12i > lq_anf__d16A));
+                                                        (~ ((Prop([lq_tmp_x315]))));
+                                                        (~ ((Prop([lq_tmp_x315]))))]}
+bind 50 lq_anf__d16C : {lq_tmp_x321 : GHC.Types.Bool | [((Prop([lq_tmp_x321])) <=> (Test0.x#r12i > lq_anf__d16A));
                                                         (lq_tmp_x321 = lq_anf__d16B)]}
-bind 51 lq_anf__d16C : {lq_tmp_x321 : GHC.Types.Bool | [((? Prop([lq_tmp_x321])) <=> (Test0.x#r12i > lq_anf__d16A));
+bind 51 lq_anf__d16C : {lq_tmp_x321 : GHC.Types.Bool | [((Prop([lq_tmp_x321])) <=> (Test0.x#r12i > lq_anf__d16A));
                                                         (lq_tmp_x321 = lq_anf__d16B);
-                                                        (? Prop([lq_tmp_x321]));
-                                                        (? Prop([lq_tmp_x321]))]}
+                                                        (Prop([lq_tmp_x321]));
+                                                        (Prop([lq_tmp_x321]))]}
 bind 52 Test0.prop_abs#r12j : {VV#287 : GHC.Types.Bool | [$k_288]}
 bind 53 VV#343 : {VV#343 : GHC.Types.Bool | [$k_239[VV#238:=VV#343][fix##36#dOrd_a165:=fix#GHC.Classes.#36#fOrdInt#35#rhx][fix##36#dNum_a166:=fix#GHC.Num.#36#fNumInt#35#rhy][gooberding#a15N:=Test0.x#r12i][lq_tmp_x332:=fix#GHC.Classes.#36#fOrdInt#35#rhx][lq_tmp_x333:=fix#GHC.Num.#36#fNumInt#35#rhy][lq_tmp_x334:=Test0.x#r12i][lq_tmp_x328:=VV#343]]}
 bind 54 VV#343 : {VV#343 : GHC.Types.Bool | [$k_239[VV#238:=VV#343][fix##36#dOrd_a165:=fix#GHC.Classes.#36#fOrdInt#35#rhx][fix##36#dNum_a166:=fix#GHC.Num.#36#fNumInt#35#rhy][gooberding#a15N:=Test0.x#r12i][lq_tmp_x332:=fix#GHC.Classes.#36#fOrdInt#35#rhx][lq_tmp_x333:=fix#GHC.Num.#36#fNumInt#35#rhy][lq_tmp_x334:=Test0.x#r12i][lq_tmp_x328:=VV#343]]}
@@ -232,9 +232,9 @@ bind 55 VV#346 : {VV#346 : int | [$k_273[VV#272:=VV#346][lq_tmp_x341:=VV#346];
                                   (VV#346 = Test0.x#r12i)]}
 bind 56 VV#346 : {VV#346 : int | [$k_273[VV#272:=VV#346][lq_tmp_x341:=VV#346];
                                   (VV#346 = Test0.x#r12i)]}
-bind 57 VV#349 : {VV#349 : GHC.Types.Bool | [(~ ((? Prop([VV#349]))));
+bind 57 VV#349 : {VV#349 : GHC.Types.Bool | [(~ ((Prop([VV#349]))));
                                              (VV#349 = GHC.Types.False#68)]}
-bind 58 VV#349 : {VV#349 : GHC.Types.Bool | [(~ ((? Prop([VV#349]))));
+bind 58 VV#349 : {VV#349 : GHC.Types.Bool | [(~ ((Prop([VV#349]))));
                                              (VV#349 = GHC.Types.False#68)]}
 bind 59 VV#352 : {VV#352 : int | [(VV#352 = (0  :  int));
                                   (VV#352 = lq_anf__d16A)]}
@@ -254,11 +254,11 @@ bind 68 VV#364 : {VV#364 : int | [(VV#364 = (0  :  int));
                                   (VV#364 = lq_anf__d16z)]}
 bind 69 VV#367 : {VV#367 : int | [(VV#367 = 0)]}
 bind 70 VV#367 : {VV#367 : int | [(VV#367 = 0)]}
-bind 71 VV#370 : {VV#370 : GHC.Types.Bool | [(? Prop([VV#370]))]}
-bind 72 VV#370 : {VV#370 : GHC.Types.Bool | [(? Prop([VV#370]))]}
-bind 73 VV#373 : {VV#373 : GHC.Types.Bool | [((? Prop([VV#373])) <=> (gooberding#a15N >= lq_anf__d16x));
+bind 71 VV#370 : {VV#370 : GHC.Types.Bool | [(Prop([VV#370]))]}
+bind 72 VV#370 : {VV#370 : GHC.Types.Bool | [(Prop([VV#370]))]}
+bind 73 VV#373 : {VV#373 : GHC.Types.Bool | [((Prop([VV#373])) <=> (gooberding#a15N >= lq_anf__d16x));
                                              (VV#373 = lq_anf__d16y)]}
-bind 74 VV#373 : {VV#373 : GHC.Types.Bool | [((? Prop([VV#373])) <=> (gooberding#a15N >= lq_anf__d16x));
+bind 74 VV#373 : {VV#373 : GHC.Types.Bool | [((Prop([VV#373])) <=> (gooberding#a15N >= lq_anf__d16x));
                                              (VV#373 = lq_anf__d16y)]}
 bind 75 VV : {VV : a_a164 | [(VV = lq_anf__d16w);
                              (VV = lq_anf__d16x)]}
@@ -417,7 +417,7 @@ constraint:
        15;
        31;
        47]
-  lhs {VV#F3 : GHC.Types.Bool | [(~ ((? Prop([VV#F3]))));
+  lhs {VV#F3 : GHC.Types.Bool | [(~ ((Prop([VV#F3]))));
                                  (VV#F3 = GHC.Types.False#68)]}
   rhs {VV#F3 : GHC.Types.Bool | [$k_288[VV#287:=VV#F3][VV#349:=VV#F3][VV#F:=VV#F3]]}
   id 3 tag [3]
@@ -603,7 +603,7 @@ constraint:
        30;
        15;
        31]
-  lhs {VV#F7 : GHC.Types.Bool | [(? Prop([VV#F7]))]}
+  lhs {VV#F7 : GHC.Types.Bool | [(Prop([VV#F7]))]}
   rhs {VV#F7 : GHC.Types.Bool | [$k_239[VV#238:=VV#F7][VV#370:=VV#F7][VV#F:=VV#F7]]}
   id 7 tag [1]
 
@@ -653,9 +653,9 @@ constraint:
        30;
        15;
        31]
-  lhs {VV#F8 : GHC.Types.Bool | [((? Prop([VV#F8])) <=> (gooberding#a15N >= lq_anf__d16x));
+  lhs {VV#F8 : GHC.Types.Bool | [((Prop([VV#F8])) <=> (gooberding#a15N >= lq_anf__d16x));
                                  (VV#F8 = lq_anf__d16y)]}
-  rhs {VV#F8 : GHC.Types.Bool | [(? Prop([VV#F8]))]}
+  rhs {VV#F8 : GHC.Types.Bool | [(Prop([VV#F8]))]}
   id 8 tag [1]
 
 

--- a/tests/pos/test000.hs.fq
+++ b/tests/pos/test000.hs.fq
@@ -1,7 +1,7 @@
 qualif Fst(v : @(1), y : @(0)) { v = fst([y])  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.spec" (line 29, column 8)
 qualif Snd(v : @(1), y : @(0)) { v = snd([y])  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.spec" (line 30, column 8)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) > 0)  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 13, column 8)
-qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (? Prop([v])) <=> (len([xs]) = 0)  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 14, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (Prop([v])) <=> (len([xs]) > 0)  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 13, column 8)
+qualif IsEmp(v : GHC.Types.Bool, xs : [@(0)]) { (Prop([v])) <=> (len([xs]) = 0)  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 14, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) = 0  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 16, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) >= 0  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 17, column 8)
 qualif ListZ(v : [@(0)]) { len([v]) > 0  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/GHC/Base.hquals" (line 18, column 8)
@@ -33,16 +33,16 @@ qualif Cmp(v : @(0), x : @(0)) { v >= x  } // "/Users/benjamin/UCSDrepos/liquidh
 qualif Cmp(v : @(0), x : @(0)) { v = x  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 20, column 8)
 qualif Cmp(v : @(0), x : @(0)) { v != x  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 21, column 8)
 qualif One(v : int) { v = 1  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 28, column 8)
-qualif True(v : bool) { ? v  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 29, column 8)
-qualif False(v : bool) { ~ ((? v))  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 30, column 8)
-qualif True1(v : GHC.Types.Bool) { ? Prop([v])  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 31, column 8)
-qualif False1(v : GHC.Types.Bool) { ~ ((? Prop([v])))  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 32, column 8)
-qualif Papp(v : @(0), p : (Pred  @(0))) { (? papp1([p;
+qualif True(v : bool) { v  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 29, column 8)
+qualif False(v : bool) { ~ ((v))  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 30, column 8)
+qualif True1(v : GHC.Types.Bool) { Prop([v])  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 31, column 8)
+qualif False1(v : GHC.Types.Bool) { ~ ((Prop([v])))  } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 32, column 8)
+qualif Papp(v : @(0), p : (Pred  @(0))) { (papp1([p;
                                                    v])) } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 35, column 8)
-qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { (? papp2([p;
+qualif Papp2(v : @(1), x : @(0), p : (Pred  @(1)  @(0))) { (papp2([p;
                                                                     v;
                                                                     x])) } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 38, column 8)
-qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { (? papp3([p;
+qualif Papp3(v : @(2), x : @(0), y : @(1), p : (Pred  @(2)  @(0)  @(1))) { (papp3([p;
                                                                                     v;
                                                                                     x;
                                                                                     y])) } // "/Users/benjamin/UCSDrepos/liquidhaskell/include/Prelude.hquals" (line 41, column 8)
@@ -138,11 +138,11 @@ bind 3 GHC.Classes.$36$fOrdInt$35$rni : {VV$35$179 : (GHC.Classes.Ord  int) | []
 bind 4 GHC.Types.EQ$35$6U : {VV$35$180 : GHC.Types.Ordering | [(VV$35$180 = GHC.Types.EQ$35$6U)]}
 bind 5 GHC.Types.LT$35$6S : {VV$35$181 : GHC.Types.Ordering | [(VV$35$181 = GHC.Types.LT$35$6S)]}
 bind 6 GHC.Types.GT$35$6W : {VV$35$182 : GHC.Types.Ordering | [(VV$35$182 = GHC.Types.GT$35$6W)]}
-bind 7 GHC.Types.True$35$6u : {v_4 : GHC.Types.Bool | [(? Prop([v_4]))]}
-bind 8 GHC.Types.False$35$68 : {v_5 : GHC.Types.Bool | [(~ ((? Prop([v_5]))))]}
-bind 9 GHC.Types.False$35$68 : {v_5 : GHC.Types.Bool | [(~ ((? Prop([v_5]))))]}
+bind 7 GHC.Types.True$35$6u : {v_4 : GHC.Types.Bool | [(Prop([v_4]))]}
+bind 8 GHC.Types.False$35$68 : {v_5 : GHC.Types.Bool | [(~ ((Prop([v_5]))))]}
+bind 9 GHC.Types.False$35$68 : {v_5 : GHC.Types.Bool | [(~ ((Prop([v_5]))))]}
 bind 10 GHC.Types.$91$$93$$35$6m : {VV : func(1, [[@(0)]]) | []}
-bind 11 GHC.Types.True$35$6u : {v_4 : GHC.Types.Bool | [(? Prop([v_4]))]}
+bind 11 GHC.Types.True$35$6u : {v_4 : GHC.Types.Bool | [(Prop([v_4]))]}
 bind 12 GHC.Types.GT$35$6W : {VV$35$227 : GHC.Types.Ordering | [(cmp([VV$35$227]) = GHC.Types.GT$35$6W)]}
 bind 13 GHC.Types.LT$35$6S : {VV$35$228 : GHC.Types.Ordering | [(cmp([VV$35$228]) = GHC.Types.LT$35$6S)]}
 bind 14 GHC.Types.EQ$35$6U : {VV$35$229 : GHC.Types.Ordering | [(cmp([VV$35$229]) = GHC.Types.EQ$35$6U)]}
@@ -154,29 +154,29 @@ bind 19 Test0.toss$35$rYP : {VV$35$234 : GHC.Types.Bool | [$k__235]}
 bind 20 lq_anf__d12s : {lq_tmp_x_275 : GHC.Types.Bool | [(lq_tmp_x_275 = Test0.toss$35$rYP)]}
 bind 21 lq_anf__d12s : {lq_tmp_x_277 : GHC.Types.Bool | [(lq_tmp_x_277 = Test0.toss$35$rYP)]}
 bind 22 lq_anf__d12s : {lq_tmp_x_277 : GHC.Types.Bool | [(lq_tmp_x_277 = Test0.toss$35$rYP);
-                                                         (~ ((? Prop([lq_tmp_x_277]))));
-                                                         (~ ((? Prop([lq_tmp_x_277]))));
-                                                         (~ ((? Prop([lq_tmp_x_277]))))]}
+                                                         (~ ((Prop([lq_tmp_x_277]))));
+                                                         (~ ((Prop([lq_tmp_x_277]))));
+                                                         (~ ((Prop([lq_tmp_x_277]))))]}
 bind 23 lq_anf__d12s : {lq_tmp_x_283 : GHC.Types.Bool | [(lq_tmp_x_283 = Test0.toss$35$rYP)]}
 bind 24 lq_anf__d12s : {lq_tmp_x_283 : GHC.Types.Bool | [(lq_tmp_x_283 = Test0.toss$35$rYP);
-                                                         (? Prop([lq_tmp_x_283]));
-                                                         (? Prop([lq_tmp_x_283]));
-                                                         (? Prop([lq_tmp_x_283]))]}
+                                                         (Prop([lq_tmp_x_283]));
+                                                         (Prop([lq_tmp_x_283]));
+                                                         (Prop([lq_tmp_x_283]))]}
 bind 25 lq_anf__d12t : {lq_tmp_x_288 : GHC.Types.Bool | [(lq_tmp_x_288 = lq_anf__d12s)]}
 bind 26 lq_anf__d12t : {lq_tmp_x_290 : GHC.Types.Bool | [(lq_tmp_x_290 = lq_anf__d12s)]}
 bind 27 lq_anf__d12t : {lq_tmp_x_290 : GHC.Types.Bool | [(lq_tmp_x_290 = lq_anf__d12s);
-                                                         (~ ((? Prop([lq_tmp_x_290]))));
-                                                         (~ ((? Prop([lq_tmp_x_290]))));
-                                                         (~ ((? Prop([lq_tmp_x_290]))))]}
+                                                         (~ ((Prop([lq_tmp_x_290]))));
+                                                         (~ ((Prop([lq_tmp_x_290]))));
+                                                         (~ ((Prop([lq_tmp_x_290]))))]}
 bind 28 lq_anf__d12t : {lq_tmp_x_296 : GHC.Types.Bool | [(lq_tmp_x_296 = lq_anf__d12s)]}
 bind 29 lq_anf__d12t : {lq_tmp_x_296 : GHC.Types.Bool | [(lq_tmp_x_296 = lq_anf__d12s);
-                                                         (? Prop([lq_tmp_x_296]));
-                                                         (? Prop([lq_tmp_x_296]));
-                                                         (? Prop([lq_tmp_x_296]))]}
+                                                         (Prop([lq_tmp_x_296]));
+                                                         (Prop([lq_tmp_x_296]));
+                                                         (Prop([lq_tmp_x_296]))]}
 bind 30 Test0.prop_abs$35$r10h : {VV$35$272 : GHC.Types.Bool | [$k__273]}
 bind 31 x$35$a11A : {VV$35$307 : int | [$k__308]}
 bind 32 lq_anf__d12u : {lq_tmp_x_315 : int | [(lq_tmp_x_315 = (0  :  int))]}
-bind 33 lq_anf__d12v : {lq_tmp_x_321 : GHC.Types.Bool | [((? Prop([lq_tmp_x_321])) <=> (x$35$a11A > lq_anf__d12u))]}
+bind 33 lq_anf__d12v : {lq_tmp_x_321 : GHC.Types.Bool | [((Prop([lq_tmp_x_321])) <=> (x$35$a11A > lq_anf__d12u))]}
 bind 34 lq_anf__d12w : {lq_tmp_x_345 : int | [$k__343[lq_tmp_x_340:=lq_anf__d12v][VV$35$342:=lq_tmp_x_345][lq_tmp_x_341:=x$35$a11A]]}
 bind 35 lq_anf__d12x : {lq_tmp_x_350 : int | [(lq_tmp_x_350 = (1  :  int))]}
 bind 36 lq_anf__d12y : {lq_tmp_x_373 : int | [(lq_tmp_x_373 = (12  :  int))]}
@@ -223,16 +223,16 @@ bind 76 VV$35$477 : {VV$35$477 : int | [(VV$35$477 = x$35$a11A)]}
 bind 77 VV$35$477 : {VV$35$477 : int | [(VV$35$477 = x$35$a11A)]}
 bind 78 VV$35$480 : {VV$35$480 : int | [(VV$35$480 = 0)]}
 bind 79 VV$35$480 : {VV$35$480 : int | [(VV$35$480 = 0)]}
-bind 80 VV$35$483 : {VV$35$483 : GHC.Types.Bool | [(? Prop([VV$35$483]))]}
-bind 81 VV$35$483 : {VV$35$483 : GHC.Types.Bool | [(? Prop([VV$35$483]))]}
+bind 80 VV$35$483 : {VV$35$483 : GHC.Types.Bool | [(Prop([VV$35$483]))]}
+bind 81 VV$35$483 : {VV$35$483 : GHC.Types.Bool | [(Prop([VV$35$483]))]}
 bind 82 VV$35$486 : {VV$35$486 : GHC.Types.Bool | [(VV$35$486 = lq_anf__d12t)]}
 bind 83 VV$35$486 : {VV$35$486 : GHC.Types.Bool | [(VV$35$486 = lq_anf__d12t)]}
 bind 84 VV$35$489 : {VV$35$489 : GHC.Types.Bool | [(VV$35$489 = GHC.Types.False$35$68)]}
 bind 85 VV$35$489 : {VV$35$489 : GHC.Types.Bool | [(VV$35$489 = GHC.Types.False$35$68)]}
 bind 86 VV$35$492 : {VV$35$492 : GHC.Types.Bool | [(VV$35$492 = GHC.Types.False$35$68)]}
 bind 87 VV$35$492 : {VV$35$492 : GHC.Types.Bool | [(VV$35$492 = GHC.Types.False$35$68)]}
-bind 88 VV$35$495 : {VV$35$495 : GHC.Types.Bool | [((? Prop([VV$35$495])) <=> (lq_anf__d12q > lq_anf__d12r))]}
-bind 89 VV$35$495 : {VV$35$495 : GHC.Types.Bool | [((? Prop([VV$35$495])) <=> (lq_anf__d12q > lq_anf__d12r))]}
+bind 88 VV$35$495 : {VV$35$495 : GHC.Types.Bool | [((Prop([VV$35$495])) <=> (lq_anf__d12q > lq_anf__d12r))]}
+bind 89 VV$35$495 : {VV$35$495 : GHC.Types.Bool | [((Prop([VV$35$495])) <=> (lq_anf__d12q > lq_anf__d12r))]}
 bind 90 VV$35$498 : {VV$35$498 : int | [(VV$35$498 = lq_anf__d12r)]}
 bind 91 VV$35$498 : {VV$35$498 : int | [(VV$35$498 = lq_anf__d12r)]}
 bind 92 VV$35$501 : {VV$35$501 : int | [(VV$35$501 = lq_anf__d12q)]}
@@ -309,7 +309,7 @@ constraint:
        15;
        31]
   lhs {VV$35$F8 : GHC.Types.Bool | [(VV$35$F8 = lq_anf__d12v)]}
-  rhs {VV$35$F8 : GHC.Types.Bool | [(? Prop([VV$35$F8]))]}
+  rhs {VV$35$F8 : GHC.Types.Bool | [(Prop([VV$35$F8]))]}
   id 8 tag [3]
   // META constraint id 8 : tests/pos/test000.hs:14:23-29
 
@@ -339,7 +339,7 @@ constraint:
        29;
        14;
        15]
-  lhs {VV$35$F11 : GHC.Types.Bool | [(? Prop([VV$35$F11]))]}
+  lhs {VV$35$F11 : GHC.Types.Bool | [(Prop([VV$35$F11]))]}
   rhs {VV$35$F11 : GHC.Types.Bool | [$k__273[VV$35$272:=VV$35$F11][VV$35$F:=VV$35$F11][VV$35$483:=VV$35$F11]]}
   id 11 tag [6]
   // META constraint id 11 : tests/pos/test000.hs:10:33-50
@@ -371,7 +371,7 @@ constraint:
        14;
        15]
   lhs {VV$35$F12 : GHC.Types.Bool | [(VV$35$F12 = lq_anf__d12t)]}
-  rhs {VV$35$F12 : GHC.Types.Bool | [(? Prop([VV$35$F12]))]}
+  rhs {VV$35$F12 : GHC.Types.Bool | [(Prop([VV$35$F12]))]}
   id 12 tag [6]
   // META constraint id 12 : tests/pos/test000.hs:10:47-50
 
@@ -456,7 +456,7 @@ constraint:
        13;
        14;
        15]
-  lhs {VV$35$F15 : GHC.Types.Bool | [((? Prop([VV$35$F15])) <=> (lq_anf__d12q > lq_anf__d12r))]}
+  lhs {VV$35$F15 : GHC.Types.Bool | [((Prop([VV$35$F15])) <=> (lq_anf__d12q > lq_anf__d12r))]}
   rhs {VV$35$F15 : GHC.Types.Bool | [$k__235[VV$35$F:=VV$35$F15][VV$35$495:=VV$35$F15][VV$35$234:=VV$35$F15]]}
   id 15 tag [5]
   // META constraint id 15 : tests/pos/test000.hs:6:1-22

--- a/tests/tasty/ParserTests.hs
+++ b/tests/tasty/ParserTests.hs
@@ -232,9 +232,6 @@ testPredP =
     , testCase "parens pred" $
         show (doParse' predP "test" "((1 == 2))") @?= "PAtom Eq (ECon (I 1)) (ECon (I 2))"
 
-    , testCase "? expr" $
-        show (doParse' predP "test" "? (1+2)") @?= "EBin Plus (ECon (I 1)) (ECon (I 2))"
-
     , testCase "funApp 1" $
         show (doParse' predP "test" "f a b") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"
 
@@ -245,10 +242,10 @@ testPredP =
         show (doParse' predP "test" "f ([a; b])") @?= "EApp (EApp (EVar \"f\") (EVar \"a\")) (EVar \"b\")"
 
     , testCase "funApp 4" $
-        show (doParse' funAppP "" "f ?(x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
+        show (doParse' funAppP "" "f (x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
 
     , testCase "funApp 5" $
-        show (doParse' predP "" "f ?(x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
+        show (doParse' predP "" "f (x > 1)") @?= "EApp (EVar \"f\") (PAtom Gt (EVar \"x\") (ECon (I 1)))"
 
     , testCase "symbol" $
         show (doParse' predP "test" "f") @?= "EVar \"f\""


### PR DESCRIPTION
Fixes #682 

Now that the predicate/expression distinction has been erased in #805, the question mark is redundant.