### PR TITLE
Remove --no-lazy-ple

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -65,7 +65,6 @@ import           Language.Fixpoint.Parse            (rr')
 import           Language.Fixpoint.Types hiding (GInfo(..), fi)
 import qualified Language.Fixpoint.Types as Types (GInfo(..))
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
-import           Language.Fixpoint.Solver.PLE as PLE (instantiate)
 import           Control.DeepSeq
 import qualified Data.ByteString as B
 import Data.Maybe (catMaybes, isJust)
@@ -266,11 +265,7 @@ simplifyFInfo !cfg !fi0 = do
   -- writeLoud $ "fq file after elaborate: \n" ++ render (toFixpoint cfg si5)
   loudDump 3 cfg si5
   let si6 = if extensionality cfg then {- SCC "expand" -} expand cfg si5 else si5
-  if rewriteAxioms cfg && noLazyPLE cfg
-    then do
-      bs <- PLE.instantiate cfg si6 Nothing Nothing
-      return si6 { Types.bs = bs }
-    else return si6
+  return si6
 
 reduceFInfo :: Fixpoint a => Config -> FInfo a -> IO (FInfo a)
 reduceFInfo cfg fi = do

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -90,7 +90,6 @@ runSolverM cfg sI act =
     -- lar     = linear cfg || Z3 /= solver cfg
     fi       = (siQuery sI) {F.hoInfo = F.cfgHoInfo cfg }
 
-
 --------------------------------------------------------------------------------
 getIter :: SolveM ann Int
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/Monad.hs
+++ b/src/Language/Fixpoint/Solver/Monad.hs
@@ -143,7 +143,7 @@ sendConcreteBindingsToSMT known be act = do
         , not (F.memberIBindEnv i known)
         ]
   st <- get
-  liftSMT $
+  (a, st'') <- liftSMT $
     smtBracket "sendConcreteBindingsToSMT" $ do
       forM_ concretePreds $ \(i, e) ->
         smtDefineFunc (F.bindSymbol (fromIntegral i)) [] F.boolSort e
@@ -151,7 +151,9 @@ sendConcreteBindingsToSMT known be act = do
       let st' = st { ssCtx = ctx }
       (a, st'') <- liftIO $ flip runStateT st' $ act $ F.unionIBindEnv known $ F.fromListIBindEnv $ map fst concretePreds
       put (ssCtx st'')
-      return a
+      return (a, st'')
+  modify $ \st''' -> st'' { ssCtx = ssCtx st''' }
+  return a
   where
     isShortExpr F.PTrue = True
     isShortExpr F.PTop = True

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -54,7 +54,6 @@ import Language.REST.ExploredTerms as ExploredTerms
 import Language.REST.RuntimeTerm as RT
 import Language.REST.SMT (withZ3, SolverHandle)
 
-import           Control.Exception.Base (bracket)
 import           Control.Monad (filterM, foldM, forM_, when, replicateM, zipWithM)
 import           Control.Monad.State
 import           Control.Monad.Trans.Maybe
