### PR TITLE
Improve debugging of smt solver queries

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -957,7 +957,7 @@ bops cmpFun = List.foldl' (flip addOperator) initOpTable builtinOps
                  , FInfix  (Just 4) ">"   (Just $ const $ PAtom Gt)  AssocNone
                  , FInfix  (Just 4) ">="  (Just $ const $ PAtom Ge)  AssocNone
 
-                 , FInfix  (Just 3) "&&"  (Just $ const $ \x y -> pAnd [x,y]) AssocRight
+                 , FInfix  (Just 3) "&&"  (Just $ const $ \x y -> PAnd [x,y]) AssocRight
                  , FInfix  (Just 2) "||"  (Just $ const $ \x y -> POr [x,y]) AssocRight
                  , FInfix  (Just 1) "=>"  (Just $ const PImp) AssocRight
                  , FInfix  (Just 1) "==>" (Just $ const PImp) AssocRight

--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -52,6 +52,7 @@ module Language.Fixpoint.Smt.Interface (
     , smtBracket, smtBracketAt
     , smtDistinct
     , smtPush, smtPop
+    , smtComment
 
     -- * Check Validity
     , checkValid
@@ -403,6 +404,9 @@ smtPush, smtPop :: SmtM ()
 smtPush = interact' Push
 smtPop  = interact' Pop
 
+smtComment :: T.Text -> SmtM ()
+smtComment t = interact' (Comment t)
+
 smtDecls :: [(Symbol, Sort)] -> SmtM ()
 smtDecls = mapM_ $ uncurry smtDecl
 
@@ -467,7 +471,8 @@ smtBracketAt sp _msg a =
 -- | `smtBracket` adds a new level to the apply stack and saves the last fresh index
 --   on the index stack before the action, and reverts these changes after the action.
 smtBracket :: String -> SmtM a -> SmtM a
-smtBracket _msg a = do
+smtBracket msg a = do
+  smtComment (T.pack $ "smtBracket - start: " ++ msg)
   smtPush
   modify $ \ctx ->
     let env = ctxSymEnv ctx in
@@ -475,6 +480,7 @@ smtBracket _msg a = do
         , ctxIxs = seIx env : ctxIxs ctx}
   r <- a
   smtPop
+  smtComment (T.pack $ "smtBracket - end: " ++ msg)
   modify $ \ctx ->
     let env = ctxSymEnv ctx
         (i , is) = fromMaybe (0, []) (uncons $ ctxIxs ctx)

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -318,6 +318,7 @@ instance SMTLIB2 Command where
   smt2     (CMany cmds)        = smt2s cmds
   smt2     Exit                = pure "(exit)"
   smt2     SetMbqi             = pure "(set-option :smt.mbqi true)"
+  smt2     (Comment t)         = pure $ fromText ("; " <> t <> "\n")
 
 instance SMTLIB2 (Triggered Expr) where
   smt2 (TR NoTrigger e)       = smt2 e

--- a/src/Language/Fixpoint/Smt/Types.hs
+++ b/src/Language/Fixpoint/Smt/Types.hs
@@ -67,6 +67,7 @@ data Command      = Push
                   | Distinct [Expr] -- {v:[Expr] | 2 <= len v}
                   | GetValue [Symbol]
                   | CMany    [Command]
+                  | Comment T.Text
                   deriving (Eq, Show)
 
 instance PPrint Command where
@@ -89,6 +90,7 @@ ppCmd (AssertAx _)  = text "AssertAxiom ..."
 ppCmd Distinct {} = text "Distinct ..."
 ppCmd GetValue {} = text "GetValue ..."
 ppCmd CMany {}    = text "CMany ..."
