### PR TITLE
Relax name capture check in substitution of expressions

### DIFF
--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -307,7 +307,10 @@ meetReft (Reft (v, ra)) (Reft (v', ra'))
 instance Subable Reft where
   syms (Reft (v, ras))      = v : syms ras
   substa f (Reft (v, ras))  = Reft (f v, substa f ras)
-  subst su (Reft (v, ras))  = Reft (v, subst (substExcept su [v]) ras)
+  subst su (Reft (v, ras))  =
+    let su' = substExcept su [v]
+        s = S.union (substSymbolsSet su') (exprSymbolsSet ras)
+     in Reft (v, rapierSubstExpr s su' ras)
   substf f (Reft (v, ras))  = Reft (v, substf (substfExcept f [v]) ras)
   subst1 (Reft (v, ras)) su = Reft (v, subst1Except [v] ras su)
 

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -195,8 +195,8 @@ instance Subable Expr where
         PKVar k su' ->
           PKVar k $ su' `catSubst` su
         PAll bs p
-          | disjoint su bs ->
-            PAll bs $ go su p --(substExcept su (fst <$> bs)) p
+          | disjointRange su bs ->
+            PAll bs $ go (substExcept su (map fst bs)) p
           | otherwise ->
             errorstar $ unlines
               [ "subst: FORALL without disjoint binds"
@@ -204,8 +204,8 @@ instance Subable Expr where
               , "expr: " ++ showpp e0
               ]
         PExist bs p
-          | disjoint su bs ->
-            PExist bs $ go su p --(substExcept su (fst <$> bs)) p
+          | disjointRange su bs ->
+            PExist bs $ go (substExcept su (map fst bs)) p
           | otherwise ->
             errorstar $ unlines
               [ "subst: EXISTS without disjoint binds"
@@ -292,10 +292,10 @@ rapierSubstExpr s su e0 =
 extendSubst :: Subst -> Symbol -> Expr -> Subst
 extendSubst (Su m) x e = Su $ M.insert x e m
 
-disjoint :: Subst -> [(Symbol, Sort)] -> Bool
-disjoint (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
+disjointRange :: Subst -> [(Symbol, Sort)] -> Bool
+disjointRange (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
-    suSyms = S.fromList $ syms (M.elems su) ++ M.keys su
+    suSyms = S.fromList $ syms (M.elems su)
     bsSyms = S.fromList $ fst <$> bs
 
 meetReft :: Reft -> Reft -> Reft

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -195,23 +195,27 @@ instance Subable Expr where
         PKVar k su' ->
           PKVar k $ su' `catSubst` su
         PAll bs p
-          | disjointRange su bs ->
-            PAll bs $ go (substExcept su (map fst bs)) p
+          | disjointRange su' bs ->
+            PAll bs $ go su' p
           | otherwise ->
             errorstar $ unlines
               [ "subst: FORALL without disjoint binds"
-              , "su: " ++ showpp su
+              , "su: " ++ showpp su'
               , "expr: " ++ showpp e0
               ]
+          where
+            su' = substExcept su (map fst bs)
         PExist bs p
-          | disjointRange su bs ->
-            PExist bs $ go (substExcept su (map fst bs)) p
+          | disjointRange su' bs ->
+            PExist bs $ go su' p
           | otherwise ->
             errorstar $ unlines
               [ "subst: EXISTS without disjoint binds"
-              , "su: " ++ showpp su
+              , "su: " ++ showpp su'
               , "expr: " ++ showpp e0
               ]
+          where
+            su' = substExcept su (map fst bs)
         p ->
           p
 


### PR DESCRIPTION
Substitution of expressions in https://github.com/ucsd-progsys/liquidhaskell/issues/2625 was failing in a name-capture check. However, the implementation could proceed with the substitution by relaxing the check a bit. This is what the first commit of the PR accomplishes.

The second commit avoids the name-capture check in the particular path that leads to the failure, by using the rapier-style substitution instead.