### PR TITLE
Directly encode String Literals in SMTLIB

### DIFF
--- a/src/Language/Fixpoint/Graph/Deps.hs
+++ b/src/Language/Fixpoint/Graph/Deps.hs
@@ -352,11 +352,12 @@ sMapMaybe f = S.fromList . mapMaybe f . S.toList
 --------------------------------------------------------------------------------
 type EdgeRank = M.HashMap F.KVar Integer
 --------------------------------------------------------------------------------
+-- | Builds a map from KVar to the _smallest_ ConstraintID that KVar appears in LHS of
 edgeRank :: [CEdge] -> EdgeRank
 edgeRank es = minimum . (n :) <$> kiM
   where
-    n       = 1 + maximum [ i | (Cstr i, _)     <- es ]
-    kiM     = group [ (k, i) | (KVar k, Cstr i) <- es ]
+    n       = 1 + maximum [ i | (Cstr i, _)     <- es ] -- number larger than maximum constraint id
+    kiM     = group [ (k, i) | (KVar k, Cstr i) <- es ] -- map each `k` to cstrs in which it appears on LHS
 
 edgeRankCut :: EdgeRank -> Cutter CVertex
 edgeRankCut km vs = case ks of

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -25,6 +25,8 @@ import qualified Language.Fixpoint.Smt.Theories as Thy
 -- import           Data.Text.Format
 import           Language.Fixpoint.Misc (sortNub, errorstar)
 import           Language.Fixpoint.Utils.Builder as Builder
+import qualified Data.Text as T
+import Data.Text (Text)
 -- import Debug.Trace (trace)
 
 instance SMTLIB2 (Symbol, Sort) where
@@ -125,7 +127,15 @@ instance SMTLIB2 LocSymbol where
   smt2 = smt2 . val
 
 instance SMTLIB2 SymConst where
-  smt2 (SL t) = pure $ quotes $ fromText t  -- emit "hello" not lit$36$hello
+  smt2 (SL t) = pure $ quotes $ fromText $ smtEscape t  -- emit "hello" not lit$36$hello
+
+-- | Per https://smt-lib.org/theories-UnicodeStrings.shtml
+-- "SMT-LIB 2.6 has one escape sequence of its own for string literals. Two
+--  double quotes ("") are used to represent the double-quote character within
+--  a string literal"
+
+smtEscape :: Text -> Text
+smtEscape = T.replace "\"" "\"\""
 
 instance SMTLIB2 Constant where
   smt2 (I n)   = pure $ bShow n

--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -125,7 +125,7 @@ instance SMTLIB2 LocSymbol where
   smt2 = smt2 . val
 
 instance SMTLIB2 SymConst where
-  smt2 = smt2 . symbol
+  smt2 (SL t) = pure $ quotes $ fromText t  -- emit "hello" not lit$36$hello
 
 instance SMTLIB2 Constant where
   smt2 (I n)   = pure $ bShow n


### PR DESCRIPTION
The thing where we used a symbol was a bit flaky as sometimes the sort was not declared...

(Claude summary of the bug)

  1. "hello" is parsed as `ESym (SL "hello")` → encoded as symbol `lit$hello` (safe-text: `lit$36$hello`)
  2. `addLiterals` uses `symConsts si` which for `SimpC` only traverses `crhs` — missing `"hello"` when it appears only in LHS binding positions
  3. So `lit$36$hello` never gets a `(declare-fun lit$36$hello () String)` declaration
  4. But it is referenced in the `lhsPred` formula sent to Z3, which crashes with an unknown constant error...
  
A proper cleanup here would be to entirely eliminate the `seLits` machinery perhaps, but I will leave that for another day!