### PR TITLE
Add `cut` to horn-parser

### DIFF
--- a/src/Language/Fixpoint/Horn/Info.hs
+++ b/src/Language/Fixpoint/Horn/Info.hs
@@ -7,6 +7,7 @@ module Language.Fixpoint.Horn.Info (
 
 import           Data.Ord (Down(..), comparing)
 import qualified Data.HashMap.Strict            as M
+import qualified Data.HashSet                   as S
 import qualified Data.List                      as L
 import qualified Data.Tuple                     as Tuple
 import           GHC.Generics                   (Generic)
@@ -28,6 +29,7 @@ hornFInfo cfg q = mempty
   , F.ddecls    = H.qData q
   , F.hoInfo    = F.cfgHoInfo cfg
   , F.defns     = F.MkDefinedFuns (H.qDefs q)
+  , F.kuts      = F.KS (S.fromList (H.qKuts q))
   }
   where
     be0         = F.emptyBindEnv

--- a/src/Language/Fixpoint/Horn/Parse.hs
+++ b/src/Language/Fixpoint/Horn/Parse.hs
@@ -11,7 +11,7 @@ module Language.Fixpoint.Horn.Parse (
   , sortP
 ) where
 
-import qualified Language.Fixpoint.Parse        as FP (Parser, addNumTyCon, lexeme', locLexeme', reserved', reservedOp', symbolR, upperIdR, lowerIdR, stringR, naturalR, mkFTycon)
+import qualified Language.Fixpoint.Parse        as FP (Parser, addNumTyCon, lexeme', locLexeme', reserved', reservedOp', symbolR, upperIdR, lowerIdR, stringR, naturalR, mkFTycon, kvarP)
 import qualified Language.Fixpoint.Types        as F
 import qualified Language.Fixpoint.Horn.Types   as H
 import           Text.Megaparsec                hiding (State)
@@ -137,6 +137,7 @@ mkQuery things = H.Query
   , H.qData  =              [ dd    | HDat dd  <- things ]
   , H.qOpts  =              [ o     | HOpt o   <- things ]
   , H.qNums  =              [ s     | HNum s   <- things ]
+  , H.qKuts  =              [ k     | HKut k   <- things ]
   }
 
 -- | A @HThing@ describes the kinds of things we may see, in no particular order
@@ -156,6 +157,7 @@ data HThing a
   | HDat !F.DataDecl
   | HOpt !String
   | HNum  F.Symbol
+  | HKut  F.KVar
   deriving (Functor)
 
 hThingP :: FParser (HThing H.Tag)
@@ -172,6 +174,7 @@ hThingP  = spaces >> parens body
         <|> HMat  <$> (reserved "match"      *> matchP)
         <|> HDat  <$> (reserved "datatype"   *> dataDeclP)
         <|> HNum  <$> (reserved "numeric"    *> numericDeclP)
+        <|> HKut  <$> (reserved "cut"        *> FP.kvarP)
 
 numericDeclP :: FParser F.Symbol
 numericDeclP = do

--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -217,6 +217,7 @@ data Query a = Query
   , qData  :: ![F.DataDecl]              -- ^ list of data-declarations
   , qOpts  :: ![String]                  -- ^ list of fixpoint options
   , qNums  :: ![F.Symbol]                -- ^ list of numeric TyCon (?)
+  , qKuts  :: ![F.KVar]                  -- ^ list of cut variables
   }
   deriving (Data, Typeable, Generic, Functor, ToJSON, FromJSON)
 

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -49,6 +49,7 @@ module Language.Fixpoint.Parse (
   , mkQual      -- constructing qualifiers
   , infixSymbolP -- parse infix symbols
   , locInfixSymbolP
+  , kvarP
 
   -- * Parsing recursive entities
   , exprP        -- Expressions
@@ -1559,4 +1560,3 @@ instance Inputable Command where
 
 instance Inputable [Command] where
   rr' = doParse' commandsP
-

--- a/tests/horn/pos/kut00.smt2
+++ b/tests/horn/pos/kut00.smt2
@@ -1,0 +1,20 @@
+; (fixpoint "--eliminate=horn")
+
+(qualif Foo ((v Int)) (= v 10))
+(qualif Foo ((v Int)) (= v 20))
+(qualif Foo ((v Int)) (= v 30))
+
+(var $k1 (Int))
+
+(cut $k1)
+
+(constraint
+  (and
+    (forall ((x Int) ((= x 5)))
+      (forall ((y Int) ((= y x)))
+        (forall ((v Int) ((= v (+ x y))))
+          ($k1 v))))
+    (forall ((z Int) ($k1 z))
+      ((< 99 105)))
+  )
+)

--- a/tests/horn/pos/kut00.smt2
+++ b/tests/horn/pos/kut00.smt2
@@ -15,6 +15,6 @@
         (forall ((v Int) ((= v (+ x y))))
           ($k1 v))))
     (forall ((z Int) ($k1 z))
-      ((< 99 105)))
+      ((< 99 105))) ;; silly constraint to make sure $k1 doesn't get "sliced out"
   )
 )


### PR DESCRIPTION
So we can mark specific variables as `cut` variables. @vrindisbacher 