### PR TITLE
Don't require a space after the comment start

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -555,12 +555,12 @@ lexer = Token.makeTokenParser languageDef
 -- | Consumes a line comment.
 lhLineComment :: ParserV v ()
 lhLineComment =
-  L.skipLineComment "// "
+  L.skipLineComment "//"
 
 -- | Consumes a block comment.
 lhBlockComment :: ParserV v ()
 lhBlockComment =
-  L.skipBlockComment "/* " "*/"
+  L.skipBlockCommentNested "/*" "*/"
 
 -- | Parser that consumes a single char within an identifier (not start of identifier).
 identLetter :: ParserV v Char


### PR DESCRIPTION
The space after the comment start was introduced in #445

The errors when a space was missing after // were rather puzzling. e.g.

{-@
//
@-}

produced

Cannot parse specification: incorrect indentation (got 1, should be greater than 1)