### PR TITLE
Debugging improvements

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -798,7 +798,7 @@ expr0P =
     <|> try (coerceP exprP) -- coercion, starts with "coerce"
     <|> litP
     <|> lamP -- lambda abstraction, starts with backslash
-    <|> (reservedOp "&&" >> pAnd <$> predsP) -- built-in prefix and
+    <|> (reservedOp "&&" >> PAnd <$> predsP) -- built-in prefix and
     <|> (reservedOp "||" >> POr  <$> predsP) -- built-in prefix or
 
 emptyListP :: Located () -> ParserV v (ExprV v)
@@ -1134,7 +1134,7 @@ existP = do
 
 -- | Refa
 refaP :: ParseableV v => ParserV v (ExprV v)
-refaP =  try (pAnd <$> brackets (sepBy exprP semi))
+refaP =  try (PAnd <$> brackets (sepBy exprP semi))
      <|> exprP
 
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1019,6 +1019,7 @@ lamP
        t <- sortP
        reservedOp "->"
        ELam (x, t) <$> exprP
+      <?> "lambda abstraction"
 
 varSortP :: ParserV v Sort
 varSortP  = FVar  <$> parens (fromInteger <$> integerP)

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -1021,7 +1021,7 @@ lamP
        ELam (x, t) <$> exprP
 
 varSortP :: ParserV v Sort
-varSortP  = FVar  <$> parens intP
+varSortP  = FVar  <$> parens (fromInteger <$> integerP)
 
 -- | Parser for function sorts without the "func" keyword.
 funcSortP :: ParserV v Sort
@@ -1372,6 +1372,11 @@ envP  = do binds <- brackets $ sepBy (intP <* spaces) semi
 
 intP :: ParserV v Int
 intP = fromInteger <$> natural
