### PR TITLE
Always expose solutions of non cut kvars to callers of solve

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1424,28 +1424,6 @@ crashP pp = do
   msg <- takeWhileP Nothing (const True) -- consume the rest of the input
   return $ Crash [(i, Nothing)] msg
 
-predSolP :: Parser Expr
-predSolP = parens (exprP  <* (comma >> iQualP))
-
-iQualP :: Parser [Symbol]
-iQualP = upperIdP >> parens (sepBy symbolP comma)
-
-solution1P :: Parser (KVar, Expr)
-solution1P = do
-  reserved "solution:"
-  k  <- kvP
-  reservedOp ":="
-  ps <- brackets $ sepBy predSolP semi
-  return (k, simplify $ PAnd ps)
-  where
-    kvP = try kvarP <|> (KV <$> symbolP)
-
-solutionP :: Parser (M.HashMap KVar Expr)
-solutionP = M.fromList <$> sepBy solution1P spaces
-
-solutionFileP :: Parser (FixResult Integer, M.HashMap KVar Expr)
-solutionFileP = (,) <$> fixResultP natural <*> solutionP
-
 --------------------------------------------------------------------------------
 
 -- | Parse via the given parser, and obtain the rest of the input
@@ -1561,9 +1539,6 @@ instance Inputable Expr where
 
 instance Inputable (FixResult Integer) where
   rr' = doParse' $ fixResultP natural
-
-instance Inputable (FixResult Integer, FixSolution) where
-  rr' = doParse' solutionFileP
 
 instance Inputable (FInfo ()) where
   rr' = {- SCC "fInfoP" -} doParse' fInfoP

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -324,7 +324,7 @@ saveSolution cfg res = when (save cfg) $ do
     , ""
     , "Non-cut kvars:"
     , ""
-    , scopedRender (resNonCutsSolution res)
+    , scopedRender (HashMap.map forceDelayed $ resNonCutsSolution res)
     ]
     where
       scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