@@ -80,25 +79,26 @@ mytracepp = notracepp
 -- unfoldings discovered by PLE on the constraints in @subcIds@ (or all
 -- constraints if @subcIds == Nothing@).
 {-# SCC instantiate #-}
-instantiate :: (Loc a) => Config -> SInfo a -> Maybe Solution -> Maybe [SubcId] -> IO (BindEnv a)
+instantiate :: (Loc a) => Config -> SInfo a -> Maybe Solution -> Maybe [SubcId] -> SmtM (BindEnv a)
 instantiate cfg fi' mSol subcIds = do
     let cs = M.filterWithKey
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
                (cm info)
     let t  = mkCTrie (M.toList cs)                                          -- 1. BUILD the Trie
-    res   <- withRESTSolver $ \solver ->
-               withProgress (1 + M.size cs) $
-               withCtx cfg file sEnv (defns fi') $
-               do env <- instEnv cfg info mSol cs solver
-                  pleTrie t env                                             -- 2. TRAVERSE Trie to compute InstRes
+    res   <- withRESTSolver $ \solver -> do
+               ctx <- get
+               (res, ctx') <- liftIO $ withProgressM (`runStateT` ctx) (1 + M.size cs) $ do
+                 env <- instEnv cfg info mSol cs solver
+                 pleTrie t env                                              -- 2. TRAVERSE Trie to compute InstRes
+               put ctx'
+               return res
     liftIO $ savePLEEqualities cfg info sEnv res
     return $ resSInfo cfg sEnv info res                                     -- 3. STRENGTHEN SInfo using InstRes
   where
-    withRESTSolver :: (Maybe SolverHandle -> IO a) -> IO a
+    withRESTSolver :: (Maybe SolverHandle -> SmtM a) -> SmtM a
     withRESTSolver f | all null (M.elems $ aenvAutoRW aEnv) = f Nothing
     withRESTSolver f = withZ3 (f . Just)
 
-    file = srcFile cfg ++ ".evals"
     sEnv = symbolEnv cfg info
     aEnv = ae info
     info = normalize fi'
@@ -541,7 +541,7 @@ updCtx InstEnv{..} ieSMT ictx delta cidMb mCTrie =
     cands     = rhs:es
     anfBinds  = bs : icANFs ictx
     econsts   = M.fromList $ findConstants ieKnowl es
-    ctxEqs    = fmap (toSMT "updCtx" ieCfg ieSMT []) $ L.nub $ filter (null . Vis.kvarsExpr)
+    ctxEqs    = toSMT "updCtx" ieCfg ieSMT [] <$> L.nub
                   [ c | xr <- bs, c <- conjuncts (expr xr), not (isTautoPred c) ]
     bs        = second unApplySortedReft <$> binds
     rhs       = unApply eRhs
@@ -1441,14 +1441,6 @@ partitionUserDataConstructorSelectors dds rws = L.partition isSelector rws
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
-
-withCtx :: Config -> FilePath -> SymEnv -> DefinedFuns -> SmtM a -> IO a
-withCtx cfg file env defns k =
-  bracket acquire release $
-    evalStateT $ SMT.smtBracket "withCtx" k
-  where
-    acquire = SMT.makeContextWithSEnv cfg file env defns
-    release = SMT.cleanupContext
 
 -- (sel_i, D, i), meaning sel_i (D x1 .. xn) = xi,
 -- i.e., sel_i selects the ith value for the data constructor D

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -149,7 +149,7 @@ solve_ cfg fi s2 wkl = do
 
   res2  <- case resStatus res1 of  {- then run normal PLE on remaining unsolved constraints -}
     Unsafe _ bads2 | rewriteAxioms cfg -> do
-      bs <- liftIO $ PLE.instantiate cfg fi1 (Just s3) (Just $ map fst bads2)
+      bs <- liftSMT $ PLE.instantiate cfg fi1 (Just s3) (Just $ map fst bads2)
       -- Check the constraints one last time after PLE
       let fi2 = fi { F.bs = bs }
           badsCs2 = lookupCMap (F.cm fi) <$> map fst bads2

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -112,7 +112,6 @@ data Config = Config
   , rwTermination    :: Bool        -- ^ Enable termination checking for rewriting
   , stdin               :: Bool        -- ^ Read input query from stdin
   , json                :: Bool        -- ^ Render output in JSON format
-  , noLazyPLE           :: Bool
   , fuel                :: Maybe Int   -- ^ Maximum PLE "fuel" (unfold depth) (default=infinite)
   , restOrdering        :: String      -- ^ Term ordering for use in REST
   , noSmtHorn           :: Bool        -- ^ Do not use (new) SMTLIB horn parser
@@ -280,7 +279,6 @@ defConfig = Config {
   , rwTermination       = False   &= help "Enable rewrite divergence checker"
   , stdin                    = False   &= help "Read input query from stdin"
   , json                     = False   &= help "Render result in JSON"
-  , noLazyPLE                = False   &= help "Don't use lazy PLE"
   , fuel                     = Nothing &= help "Maximum fuel (per-function unfoldings) for PLE"
   , restOrdering             = "rpo"   &= help "Ordering Constraint Algebra to use for REST"
   , noSmtHorn                = False &= help "Do not use SMTLIB horn format"

--- a/unix/Language/Fixpoint/Utils/Progress.hs
+++ b/unix/Language/Fixpoint/Utils/Progress.hs
@@ -2,6 +2,7 @@
 -- | Progress Bar API
 module Language.Fixpoint.Utils.Progress (
       withProgress
+    , withProgressM
     , progressInit
     , progressTick
     , progressClose
@@ -22,7 +23,10 @@ pbRef :: IORef (Maybe ProgressBar)
 pbRef = unsafePerformIO (newIORef Nothing)
 
 withProgress :: Int -> IO a -> IO a
-withProgress n act = do
+withProgress = withProgressM id
+
+withProgressM :: (m a -> IO b) -> Int -> m a -> IO b
+withProgressM mToIO n act = do
   showBar <- (Quiet /=) <$> getVerbosity
   -- We don't show the progress bar if the output is not a terminal.
   -- Besides improving the output, this also avoids a concurrency
@@ -33,10 +37,10 @@ withProgress n act = do
     then displayConsoleRegions $ do
       -- putStrLn $ "withProgress: " ++ show n
       progressInit n
-      r <- act
+      r <- mToIO act
       progressClose
       return r
-    else act
+    else mToIO act
 
 progressInit :: Int -> IO ()
 progressInit n = do

--- a/win/Language/Fixpoint/Utils/Progress.hs
+++ b/win/Language/Fixpoint/Utils/Progress.hs
@@ -1,6 +1,7 @@
 -- | Progress Bar API
 module Language.Fixpoint.Utils.Progress (
       withProgress
+    , withProgressM
     , progressInit
     , progressTick
     , progressClose
@@ -8,6 +9,9 @@ module Language.Fixpoint.Utils.Progress (
 
 withProgress :: Int -> IO a -> IO a
 withProgress _ x = x
+
+withProgressM :: (m a -> IO b) -> Int -> m a -> IO b
+withProgressM f _ = f
 
 progressInit :: Int -> IO ()
 progressInit _ = return ()


### PR DESCRIPTION
--no-lazy-ple causes PLE to run before kvar solving (FUSION).

This feature is tested in only one test (benchmarks/sf/Lists.hs), which is actually slower to verify when compared to the regular PLE.

This PR is also using the same SMT solver process for FUSION and PLE. This simplifies handling of apply symbols in the solver state which was not aware of multiple solver instances.

Lastly, the PR includes a fix after #812 had sendConcreteBindingsInSMT drop stats in the solver state.