+
+integerP :: ParserV v Integer
+integerP =
+        (try (char '-') >> negate <$> natural)
+    <|> natural
 
 boolP :: Parser Bool
 boolP = (reserved "True" >> return True)

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -26,6 +26,7 @@ module Language.Fixpoint.Solver (
 
 import           Control.Concurrent                 (setNumCapabilities)
 import qualified Data.HashMap.Strict              as HashMap
+import qualified Data.HashSet                     as HashSet
 import qualified Data.Store                       as S
 import           Data.Aeson                         (ToJSON, encode)
 import qualified Data.Text.Lazy.IO                as LT
@@ -335,6 +336,6 @@ simplifyResult cfg res =
       , resNonCutsSolution = HashMap.map (fmap simplifyKVar') (resNonCutsSolution res)
       }
   where
-    simplifyKVar' = unElabSets . unElab . Sol.simplifyKVar
+    simplifyKVar' = unElabSets . unElab . Sol.simplifyKVar HashSet.empty
     sets          = elabSetBag . solverFlags $ cfg
     unElabSets    = if sets then unElabFSetBagZ3 else id

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -33,7 +33,7 @@ import qualified Data.Text.Lazy.Encoding          as LT
 import           System.Exit                        (ExitCode (..))
 import           System.Console.CmdArgs.Verbosity   (whenNormal, whenLoud)
 import           Control.Monad                      (when)
-import           Control.Exception                  (catch)
+import           Control.Exception                  (SomeException, catch)
 import           Control.Exception.Compat
     (ExceptionWithContext(..), displayExceptionContext, wrapExceptionWithContext)
 import           Language.Fixpoint.Solver.EnvironmentReduction
@@ -184,7 +184,9 @@ solveNative, solveNative'
 --------------------------------------------------------------------------------
 solveNative !cfg !fi0 = solveNative' cfg fi0
                           `catch`
-                             (return . crashResult (errorMap fi0). wrapExceptionWithContext)
+                             (return . crashResult (errorMap fi0) . wrapExceptionWithContext)
+                          `catch`
+                             (return . crashResultOther . wrapExceptionWithContext)
 
 crashResult :: (PPrint a) => ErrorMap a -> ExceptionWithContext Error -> Result (Integer, a)
 crashResult m (ExceptionWithContext ectx ex) = Result res mempty mempty mempty
@@ -196,6 +198,15 @@ crashResult m (ExceptionWithContext ectx ex) = Result res mempty mempty mempty
     msg0 | null ers = "Sorry, unexpected panic in liquid-fixpoint!\n"
                        ++ showpp ex
          | otherwise = showpp ex
+
+crashResultOther
+  :: ExceptionWithContext SomeException -> Result (Integer, a)
+crashResultOther (ExceptionWithContext ectx ex) =
+    Result res mempty mempty mempty
+  where
+    res = Crash [] msg
+    msg = displayExceptionContext ectx ++ "\n" ++ msg0
+    msg0 = "Sorry, unexpected panic in liquid-fixpoint!\n" ++ show ex
 
 -- | Unpleasant hack to save meta-data that can be recovered from SrcSpan
 type ErrorMap a = HashMap.HashMap SrcSpan a

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -528,18 +528,22 @@ extendKInfo ki t = ki { kiTags  = appendTags [t] (kiTags  ki)
 -- >   ==
 -- > "exists y. (P && Q y)[x:=C]"
 --
-simplifyKVar :: F.Expr -> F.Expr
-simplifyKVar = F.conj . dedupByAlphaEq . floatPExistConjuncts . go
+-- The first parameter is the set of symbols that can appear free in the input
+-- expression. At the moment, this only needs to include the free variables that
+-- start with the @subst$@ prefix.
+--
+simplifyKVar :: S.HashSet F.Symbol -> F.Expr -> F.Expr
+simplifyKVar s0 = F.conj . dedupByAlphaEq s0 . floatPExistConjuncts . go s0
   where
-    go (F.POr es) = disj $ map (F.conj . floatPExistConjuncts . go) es
-    go (F.PAnd es) = F.conj $ dedupByAlphaEq $ concatMap (floatPExistConjuncts . go) es
-    go (F.PExist bs e0) =
-      let es = concatMap (floatPExistConjuncts . go) (F.conjuncts e0)
+    go s (F.POr es) = disj $ map (F.conj . floatPExistConjuncts . go s) es
+    go s (F.PAnd es) = F.conj $ dedupByAlphaEq S.empty $ concatMap (floatPExistConjuncts . go s) es
+    go s (F.PExist bs e0) =
+      let es = concatMap (floatPExistConjuncts . go (S.union s $ S.fromList $ map fst bs)) (F.conjuncts e0)
        in elimExistentialBinds (F.PExist bs (F.conj es))
-    go e = e
+    go _ e = e
 
-    dedupByAlphaEq :: [F.Expr] -> [F.Expr]
-    dedupByAlphaEq = List.nubBy (\e1 e2 -> alphaEq e1 e2)
+    dedupByAlphaEq :: S.HashSet F.Symbol -> [F.Expr] -> [F.Expr]
+    dedupByAlphaEq s = List.nubBy (\e1 e2 -> alphaEq s e1 e2)
 
     disj :: [F.Expr] -> F.Expr
     disj [] = F.PFalse
@@ -586,21 +590,28 @@ simplifyKVar = F.conj . dedupByAlphaEq . floatPExistConjuncts . go
 
 -- | Determine if two expressions are alpha-equivalent.
 --
+-- Takes as first parameter the set of variables that might appear free
+-- in the expressions to compare.
+--
 -- Doesn't handle all cases, just enough for simplifying KVars which requires
 -- alpha-equivalence checking of existentially quantified expressions.
-alphaEq :: F.Expr -> F.Expr -> Bool
-alphaEq = go (F.mkSubst [])
+alphaEq :: S.HashSet F.Symbol -> F.Expr -> F.Expr -> Bool
+alphaEq s0 = go s0 (F.mkSubst [])
   where
-    go :: F.Subst -> F.Expr -> F.Expr -> Bool
-    go su (F.PExist bs1 x1) (F.PExist bs2 x2) =
-      let su' = List.foldl' (\s (v1, v2) -> F.extendSubst s v1 (F.EVar v2)) su (zip (map fst bs1) (map fst bs2))
-       in go su' x1 x2
-    go su (F.PAnd es1) (F.PAnd es2) =
-      length es1 == length es2 && and (zipWith (go su) es1 es2)
-    go su (F.POr es1) (F.POr es2) =
-      length es1 == length es2 && and (zipWith (go su) es1 es2)
-    go su e1 e2 =
-      F.subst su e1 == e2
+    go :: S.HashSet F.Symbol -> F.Subst -> F.Expr -> F.Expr -> Bool
+    go s su (F.PExist bs1 x1) (F.PExist bs2 x2) =
+      let su' =
+            List.foldl'
+              (\su1 (v1, v2) -> F.extendSubst su1 v1 (F.EVar v2))
+              su
+              (zip (map fst bs1) (map fst bs2))
+       in go (S.union s (S.fromList $ map fst bs2)) su' x1 x2
+    go s su (F.PAnd es1) (F.PAnd es2) =
+      length es1 == length es2 && and (zipWith (go s su) es1 es2)
+    go s su (F.POr es1) (F.POr es2) =
+      length es1 == length es2 && and (zipWith (go s su) es1 es2)
+    go s su e1 e2 =
+      F.rapierSubstExpr s su e1 == e2
 
 -- | Determine if the expression is an equality that sets the value of
 -- a variable in the given set.

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -116,6 +116,7 @@ import qualified Data.HashMap.Strict       as HashMap
 import           Data.HashSet              (HashSet)
 import qualified Data.HashSet              as HashSet
 import           GHC.Generics              (Generic)
+import           GHC.Stack                 (HasCallStack)
 #if MIN_VERSION_base(4,20,0)
 import           Data.List                 (partition)
 #else
@@ -1013,7 +1014,7 @@ class Subable a where
   -- substa f  = substf (EVar . f)
 
   substf :: (Symbol -> Expr) -> a -> a
-  subst  :: Subst -> a -> a
+  subst  :: HasCallStack => Subst -> a -> a
   subst1 :: a -> (Symbol, Expr) -> a
   subst1 y (x, e) = subst (Su $ M.fromList [(x,e)]) y
 

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -577,7 +577,7 @@ instance (Ord v, Fixpoint v) => Fixpoint (ExprV v) where
   toFix (ETApp e s)      = text "tapp" <+> toFix e <+> toFix s
   toFix (ETAbs e s)      = text "tabs" <+> toFix e <+> toFix s
   toFix (ECoerc a t e)   = parens (text "coerce" <+> toFix a <+> text "~" <+> toFix t <+> text "in" <+> toFix e)
-  toFix (ELam (x,s) e)   = text "lam" <+> toFix x <+> ":" <+> toFix s <+> "." <+> toFix e
+  toFix (ELam (x,s) e)   = parens (char '\\' <+> toFix x <+> ":" <+> toFix s <+> "->" <+> toFix e)
 
   simplify = simplifyExpr dedup
     where

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -154,29 +154,58 @@ instance Subable Expr where
   substf _  p              = p
 
 
-  subst su (EApp f e)      = EApp (subst su f) (subst su e)
-  subst su (ELam x e)      = ELam x (subst su' e) where su' = removeSubst su (fst x)
-  subst su (ELet x e1 e2)  = ELet x (subst su e1) (subst su' e2) where su' = removeSubst su x
-  subst su (ECoerc a t e)  = ECoerc a t (subst su e)
-  subst su (ENeg e)        = ENeg (subst su e)
-  subst su (EBin op e1 e2) = EBin op (subst su e1) (subst su e2)
-  subst su (EIte p e1 e2)  = EIte (subst su p) (subst su e1) (subst su e2)
-  subst su (ECst e so)     = ECst (subst su e) so
-  subst su (EVar x)        = appSubst su x
-  subst su (PAnd ps)       = PAnd $ map (subst su) ps
-  subst su (POr  ps)       = POr  $ map (subst su) ps
-  subst su (PNot p)        = PNot $ subst su p
-  subst su (PImp p1 p2)    = PImp (subst su p1) (subst su p2)
-  subst su (PIff p1 p2)    = PIff (subst su p1) (subst su p2)
-  subst su (PAtom r e1 e2) = PAtom r (subst su e1) (subst su e2)
-  subst su (PKVar k su')   = PKVar k $ su' `catSubst` su
-  subst su (PAll bs p)
-          | disjoint su bs = PAll bs $ subst su p --(substExcept su (fst <$> bs)) p
-          | otherwise      = errorstar "subst: PAll (without disjoint binds)"
-  subst su (PExist bs p)
-          | disjoint su bs = PExist bs $ subst su p --(substExcept su (fst <$> bs)) p
-          | otherwise      = errorstar ("subst: EXISTS (without disjoint binds)" ++ show (bs, su, p))
-  subst _  p               = p
+  subst = go
+    where
+      -- The auxiliary go function skips the HasCallStack constraint on every
+      -- recursive call. In case of error, the call stack only contains the
+      -- point at which subst was first called.
+      go su e0 = case e0 of
+        EApp f e ->
+          EApp (go su f) (go su e)
+        ELam x e ->
+          let su' = removeSubst su (fst x)
+           in ELam x (go su' e)
+        ELet x e1 e2 ->
+          let su' = removeSubst su x
+           in ELet x (go su e1) (go su' e2)
+        ECoerc a t e ->
+          ECoerc a t (go su e)
+        ENeg e ->
+          ENeg (go su e)
+        EBin op e1 e2 ->
+          EBin op (go su e1) (go su e2)
+        EIte p e1 e2 ->
+          EIte (go su p) (go su e1) (go su e2)
+        ECst e so ->
+          ECst (go su e) so
+        EVar x ->
+          appSubst su x
+        PAnd ps ->
+          PAnd $ map (go su) ps
+        POr  ps ->
+          POr  $ map (go su) ps
+        PNot p ->
+          PNot $ go su p
+        PImp p1 p2 ->
+          PImp (go su p1) (go su p2)
+        PIff p1 p2 ->
+          PIff (go su p1) (go su p2)
+        PAtom r e1 e2 ->
+          PAtom r (go su e1) (go su e2)
+        PKVar k su' ->
+          PKVar k $ su' `catSubst` su
+        PAll bs p
+          | disjoint su bs ->
+            PAll bs $ go su p --(substExcept su (fst <$> bs)) p
+          | otherwise ->
+            errorstar "subst: PAll (without disjoint binds)"
+        PExist bs p
+          | disjoint su bs ->
+            PExist bs $ go su p --(substExcept su (fst <$> bs)) p
+          | otherwise ->
+            errorstar ("subst: EXISTS (without disjoint binds)" ++ show (bs, su, p))
+        p ->
+          p
 
 removeSubst :: Subst -> Symbol -> Subst
 removeSubst (Su su) x = Su $ M.delete x su

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -295,8 +295,8 @@ extendSubst (Su m) x e = Su $ M.insert x e m
 disjoint :: Subst -> [(Symbol, Sort)] -> Bool
 disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
-    suSyms = S.fromList $ syms (M.elems su) ++ syms (M.keys su)
-    bsSyms = S.fromList $ syms $ fst <$> bs
+    suSyms = S.fromList $ syms (M.elems su) ++ M.keys su
+    bsSyms = S.fromList $ fst <$> bs
 
 meetReft :: Reft -> Reft -> Reft
 meetReft (Reft (v, ra)) (Reft (v', ra'))

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -198,12 +198,20 @@ instance Subable Expr where
           | disjoint su bs ->
             PAll bs $ go su p --(substExcept su (fst <$> bs)) p
           | otherwise ->
-            errorstar "subst: PAll (without disjoint binds)"
+            errorstar $ unlines
+              [ "subst: FORALL without disjoint binds"
+              , "su: " ++ showpp su
+              , "expr: " ++ showpp e0
+              ]
         PExist bs p
           | disjoint su bs ->
             PExist bs $ go su p --(substExcept su (fst <$> bs)) p
           | otherwise ->
-            errorstar ("subst: EXISTS (without disjoint binds)" ++ show (bs, su, p))
+            errorstar $ unlines
+              [ "subst: EXISTS without disjoint binds"
+              , "su: " ++ showpp su
+              , "expr: " ++ showpp e0
+              ]
         p ->
           p
 

--- a/tests/pos/func00.fq
+++ b/tests/pos/func00.fq
@@ -2,7 +2,7 @@
 bind 0 f : {v: func(0, [int; int]) | []}
 
 constraint:
-  env [ ]
+  env [ 0 ]
   lhs {v : int | [f = f]}
   rhs {v : int | [0 < 7]}
   id 1 tag []

--- a/tests/tasty/ParserTests.hs
+++ b/tests/tasty/ParserTests.hs
@@ -254,7 +254,7 @@ testPredP =
         show (doParse' predP "test" "&& []") @?= "PAnd []"
 
     , testCase "&& 1" $
-        show (doParse' predP "test" "&& [x]") @?= "EVar \"x\""
+        show (doParse' predP "test" "&& [x]") @?= "PAnd [EVar \"x\"]"
 
     , testCase "&& 2" $
         show (doParse' predP "test" "&& [x;y]") @?= "PAnd [EVar \"x\",EVar \"y\"]"

--- a/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
+++ b/tests/tasty/ghc-9.12.1/SimplifyKVarTests.hs
@@ -3,6 +3,7 @@
 module SimplifyKVarTests (tests) where
 
 import Control.Monad (when)
+import qualified Data.HashSet as HashSet
 import Language.Fixpoint.Parse
 import qualified Language.Fixpoint.Types as F
 import qualified Language.Fixpoint.Solver.Solution as F
@@ -78,9 +79,12 @@ data SimplificationTest = SimplificationTest
 simplificationTest :: SimplificationTest -> TestTree
 simplificationTest test =
   testCase (name test) $ do
-    let actual = F.simplifyKVar (doParse'' True predP (name test) (input test))
+    let actual =
+          F.simplifyKVar
+            HashSet.empty
+            (doParse'' True predP (name test) (input test))
         expectedE = doParse'' True predP (name test) (expected test)
-    when (not (F.alphaEq actual expectedE)) $ do
+    when (not (F.alphaEq HashSet.empty actual expectedE)) $ do
       assertFailure $ unlines
         [ "output is not as expected"
         , "Expected:"


### PR DESCRIPTION
The experience of debugging is sometimes difficult when stack traces are missing, or when liquid-fixpoint refuses to parse some .fq files produced by Liquid Haskell.

This PR contributes some improvements along these lines, except for "Use rapier-style substitution in simplifyKVars", which fixes a problem with substitutions when upgrading to ghc 9.14 (discussed in https://github.com/ucsd-progsys/liquidhaskell/pull/2604).

Also, the first commit "Do not simplify conjunctions in the parser" makes the code easier to follow, IMO. I think most developers would be surprised by a parser that does not return the AST corresponding to some token stream, but an AST that has been somehow simplified.