@@ -336,7 +336,7 @@ simplifyResult :: Config -> Result a -> Result a
 simplifyResult cfg res =
     res
       { resSolution = HashMap.map simplifyKVar' (resSolution res)
-      , resNonCutsSolution = HashMap.map simplifyKVar' (resNonCutsSolution res)
+      , resNonCutsSolution = HashMap.map (fmap simplifyKVar') (resNonCutsSolution res)
       }
   where
     simplifyKVar' = unElabSets . unElab . simplifyKVar

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -26,6 +26,9 @@ module Language.Fixpoint.Solver (
 
     -- * Simplify KVar solutions
   , simplifyKVar
+
+    -- * Exported for testing
+  , alphaEq
 ) where
 
 import           Control.Concurrent                 (setNumCapabilities)

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -363,15 +363,24 @@ simplifyResult cfg res =
 -- > "exists y. (P && Q y)[x:=C]"
 --
 simplifyKVar :: Expr -> Expr
-simplifyKVar = pAnd . dedupByAlphaEq . floatPExistConjuncts . go
+simplifyKVar =
+   pAnd . dedupByAlphaEq . floatPExistConjuncts . go
   where
     go (POr es) = pOr $ map (pAnd . floatPExistConjuncts . go) es
     go (PAnd es) = pAnd $ dedupByAlphaEq $ concatMap (floatPExistConjuncts . go) es
-    go (PExist bs0 (PExist bs1 p)) =
-      let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
-       in go (PExist (bs0' ++ bs1) p)
     go (PExist bs e0) =
       let es = concatMap (floatPExistConjuncts . go) (conjuncts e0)
+       in elimExistentialBinds (PExist bs (pAnd es))
+    go e = e
+
+    dedupByAlphaEq :: [Expr] -> [Expr]
+    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
+
+    elimExistentialBinds (PExist bs0 (PExist bs1 p)) =
+      let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
+       in elimExistentialBinds (PExist (bs0' ++ bs1) p)
+    elimExistentialBinds (PExist bs e0) =
+      let es = conjuncts e0
           esv = map (isVarEq (map fst bs)) es
           -- Eliminating multiple variables at once can be difficult if the
           -- equalities define cyclic dependencies, so we only eliminate one
@@ -384,24 +393,22 @@ simplifyKVar = pAnd . dedupByAlphaEq . floatPExistConjuncts . go
           e' = rapierSubstExpr (substSymbolsSet su) su $ pAnd esvKeep
           bs' = filter ((`S.member` exprSymbolsSet e') . fst) bs
           e'' = pExist bs' e'
-      in
-          if null esvElim then e'' else go e''
-    go e = e
-
-    dedupByAlphaEq :: [Expr] -> [Expr]
-    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
+       in
+          if null esvElim then e'' else elimExistentialBinds e''
+    elimExistentialBinds e = e
 
     -- | Float out conjuncts from an existential expression that does not
     -- depend on the existentially bound variables.
     floatPExistConjuncts :: Expr -> [Expr]
-    floatPExistConjuncts e0@(PExist bs (PAnd es)) =
-      let (floatable, nonFloatable) =
+    floatPExistConjuncts e0@(PExist bs es0) =
+      let es = conjuncts es0
+          (floatable, nonFloatable) =
            List.partition (isFloatableConjunct (S.fromList (map fst bs))) es
        in
           if null floatable then
             [e0]
           else
-            go (PExist bs (pAndNoDedup nonFloatable)) : floatable
+            elimExistentialBinds (pExist bs (pAndNoDedup nonFloatable)) : floatable
       where
         isFloatableConjunct :: S.HashSet Symbol -> Expr -> Bool
         isFloatableConjunct s e = S.null $ S.intersection (exprSymbolsSet e) s

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -327,8 +327,8 @@ mkNonCutsExpr ce s k cs =
   let bcps = map (bareCubePred ce s k) cs
    in F.pOr bcps
 
-nonCutsResult :: F.BindEnv ann -> Sol.Sol Sol.QBind -> M.HashMap F.KVar F.Expr
-nonCutsResult be s = M.mapWithKey (mkNonCutsExpr g s) $ Sol.sHyp s
+nonCutsResult :: F.BindEnv ann -> Sol.Sol Sol.QBind -> FixDelayedSolution
+nonCutsResult be s = M.mapWithKey (\k -> Delayed . mkNonCutsExpr g s k) $ Sol.sHyp s
   where
     g = CEnv Nothing be F.emptyIBindEnv F.dummySpan F.emptyIBindEnv
 

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -177,7 +177,7 @@ solve_ cfg fi s2 wkl = do
 tidyResult :: Config -> F.Result a -> F.Result a
 tidyResult _ r = r
   { F.resSolution = tidySolution (F.resSolution r)
-  , F.resNonCutsSolution = tidySolution (F.resNonCutsSolution r)
+  , F.resNonCutsSolution = M.map (fmap tidyPred) (F.resNonCutsSolution r)
   , F.resSorts = fmap tidyBind <$>  F.resSorts r
   }
 

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -295,7 +295,7 @@ result bindingsInSmt cfg fi cs s =
     stat      <- result_ bindingsInSmt2 be cfg cs s
     lift       $ whenLoud $ putStrLn $ "RESULT: " ++ show (F.sid <$> stat)
     resCut    <- solResult cfg s
-    let resNonCut = solNonCutsResult cfg be s
+    let resNonCut = S.nonCutsResult be s
         resSorts = resultSorts fi (M.keys resCut ++ M.keys resNonCut) be
     return     $ F.Result (ci <$> stat) resCut resNonCut resSorts
   where
@@ -322,14 +322,6 @@ bindInfo be i = (x, F.sr_sort sr)
 
 solResult :: Config -> Sol.Solution -> SolveM ann (M.HashMap F.KVar F.Expr)
 solResult cfg = minimizeResult cfg . Sol.result
-
-solNonCutsResult :: Config -> F.BindEnv a -> Sol.Solution -> M.HashMap F.KVar F.Expr
-solNonCutsResult cfg be s
-  | cfgNonCuts cfg = S.nonCutsResult be s
-  | otherwise = mempty
-
-cfgNonCuts :: Config -> Bool
-cfgNonCuts cfg = save cfg || json cfg
 
 result_
   :: (F.Loc a, NFData a)

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -63,6 +63,8 @@ module Language.Fixpoint.Types.Constraints (
 
   -- * Results
   , FixSolution
+  , FixDelayedSolution
+  , Delayed (..)
   , Result (..), ResultSorts
   , unsafe, isUnsafe, isSafe ,safe
 
@@ -97,9 +99,6 @@ module Language.Fixpoint.Types.Constraints (
   , sortVars
   , gSorts
 
-  -- * ScopedResult
-  , ScopedResult (..), ScopedExpr (..)
-  , scopedResult
   ) where
 
 import qualified Data.Store as S
@@ -248,12 +247,24 @@ subcId = mfromJust "subCId" . sid
 -- | Solutions and Results
 ---------------------------------------------------------------------------
 
+-- | Since some solutions are expensive to compute, we wrap them in a
+-- "Delayed" type to compute them only if needed.
+{- HLINT ignore Delayed "Use newtype instead of data" -}
+data Delayed a = Delayed
+  { forceDelayed  :: a
+  }
+  deriving (Generic, Show, Functor)
+
+instance (NFData a) => NFData (Delayed a)
+
+
 type FixSolution  = M.HashMap KVar Expr
+type FixDelayedSolution  = M.HashMap KVar (Delayed Expr)
 
 data Result a = Result
   { resStatus    :: !(FixResult a)
   , resSolution  :: !FixSolution
-  , resNonCutsSolution :: !FixSolution
+  , resNonCutsSolution :: !FixDelayedSolution
   , resSorts     :: !ResultSorts
   }
   deriving (Generic, Show, Functor)
@@ -284,8 +295,8 @@ instance ToHornSMT ScopedExpr where
 scopedResult :: Result a -> ScopedResult
 scopedResult res = MkScopedResult cuts  nonCuts
   where
-    cuts = scoped (resSolution res)
-    nonCuts = scoped (resNonCutsSolution res)
+    cuts = scoped $ resSolution res
+    nonCuts = scoped $ M.map forceDelayed $ resNonCutsSolution res
     scoped sol = MkKVarMap $ M.fromList [ (k, MkScopedExpr (scope k) e) | (k, e) <- M.toList sol]
     scope k = M.lookupDefault [] k $ resSorts res
 

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -24,7 +24,6 @@ module Language.Fixpoint.Types.Substitutions (
   , pprReft
   ) where
 
-import           Data.Either               (rights)
 import           Data.List                 as List
 import           Data.Maybe
 import qualified Data.HashMap.Strict       as M
@@ -224,7 +223,7 @@ rapierSubstExpr s su e0 =
     PKVar k su' -> PKVar k $ catSubstGo su' su
     PAll bs p ->
       let mfs = map (maybeFresh . fst) bs
-          fs = rights mfs
+          fs = map (either (\x -> (x, x)) id) mfs
           su' = List.foldl' (\su1 (x, x') -> extendSubst su1 x (EVar x')) su fs
           bs' = zip (map (either id snd) mfs) (map snd bs)
           s' = foldr (S.insert . fst) s bs'
@@ -232,7 +231,7 @@ rapierSubstExpr s su e0 =
           PAll bs' $ go s' su' p
     PExist bs p ->
       let mfs = map (maybeFresh . fst) bs
-          fs = rights mfs
+          fs = map (either (\x -> (x, x)) id) mfs
           su' = List.foldl' (\su1 (x, x') -> extendSubst su1 x (EVar x')) su fs
           bs' = zip (map (either id snd) mfs) (map snd bs)
           s' = foldr (S.insert . fst) s bs'

--- a/src/Language/Fixpoint/Types/Utils.hs
+++ b/src/Language/Fixpoint/Types/Utils.hs
@@ -31,14 +31,14 @@ import qualified Language.Fixpoint.Misc as Misc
 --------------------------------------------------------------------------------
 -- | Compute the domain of a kvar
 --------------------------------------------------------------------------------
-kvarDomain :: SInfo a -> KVar -> [Symbol]
+kvarDomain :: GInfo c a -> KVar -> [Symbol]
 --------------------------------------------------------------------------------
 kvarDomain si k = domain (bs si) (getWfC si k)
 
 domain :: BindEnv a -> WfC a -> [Symbol]
 domain be wfc = fst3 (wrft wfc) : map fst (envCs be $ wenv wfc)
 
-getWfC :: SInfo a -> KVar -> WfC a
+getWfC :: GInfo c a -> KVar -> WfC a
 getWfC si k = ws si M.! k
 
 --------------------------------------------------------------------------------

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -78,15 +78,16 @@ data SimplificationTest = SimplificationTest
 simplificationTest :: SimplificationTest -> TestTree
 simplificationTest test =
   testCase (name test) $ do
-    let actual = F.showpp (F.simplifyKVar (doParse'' True predP (name test) (input test)))
-    when (unwords (words actual) /= unwords (words (expected test))) $ do
+    let actual = F.simplifyKVar (doParse'' True predP (name test) (input test))
+        expectedE = doParse'' True predP (name test) (expected test)
+    when (not (F.alphaEq actual expectedE)) $ do
       assertFailure $ unlines
         [ "output is not as expected"
         , "Expected:"
         , expected test
         , ""
         , "Actual:"
-        , actual
+        , F.showpp actual
         ]
 
 largeSimplificationTest :: SimplificationTest

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -12,7 +12,7 @@ import Test.Tasty.HUnit
 
 tests :: TestTree
 tests =
-  testGroup "simplifyKVar" $ map simplificationTest 
+  testGroup "simplifyKVar" $ map simplificationTest
     [ SimplificationTest
         { name = "single elimination"
         , expected = """


### PR DESCRIPTION
The non-cut kvar solutions were hidden if --save was not given (#770).

This PR also generalizes a bit `kvarDomain` so it can be used with FInfo queries.

These changes are needed so kvar solutions can be shown in error messages in Liquid Haskell.