+ppCmd (Comment t) = text ("; " ++ T.unpack t)
 
 -- | Responses received from SMT engine
 data Response     = Ok

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -436,7 +436,7 @@ alphaEq = go (mkSubst [])
 -- @isVarEq fvs e@ yields @(Just (v, e'), e)@ if @v@ is in @fvs@, and @e@ has
 -- the form @v == e'@.
 isVarEq :: [Symbol] -> Expr -> (Maybe (Symbol, Expr), Expr)
-isVarEq fvs ei0 = case unElab ei0 of
+isVarEq fvs ei0 = case ei0 of
   PAtom brel e0 e1
     | isEqRel brel ->
       let m = do
@@ -456,13 +456,7 @@ isVarEq fvs ei0 = case unElab ei0 of
 
     -- | @isVarIn s fvs@ yields @Just s@ if @s@ is a variable and it is in
     -- @fvs@.
-    --
-    -- It also ignores @cast_as_int@ coercions, so that
-    --
-    -- > isVarIn (cast_as_int s) fvs == isVarIn s fvs
-    --
     isVarIn :: Expr -> [Symbol] -> Maybe Symbol
-    isVarIn (EApp (EVar "cast_as_int") ei) vs = isVarIn ei vs
     isVarIn (EVar s) vs
       | elem s vs = Just s
     isVarIn _ _vs = Nothing

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DoAndIfThenElse     #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
 
 module Language.Fixpoint.Solver (
     -- * Invoke Solver on an FInfo
@@ -23,25 +22,17 @@ module Language.Fixpoint.Solver (
 
     -- * Simplified Info
   , simplifyFInfo
-
-    -- * Simplify KVar solutions
-  , simplifyKVar
-
-    -- * Exported for testing
-  , alphaEq
 ) where
 
 import           Control.Concurrent                 (setNumCapabilities)
 import qualified Data.HashMap.Strict              as HashMap
-import qualified Data.HashSet                     as S
-import qualified Data.List                        as List
 import qualified Data.Store                       as S
 import           Data.Aeson                         (ToJSON, encode)
 import qualified Data.Text.Lazy.IO                as LT
 import qualified Data.Text.Lazy.Encoding          as LT
 import           System.Exit                        (ExitCode (..))
 import           System.Console.CmdArgs.Verbosity   (whenNormal, whenLoud)
-import           Control.Monad                      (guard, mplus, when)
+import           Control.Monad                      (when)
 import           Control.Exception                  (catch)
 import           Control.Exception.Compat
     (ExceptionWithContext(..), displayExceptionContext, wrapExceptionWithContext)
@@ -55,6 +46,7 @@ import           Language.Fixpoint.Solver.Extensionality (expand)
 import           Language.Fixpoint.Solver.Prettify (savePrettifiedQuery)
 import           Language.Fixpoint.Solver.UniqifyKVars (wfcUniqify)
 import qualified Language.Fixpoint.Solver.Solve     as Sol
+import qualified Language.Fixpoint.Solver.Solution  as Sol
 import           Language.Fixpoint.Types.Config
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files            hiding (Result)
@@ -67,7 +59,7 @@ import qualified Language.Fixpoint.Types as Types (GInfo(..))
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
 import           Control.DeepSeq
 import qualified Data.ByteString as B
-import Data.Maybe (catMaybes, isJust)
+import Data.Maybe (catMaybes)
 import qualified Text.PrettyPrint.HughesPJ as PJ
 
 ---------------------------------------------------------------------------
@@ -334,129 +326,7 @@ simplifyResult cfg res =
       , resNonCutsSolution = HashMap.map (fmap simplifyKVar') (resNonCutsSolution res)
       }
   where
-    simplifyKVar' = unElabSets . unElab . simplifyKVar
+    simplifyKVar' = unElabSets . unElab . Sol.simplifyKVar
     sets          = elabSetBag . solverFlags . solver $ cfg
     unElabSets    = if sets then unElabFSetBagZ3 else id
 
-
--- | Simplifies existential expressions with unused or inconsequential bindings.
---
--- For instance, in the following example, "x" is not used at all.
---
--- > simplifyKVar "exists x y. y == z && y == C"
--- >   ==
--- > "exists y. y == z && y == C"
---
--- And in the following example, @x@ is used but in a way that doesn't
--- contribute any useful knowledge.
---
--- > simplifyKVar "exists x y. x == C && y == z && y == C"
--- >   ==
--- > "exists y. y == z && y == C"
---
--- Therefore we eliminate variables that appear in equalities via substitutions.
---
--- > simplifyKVar "exists x y. x == C && P && Q y"
--- >   ==
--- > "exists y. (P && Q y)[x:=C]"
---
-simplifyKVar :: Expr -> Expr
-simplifyKVar =
-   pAnd . dedupByAlphaEq . floatPExistConjuncts . go
-  where
-    go (POr es) = pOr $ map (pAnd . floatPExistConjuncts . go) es
-    go (PAnd es) = pAnd $ dedupByAlphaEq $ concatMap (floatPExistConjuncts . go) es
-    go (PExist bs e0) =
-      let es = concatMap (floatPExistConjuncts . go) (conjuncts e0)
-       in elimExistentialBinds (PExist bs (pAnd es))
-    go e = e
-
-    dedupByAlphaEq :: [Expr] -> [Expr]
-    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
-
-    elimExistentialBinds (PExist bs0 (PExist bs1 p)) =
-      let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
-       in elimExistentialBinds (PExist (bs0' ++ bs1) p)
-    elimExistentialBinds (PExist bs e0) =
-      let es = conjuncts e0
-          esv = map (isVarEq (map fst bs)) es
-          -- Eliminating multiple variables at once can be difficult if the
-          -- equalities define cyclic dependencies, so we only eliminate one
-          -- variable at a time.
-          esvElim = take 1 [ (x, v) | (Just (x, v), _) <- esv ]
-          esvKeep =
-            let (xs, ys) = break (isJust . fst) esv
-             in map snd (xs ++ drop 1 ys)
-          su = mkSubst esvElim
-          e' = rapierSubstExpr (substSymbolsSet su) su $ pAnd esvKeep
-          bs' = filter ((`S.member` exprSymbolsSet e') . fst) bs
-          e'' = pExist bs' e'
-       in
-          if null esvElim then e'' else elimExistentialBinds e''
-    elimExistentialBinds e = e
-
-    -- | Float out conjuncts from an existential expression that does not
-    -- depend on the existentially bound variables.
-    floatPExistConjuncts :: Expr -> [Expr]
-    floatPExistConjuncts e0@(PExist bs es0) =
-      let es = conjuncts es0
-          (floatable, nonFloatable) =
-           List.partition (isFloatableConjunct (S.fromList (map fst bs))) es
-       in
-          if null floatable then
-            [e0]
-          else
-            elimExistentialBinds (pExist bs (pAndNoDedup nonFloatable)) : floatable
-      where
-        isFloatableConjunct :: S.HashSet Symbol -> Expr -> Bool
-        isFloatableConjunct s e = S.null $ S.intersection (exprSymbolsSet e) s
-    floatPExistConjuncts e = [e]
-
--- | Determine if two expressions are alpha-equivalent.
---
--- Doesn't handle all cases, just enough for simplifying KVars which requires
--- alpha-equivalence checking of existentially quantified expressions.
-alphaEq :: Expr -> Expr -> Bool
-alphaEq = go (mkSubst [])
-  where
-    go :: Subst -> Expr -> Expr -> Bool
-    go su (PExist bs1 x1) (PExist bs2 x2) =
-      let su' = List.foldl' (\s (v1, v2) -> extendSubst s v1 (EVar v2)) su (zip (map fst bs1) (map fst bs2))
-       in go su' x1 x2
-    go su (PAnd es1) (PAnd es2) =
-      length es1 == length es2 && and (zipWith (go su) es1 es2)
-    go su (POr es1) (POr es2) =
-      length es1 == length es2 && and (zipWith (go su) es1 es2)
-    go su e1 e2 =
-      subst su e1 == e2
-
--- | Determine if the expression is an equality that sets the value of
--- a variable in the given set.
---
--- @isVarEq fvs e@ yields @(Just (v, e'), e)@ if @v@ is in @fvs@, and @e@ has
--- the form @v == e'@.
-isVarEq :: [Symbol] -> Expr -> (Maybe (Symbol, Expr), Expr)
-isVarEq fvs ei0 = case ei0 of
-  PAtom brel e0 e1
-    | isEqRel brel ->
-      let m = do
-            (v, ei) <- ((,e1) <$> isVarIn e0 fvs) `mplus`
-                       ((,e0) <$> isVarIn e1 fvs)
-            () <- guard (not (S.member v (exprSymbolsSet ei)))
-            return (v, ei)
-       in (m, ei0)
-  _ ->
-    (Nothing, ei0)
-  where
-    -- | Tells if the binary relation is an equality.
-    isEqRel :: Brel -> Bool
-    isEqRel Eq = True
-    isEqRel Ueq = True
-    isEqRel _ = False
-
-    -- | @isVarIn s fvs@ yields @Just s@ if @s@ is a variable and it is in
-    -- @fvs@.
-    isVarIn :: Expr -> [Symbol] -> Maybe Symbol
-    isVarIn (EVar s) vs
-      | elem s vs = Just s
-    isVarIn _ _vs = Nothing

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -534,15 +534,21 @@ updCtx InstEnv{..} ieSMT ictx delta cidMb mCTrie =
            , icFreshExistentialCounter = existentialCounter
            , icInitialLHSs = M.unionWith S.union candsPerExScopeNoRHS (icInitialLHSs ictx)
            }
-    , S.toList $ S.fromList $ concat $ M.keys candsPerExScope
+    , ebs
     )
   where
+    ebs = concat (M.keys candsPerExScope)
     ibinds = insertsIBindEnv delta (icBindIds ictx)
     cands     = rhs:es
     anfBinds  = bs : icANFs ictx
     econsts   = M.fromList $ findConstants ieKnowl es
-    ctxEqs    = toSMT "updCtx" ieCfg ieSMT [] <$> L.nub
-                  [ c | xr <- bs, c <- conjuncts (expr xr), not (isTautoPred c) ]
+    ctxEqs    = toSMT "updCtx" ieCfg ieSMT ebs <$> L.nub
+                  [ c
+                  | (_, s) <- drop 1 deANFedCands
+                  , e <- S.toList s
+                  , c <- conjuncts e
+                  , not (isTautoPred c)
+                  ]
     bs        = second unApplySortedReft <$> binds
     rhs       = unApply eRhs
     es        = expr <$> bs
@@ -558,6 +564,7 @@ updCtx InstEnv{..} ieSMT ictx delta cidMb mCTrie =
     newLRWs   = Mb.mapMaybe (`lookupLocalRewrites` ieLRWs) delta
 
     candsPerExScopeNoRHS = M.fromListWith S.union $ ([], S.empty) : drop 1 deANFedCands
+    -- ebs expects all keys to contain disjoint sets of bindings
     candsPerExScope = M.unionWith S.union candsPerExScopeNoRHS $ M.fromListWith S.union (take 1 deANFedCands)
 
     deANFedCands = map (second S.singleton . prenexExistentials) $

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wwarn #-}
 
 module Language.Fixpoint.Solver.Solution
   ( -- * Create Initial Solution
@@ -17,13 +19,18 @@ module Language.Fixpoint.Solver.Solution
   , lhsPred
 
   , nonCutsResult
+
+    -- * Exported for Testing
+  , simplifyKVar
+  , alphaEq
   ) where
 
 import           Control.Arrow (second, (***))
-import           Control.Monad                  (guard)
+import           Control.Monad                  (guard, mplus)
 import           Control.Monad.Reader
 import qualified Data.HashSet                   as S
 import qualified Data.HashMap.Strict            as M
+import qualified Data.List                      as List
 import           Data.Maybe                     (maybeToList, isJust, isNothing)
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Types.Visitor      as V
@@ -487,3 +494,135 @@ appendTags ts ts' = Misc.sortNub (ts ++ ts')
 extendKInfo :: KInfo -> F.Tag -> KInfo
 extendKInfo ki t = ki { kiTags  = appendTags [t] (kiTags  ki)
                       , kiDepth = 1  +            kiDepth ki }
+
+-- | Simplifies existential expressions with unused or inconsequential bindings.
+--
+-- Simplification is helpful for human readability of solutions. It makes easier
+-- reporting errors. Sometimes it can be useful for debugging if run on queries
+-- sent to the SMT solver. We don't do that by default because some benchmarks
+-- show a slowdown in some cases.
+--
+-- For instance, in the following example, "x" is not used at all.
+--
+-- > simplifyKVar "exists x y. y == z && y == C"
+-- >   ==
+-- > "exists y. y == z && y == C"
+--
+-- And in the following example, @x@ is used but in a way that doesn't
+-- contribute any useful knowledge.
+--
+-- > simplifyKVar "exists x y. x == C && y == z && y == C"
+-- >   ==
+-- > "exists y. y == z && y == C"
+--
+-- Therefore we eliminate variables that appear in equalities via substitutions.
+--
+-- > simplifyKVar "exists x y. x == C && P && Q y"
+-- >   ==
+-- > "exists y. (P && Q y)[x:=C]"
+--
+simplifyKVar :: F.Expr -> F.Expr
+simplifyKVar = F.conj . dedupByAlphaEq . floatPExistConjuncts . go
+  where
+    go (F.POr es) = disj $ map (F.conj . floatPExistConjuncts . go) es
+    go (F.PAnd es) = F.conj $ dedupByAlphaEq $ concatMap (floatPExistConjuncts . go) es
+    go (F.PExist bs e0) =
+      let es = concatMap (floatPExistConjuncts . go) (F.conjuncts e0)
+       in elimExistentialBinds (F.PExist bs (F.conj es))
+    go e = e
+
+    dedupByAlphaEq :: [F.Expr] -> [F.Expr]
+    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
+
+    disj :: [F.Expr] -> F.Expr
+    disj [] = F.PFalse
+    disj [e] = e
+    disj es = F.POr es
+
+    elimExistentialBinds (F.PExist bs0 (F.PExist bs1 p)) =
+      let bs0' = filter (\(x,_) -> x `notElem` map fst bs1) bs0
+       in elimExistentialBinds (F.PExist (bs0' ++ bs1) p)
+    elimExistentialBinds (F.PExist bs e0) =
+      let es = F.conjuncts e0
+          esv = map (isVarEq (map fst bs)) es
+          -- Eliminating multiple variables at once can be difficult if the
+          -- equalities define cyclic dependencies, so we only eliminate one
+          -- variable at a time.
+          esvElim = take 1 [ (x, v) | (Just (x, v), _) <- esv ]
+          esvKeep =
+            let (xs, ys) = break (isJust . fst) esv
+             in map snd (xs ++ drop 1 ys)
+          su = F.mkSubst esvElim
+          e' = F.rapierSubstExpr (F.substSymbolsSet su) su $ F.conj esvKeep
+          bs' = filter ((`S.member` F.exprSymbolsSet e') . fst) bs
+          e'' = F.pExist bs' e'
+       in
+          if null esvElim then e'' else elimExistentialBinds e''
+    elimExistentialBinds e = e
+
+    -- | Float out conjuncts from an existential expression that does not
+    -- depend on the existentially bound variables.
+    floatPExistConjuncts :: F.Expr -> [F.Expr]
+    floatPExistConjuncts e0@(F.PExist bs es0) =
+      let es = F.conjuncts es0
+          (floatable, nonFloatable) =
+           List.partition (isFloatableConjunct (S.fromList (map fst bs))) es
+       in
+          if null floatable then
+            [e0]
+          else
+            elimExistentialBinds (F.pExist bs (F.conj nonFloatable)) : floatable
+      where
+        isFloatableConjunct :: S.HashSet F.Symbol -> F.Expr -> Bool
+        isFloatableConjunct s e = S.null $ S.intersection (F.exprSymbolsSet e) s
+    floatPExistConjuncts e = [e]
+
+-- | Determine if two expressions are alpha-equivalent.
+--
+-- Doesn't handle all cases, just enough for simplifying KVars which requires
+-- alpha-equivalence checking of existentially quantified expressions.
+alphaEq :: F.Expr -> F.Expr -> Bool
+alphaEq = go (F.mkSubst [])
+  where
+    go :: F.Subst -> F.Expr -> F.Expr -> Bool
+    go su (F.PExist bs1 x1) (F.PExist bs2 x2) =
+      let su' = List.foldl' (\s (v1, v2) -> F.extendSubst s v1 (F.EVar v2)) su (zip (map fst bs1) (map fst bs2))
+       in go su' x1 x2
+    go su (F.PAnd es1) (F.PAnd es2) =
+      length es1 == length es2 && and (zipWith (go su) es1 es2)
+    go su (F.POr es1) (F.POr es2) =
+      length es1 == length es2 && and (zipWith (go su) es1 es2)
+    go su e1 e2 =
+      F.subst su e1 == e2
+
+-- | Determine if the expression is an equality that sets the value of
+-- a variable in the given set.
+--
+-- @isVarEq fvs e@ yields @(Just (v, e'), e)@ if @v@ is in @fvs@, and @e@ has
+-- the form @v == e'@.
+isVarEq :: [F.Symbol] -> F.Expr -> (Maybe (F.Symbol, F.Expr), F.Expr)
+isVarEq fvs ei0 = case ei0 of
+  F.PAtom brel e0 e1
+    | isEqRel brel ->
+      let m :: Maybe (F.Symbol, F.Expr)
+          m = do
+            (v, ei) <- ((,e1) <$> isVarIn e0 fvs) `mplus`
+                       ((,e0) <$> isVarIn e1 fvs)
+            () <- guard (not (S.member v (F.exprSymbolsSet ei)))
+            return (v, ei)
+       in (m, ei0)
+  _ ->
+    (Nothing, ei0)
+  where
+    -- | Tells if the binary relation is an equality.
+    isEqRel :: F.Brel -> Bool
+    isEqRel F.Eq = True
+    isEqRel F.Ueq = True
+    isEqRel _ = False
+
+    -- | @isVarIn s fvs@ yields @Just s@ if @s@ is a variable and it is in
+    -- @fvs@.
+    isVarIn :: F.Expr -> [F.Symbol] -> Maybe F.Symbol
+    isVarIn (F.EVar s) vs
+      | elem s vs = Just s
+    isVarIn _ _vs = Nothing

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -475,11 +475,11 @@ instance Monoid KInfo where
   mempty  = KI [] 0 1
   mappend = (<>)
 
-mplus :: KInfo -> KInfo -> KInfo
-mplus ki ki' = (mappend ki ki') { kiCubes = kiCubes ki + kiCubes ki'}
+mplusKInfo :: KInfo -> KInfo -> KInfo
+mplusKInfo ki ki' = (mappend ki ki') { kiCubes = kiCubes ki + kiCubes ki'}
 
 mconcatPlus :: [KInfo] -> KInfo
-mconcatPlus = foldr mplus mempty
+mconcatPlus = foldr mplusKInfo mempty
 
 appendTags :: [Tag] -> [Tag] -> [Tag]
 appendTags ts ts' = Misc.sortNub (ts ++ ts')

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -39,6 +39,7 @@ import qualified Data.HashSet        as S
 -- import qualified Data.Maybe          as Mb
 import qualified Data.List           as L
 import Language.Fixpoint.Types (resStatus, FixResult(Unsafe))
+import Language.Fixpoint.Smt.Interface (smtComment)
 import Language.Fixpoint.Solver.Interpreter (instInterpreter)
 import qualified Language.Fixpoint.Solver.PLE as PLE      (instantiate)
 import Data.Maybe (maybeToList)
@@ -132,6 +133,7 @@ solve_ :: (NFData a, F.Fixpoint a, F.Loc a)
        -> SolveM a (F.Result (Integer, a), Stats)
 --------------------------------------------------------------------------------
 solve_ cfg fi s2 wkl = do
+  liftSMT $ smtComment "solve: start"
   (s3, res0) <- sendConcreteBindingsToSMT F.emptyIBindEnv (F.bs fi) $ \bindingsInSmt -> do
     -- let s3   = solveEbinds fi s2
     s3       <- {- SCC "sol-refine" -} refine bindingsInSmt (F.bs fi) s2 wkl
@@ -140,23 +142,28 @@ solve_ cfg fi s2 wkl = do
 
   (fi1, res1) <- case resStatus res0 of  {- first run the interpreter -}
     Unsafe _ bads | rewriteAxioms cfg && interpreter cfg -> do
+      liftSMT $ smtComment "solve: interpreter"
       bs <- doInterpret cfg fi (map fst $ mytrace ("before the Interpreter " ++ show (length bads) ++ " constraints remain") bads)
       let fi1 = fi { F.bs = bs }
           badCs = lookupCMap (F.cm fi) <$> map fst bads
+      liftSMT $ smtComment "solve: pos-interpreter check"
       fmap (fi1,) $ sendConcreteBindingsToSMT F.emptyIBindEnv bs $ \bindingsInSmt ->
         result bindingsInSmt cfg fi1 badCs s3
     _ -> return  (fi, mytrace "all checked before interpreter" res0)
 
   res2  <- case resStatus res1 of  {- then run normal PLE on remaining unsolved constraints -}
     Unsafe _ bads2 | rewriteAxioms cfg -> do
+      liftSMT $ smtComment "solve: ple"
       bs <- liftSMT $ PLE.instantiate cfg fi1 (Just s3) (Just $ map fst bads2)
       -- Check the constraints one last time after PLE
       let fi2 = fi { F.bs = bs }
           badsCs2 = lookupCMap (F.cm fi) <$> map fst bads2
+      liftSMT $ smtComment "solve: pos-ple check"
       sendConcreteBindingsToSMT F.emptyIBindEnv bs $ \bindingsInSmt ->
         result bindingsInSmt cfg fi2 badsCs2 s3
     _ -> return $ mytrace "all checked with interpreter" res1
 
+  liftSMT $ smtComment "solve: finished"
   st      <- stats
   let res3 = {- SCC "sol-tidy" -} tidyResult cfg res2
   return $!! (res3, st)

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -36,8 +36,8 @@ tests =
     , SimplificationTest
         { name = "alpha equivalence"
         , expected = """
-            (exists [w : int, z : int] . P w z) &&
-            (exists [w : int, z : int] . Q w z)
+            (exists [w : int, z : int] . Q w z) &&
+            (exists [w : int, z : int] . P w z)
           """
         , input = """
             (exists [w : int, z : int] . Q w z) &&
@@ -49,7 +49,7 @@ tests =
     , SimplificationTest
         { name = "floating"
         , expected = """
-            A == C && (exists [x : int, y : int] . P x y)
+            (exists [x : int, y : int] . P x y) && A == C
           """
         , input = """
             exists [x : int, y : int] . A == C && P x y

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -5,7 +5,7 @@ module SimplifyKVarTests (tests) where
 import Control.Monad (when)
 import Language.Fixpoint.Parse
 import qualified Language.Fixpoint.Types as F
-import qualified Language.Fixpoint.Solver as F
+import qualified Language.Fixpoint.Solver.Solution as F
 import Test.Tasty
 import Test.Tasty.HUnit
 


### PR DESCRIPTION
* The .smt2 logging output is annotated with comments that relate it to the code
* simplifyKVar now can be used for SMT queries (it used to call unElab). This is useful for debugging.
* The parser doesn't do simplification before returning expressions. I think I introduced such simplifications accidentally.
* The logging output of PLE is slightly simpler now, as some assertions have less existentials.