### PR TITLE
chore: add --savebfq flag to collect .bfq files on verification failure

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -69,4 +69,10 @@ jobs:
         run: cabal build all --enable-tests
 
       - name: Test
-        run: cabal test all --test-show-details=direct --test-option="--color=always"
+        run: cabal test all --test-show-details=direct --test-option="--color=always" --test-option="--save-bfq-on-error"
+      - name: Upload bfq artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bfq-files
+          path: '**/*.bfq'

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -69,7 +69,7 @@ jobs:
         run: cabal build all --enable-tests
 
       - name: Test
-        run: cabal test all --test-show-details=direct --test-option="--color=always" --test-option="--save-bfq-on-error"
+        run: cabal test all --test-show-details=direct --test-option="--color=always"
       - name: Upload bfq artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -10,3 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: andreasabel/fix-whitespace-action@v1
+        with:
+          version:    0.1
+          configfile: fix-whitespace.yaml
+          fix:        false
+          verbose:    true

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -116,7 +116,7 @@ solve cfg q
 solve'
   :: (PPrint a, NFData a, Fixpoint a, Show a, Loc a)
   => Config -> FInfo a -> IO (Result (Integer, a))
-solve' cfg q = do 
+solve' cfg q = do
     when (save cfg) $ saveQuery cfg q
     res <- if multicore cfg then
              solvePar cfg q

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -122,7 +122,7 @@ solve' cfg q = do
              solvePar cfg q
            else
              solveNative cfg (slice cfg q)
-    when (saveBfq cfg && isUnsafe res) $ saveBinaryQuery cfg (void q)
+    when (saveBfqOnError cfg && isUnsafe res) $ saveBinaryQuery cfg (void q)
     return res
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -59,6 +59,7 @@ import           Language.Fixpoint.Types hiding (GInfo(..), fi)
 import qualified Language.Fixpoint.Types as Types (GInfo(..))
 import           Language.Fixpoint.Minimize (minQuery, minQuals, minKvars)
 import           Control.DeepSeq
+import           Data.Functor                        (void)
 import qualified Data.ByteString as B
 import Data.Maybe (catMaybes)
 import qualified Text.PrettyPrint.HughesPJ as PJ
@@ -115,12 +116,14 @@ solve cfg q
 solve'
   :: (PPrint a, NFData a, Fixpoint a, Show a, Loc a)
   => Config -> FInfo a -> IO (Result (Integer, a))
-solve' cfg q = do
-  when (save cfg) $ saveQuery   cfg q
-  if multicore cfg then
-    solvePar cfg q
-  else
-    solveNative cfg (slice cfg q)
+solve' cfg q = do 
+    when (save cfg) $ saveQuery cfg q
+    res <- if multicore cfg then
+             solvePar cfg q
+           else
+             solveNative cfg (slice cfg q)
+    when (saveBfq cfg && isUnsafe res) $ saveBinaryQuery cfg (void q)
+    return res
 
 --------------------------------------------------------------------------------
 readFInfo :: FilePath -> IO (FInfo (), [String])

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -249,7 +249,7 @@ defConfig = Config {
   , elimStats                = False   &= help "(alpha) Print eliminate stats"
   , solverStats              = False   &= help "Print solver stats"
   , save                     = False   &= help "Save Query as .fq and .bfq files"
-  , saveBfqOnError           = False   &= help "Save Query as .bfq file only when verification fails" 
+  , saveBfqOnError           = False   &= help "Save Query as .bfq file only when verification fails"
                                        &= name "save-bfq-on-error"
                                        &= explicit
   , metadata                 = False   &= help "Print meta-data associated with constraints"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -250,7 +250,7 @@ defConfig = Config {
   , solverStats              = False   &= help "Print solver stats"
   , save                     = False   &= help "Save Query as .fq and .bfq files"
   , saveBfqOnError           = False   &= help "Save Query as .bfq file only when verification fails" 
-                                       &= name "--save-bfq-on-error"
+                                       &= name "save-bfq-on-error"
                                        &= explicit
   , metadata                 = False   &= help "Print meta-data associated with constraints"
   , stats                    = False   &= help "Compute constraint statistics"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -91,6 +91,7 @@ data Config = Config
   , stats       :: Bool                -- ^ compute constraint statistics
   , parts       :: Bool                -- ^ partition FInfo into separate fq files
   , save        :: Bool                -- ^ save FInfo as .bfq and .fq file
+  , saveBfq     :: Bool                -- ^ save FInfo as .bfq only on verification failure
   , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
   , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
   , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
@@ -248,6 +249,7 @@ defConfig = Config {
   , elimStats                = False   &= help "(alpha) Print eliminate stats"
   , solverStats              = False   &= help "Print solver stats"
   , save                     = False   &= help "Save Query as .fq and .bfq files"
+  , saveBfq                  = False   &= help "Save Query as .bfq file only when verification fails" 
   , metadata                 = False   &= help "Print meta-data associated with constraints"
   , stats                    = False   &= help "Compute constraint statistics"
   , etaElim                  = False   &= help "Eta elimination in function definition"

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -91,7 +91,6 @@ data Config = Config
   , stats       :: Bool                -- ^ compute constraint statistics
   , parts       :: Bool                -- ^ partition FInfo into separate fq files
   , save        :: Bool                -- ^ save FInfo as .bfq and .fq file
-  , saveBfq     :: Bool                -- ^ save FInfo as .bfq only on verification failure
   , minimize    :: Bool                -- ^ min .fq by delta debug (unsat with min constraints)
   , minimizeQs  :: Bool                -- ^ min .fq by delta debug (sat with min qualifiers)
   , minimizeKs  :: Bool                -- ^ min .fq by delta debug (sat with min kvars)
@@ -104,6 +103,7 @@ data Config = Config
   , pleUndecGuards   :: Bool           -- ^ Unfold invocations with undecided guards in PLE
   , etabeta          :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
   , localRewrites    :: Bool           -- ^ Eta expand and beta reduce terms to aid PLE
+  , saveBfqOnError   :: Bool           -- ^ save FInfo as .bfq only on verification failure
   , interpreter      :: Bool           -- ^ Do not use the interpreter to assist PLE
   , noEnvReduction   :: Bool     -- ^ Don't use environment reduction
   , inlineANFBinds   :: Bool          -- ^ Inline ANF bindings.
@@ -249,7 +249,9 @@ defConfig = Config {
   , elimStats                = False   &= help "(alpha) Print eliminate stats"
   , solverStats              = False   &= help "Print solver stats"
   , save                     = False   &= help "Save Query as .fq and .bfq files"
-  , saveBfq                  = False   &= help "Save Query as .bfq file only when verification fails" 
+  , saveBfqOnError           = False   &= help "Save Query as .bfq file only when verification fails" 
+                                       &= name "--save-bfq-on-error"
+                                       &= explicit
   , metadata                 = False   &= help "Print meta-data associated with constraints"
   , stats                    = False   &= help "Compute constraint statistics"
   , etaElim                  = False   &= help "Eta elimination in function definition"

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -28,6 +28,7 @@ module Language.Fixpoint.Types.Constraints (
   , toFixpoint
   , writeFInfo
   , saveQuery
+  , saveBinaryQuery
   , saveSInfo
 
    -- * Constructing Queries

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -87,39 +87,39 @@ combineReporters _ _ = error "combineReporters needs TestReporters"
 unitTests :: FilePath -> IO TestTree
 unitTests lfDir
   = group "Unit" [
-      testGroup "native-pos"       <$> dirTests     nativeCmd   "tests/pos"              skipNativePos  ExitSuccess
-    , testGroup "native-neg"       <$> dirTests     nativeCmd   "tests/neg"              ["float.fq"]  (ExitFailure 1)
-    , testGroup "elim-crash"       <$> dirTests     nativeCmd   "tests/crash"            []            (ExitFailure 1)
-    , testGroup "elim-pos1"        <$> dirTests     elimCmd     "tests/pos"              []             ExitSuccess
-    , testGroup "elim-pos2"        <$> dirTests     elimCmd     "tests/elim"             []             ExitSuccess
-    , testGroup "elim-neg"         <$> dirTests     elimCmd     "tests/neg"              ["float.fq"]  (ExitFailure 1)
-    , testGroup "elim-crash"       <$> dirTests     elimCmd     "tests/crash"            []            (ExitFailure 1)
-    , testGroup "cvc5-pos"         <$> dirTests     cvc5Cmd     "tests/pos"              skipNativePos  ExitSuccess
-    , testGroup "cvc5-spec"        <$> dirTests     cvc5Cmd     "tests/cvc5"             skipNativePos  ExitSuccess
-    , testGroup "proof"            <$> dirTests     elimCmd     "tests/proof"            []             ExitSuccess
-    , testGroup "rankN"            <$> dirTests     elimCmd     "tests/rankNTypes"       []             ExitSuccess
-    , testGroup "horn-pos-el"      <$> dirTests     elimSaveCmd "tests/horn/pos"         []             ExitSuccess
-    , testGroup "horn-pos-cvc5"    <$> dirTests     cvc5Cmd     "tests/horn/pos"         []             ExitSuccess
-    , testGroup "horn-neg-el"      <$> dirTests     elimSaveCmd "tests/horn/neg"         []            (ExitFailure 1)
-    , testGroup "horn-neg-cvc5"    <$> dirTests     cvc5Cmd     "tests/horn/neg"         []            (ExitFailure 1)
-    , testGroup "horn-json-pos-el" <$> dirJsonTests elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
-    , testGroup "horn-json-neg-el" <$> dirJsonTests elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
-    , testGroup "horn-smt2-pos-el" <$> dirHornTests elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
-    , testGroup "horn-smt2-neg-el" <$> dirHornTests elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
-    , testGroup "horn-pos-na"      <$> dirTests     nativeCmd   "tests/horn/pos"         []             ExitSuccess
-    , testGroup "horn-neg-na"      <$> dirTests     nativeCmd   "tests/horn/neg"         []            (ExitFailure 1)
+      dirTests "native-pos"           nativeCmd   "tests/pos"              skipNativePos  ExitSuccess
+    , dirTests "native-neg"           nativeCmd   "tests/neg"              ["float.fq"]  (ExitFailure 1)
+    , dirTests "elim-crash"           nativeCmd   "tests/crash"            []            (ExitFailure 1)
+    , dirTests "elim-pos1"            elimCmd     "tests/pos"              []             ExitSuccess
+    , dirTests "elim-pos2"            elimCmd     "tests/elim"             []             ExitSuccess
+    , dirTests "elim-neg"             elimCmd     "tests/neg"              ["float.fq"]  (ExitFailure 1)
+    , dirTests "elim-crash"           elimCmd     "tests/crash"            []            (ExitFailure 1)
+    , dirTests "cvc5-pos"             cvc5Cmd     "tests/pos"              skipNativePos  ExitSuccess
+    , dirTests "cvc5-spec"            cvc5Cmd     "tests/cvc5"             skipNativePos  ExitSuccess
+    , dirTests "proof"                elimCmd     "tests/proof"            []             ExitSuccess
+    , dirTests "rankN"                elimCmd     "tests/rankNTypes"       []             ExitSuccess
+    , dirTests "horn-pos-el"          elimSaveCmd "tests/horn/pos"         []             ExitSuccess
+    , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         []             ExitSuccess
+    , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []            (ExitFailure 1)
+    , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []            (ExitFailure 1)
+    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
+    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
+    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
+    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
+    , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         []             ExitSuccess
+    , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []            (ExitFailure 1)
    ]
    where
-    dirTests     = dirTests' isTest
-    dirJsonTests = dirTests' ("horn.json" `isSuffixOf`)
-    dirHornTests = dirTests' ("horn.smt2" `isSuffixOf`)
+    dirTests     n a b c d = testGroup n <$> dirTests' n isTest a b c d
+    dirJsonTests n a b c d = testGroup n <$> dirTests' n ("horn.json" `isSuffixOf`) a b c d
+    dirHornTests n a b c d = testGroup n <$> dirTests' n ("horn.smt2" `isSuffixOf`) a b c d
 
-    dirTests' :: (FilePath -> Bool) -> TestCmd -> FilePath -> [FilePath] -> ExitCode -> IO [TestTree]
-    dirTests' isT testCmd root ignored code = do
+    dirTests' :: String -> (FilePath -> Bool) -> TestCmd -> FilePath -> [FilePath] -> ExitCode -> IO [TestTree]
+    dirTests' testName isT testCmd root ignored code = do
       let absRoot = lfDir </> root
       files    <- walkDirectory absRoot
       let tests = [ rel | f <- files, isT f, let rel = makeRelative absRoot f, rel `notElem` ignored ]
-      return    $ mkTest testCmd code absRoot <$> tests
+      return    $ mkTest testName testCmd code absRoot <$> tests
 
 isTest   :: FilePath -> Bool
 isTest f = takeExtension f `elem` [".fq", ".smt2"]
@@ -150,9 +150,9 @@ instance IsOption FixpointOpts where
       )
 
 ---------------------------------------------------------------------------
-mkTest :: TestCmd -> ExitCode -> FilePath -> FilePath -> TestTree
+mkTest :: String -> TestCmd -> ExitCode -> FilePath -> FilePath -> TestTree
 ---------------------------------------------------------------------------
-mkTest testCmd code dir file
+mkTest testName testCmd code dir file
   =
     askOption $ \opts ->
     testCase file $
@@ -172,7 +172,9 @@ mkTest testCmd code dir file
 
   where
     test = dir </> file
-    log  = let (d,f) = splitFileName file in dir </> d </> ".liquid" </> f <.> "log"
+    -- select a file name that is unique to the test, as the tests might run
+    -- in parallel.
+    log  = let (d,f) = splitFileName file in dir </> d </> ".liquid" </> testName </> f <.> "harness.log"
 
 knownToFail :: [a]
 knownToFail = []

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -87,39 +87,41 @@ combineReporters _ _ = error "combineReporters needs TestReporters"
 unitTests :: FilePath -> IO TestTree
 unitTests lfDir
   = group "Unit" [
-      dirTests "native-pos"           nativeCmd   "tests/pos"              skipNativePos  ExitSuccess
-    , dirTests "native-neg"           nativeCmd   "tests/neg"              ["float.fq"]  (ExitFailure 1)
-    , dirTests "elim-crash"           nativeCmd   "tests/crash"            []            (ExitFailure 1)
-    , dirTests "elim-pos1"            elimCmd     "tests/pos"              []             ExitSuccess
-    , dirTests "elim-pos2"            elimCmd     "tests/elim"             []             ExitSuccess
-    , dirTests "elim-neg"             elimCmd     "tests/neg"              ["float.fq"]  (ExitFailure 1)
-    , dirTests "elim-crash"           elimCmd     "tests/crash"            []            (ExitFailure 1)
-    , dirTests "cvc5-pos"             cvc5Cmd     "tests/pos"              skipNativePos  ExitSuccess
-    , dirTests "cvc5-spec"            cvc5Cmd     "tests/cvc5"             skipNativePos  ExitSuccess
-    , dirTests "proof"                elimCmd     "tests/proof"            []             ExitSuccess
-    , dirTests "rankN"                elimCmd     "tests/rankNTypes"       []             ExitSuccess
-    , dirTests "horn-pos-el"          elimSaveCmd "tests/horn/pos"         []             ExitSuccess
-    , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         []             ExitSuccess
-    , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []            (ExitFailure 1)
-    , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []            (ExitFailure 1)
-    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
-    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
-    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/horn/pos/.liquid" []             ExitSuccess
-    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/horn/neg/.liquid" []            (ExitFailure 1)
-    , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         []             ExitSuccess
-    , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []            (ExitFailure 1)
+      dirTests "native-pos"           nativeCmd   "tests/pos"              posOptions skipNativePos  ExitSuccess
+    , dirTests "native-neg"           nativeCmd   "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
+    , dirTests "elim-crash"           nativeCmd   "tests/crash"            posOptions []            (ExitFailure 1)
+    , dirTests "elim-pos1"            elimCmd     "tests/pos"              posOptions []             ExitSuccess
+    , dirTests "elim-pos2"            elimCmd     "tests/elim"             posOptions []             ExitSuccess
+    , dirTests "elim-neg"             elimCmd     "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
+    , dirTests "elim-crash"           elimCmd     "tests/crash"            []                      []            (ExitFailure 1)
+    , dirTests "cvc5-pos"             cvc5Cmd     "tests/pos"              posOptions skipNativePos  ExitSuccess
+    , dirTests "cvc5-spec"            cvc5Cmd     "tests/cvc5"             posOptions skipNativePos  ExitSuccess
+    , dirTests "proof"                elimCmd     "tests/proof"            posOptions []             ExitSuccess
+    , dirTests "rankN"                elimCmd     "tests/rankNTypes"       posOptions []             ExitSuccess
+    , dirTests "horn-pos-el"          elimSaveCmd "tests/horn/pos"         posOptions []             ExitSuccess
+    , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         posOptions []             ExitSuccess
+    , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []         []            (ExitFailure 1)
+    , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []         []            (ExitFailure 1)
+    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/horn/pos/.liquid" []         []             ExitSuccess
+    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/horn/neg/.liquid" []         []            (ExitFailure 1)
+    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/horn/pos/.liquid" []         []             ExitSuccess
+    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/horn/neg/.liquid" []         []            (ExitFailure 1)
+    , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         posOptions []             ExitSuccess
+    , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []         []            (ExitFailure 1)
    ]
    where
-    dirTests     n a b c d = testGroup n <$> dirTests' n isTest a b c d
-    dirJsonTests n a b c d = testGroup n <$> dirTests' n ("horn.json" `isSuffixOf`) a b c d
-    dirHornTests n a b c d = testGroup n <$> dirTests' n ("horn.smt2" `isSuffixOf`) a b c d
+    posOptions = ["--save-bfq-on-error"]
 
-    dirTests' :: String -> (FilePath -> Bool) -> TestCmd -> FilePath -> [FilePath] -> ExitCode -> IO [TestTree]
-    dirTests' testName isT testCmd root ignored code = do
+    dirTests     n a b c d e = testGroup n <$> dirTests' n isTest a b c d e
+    dirJsonTests n a b c d e = testGroup n <$> dirTests' n ("horn.json" `isSuffixOf`) a b c d e
+    dirHornTests n a b c d e = testGroup n <$> dirTests' n ("horn.smt2" `isSuffixOf`) a b c d e
+
+    dirTests' :: String -> (FilePath -> Bool) -> TestCmd -> FilePath -> [String] -> [FilePath] -> ExitCode -> IO [TestTree]
+    dirTests' testName isT testCmd root extraOpts ignored code = do
       let absRoot = lfDir </> root
       files    <- walkDirectory absRoot
       let tests = [ rel | f <- files, isT f, let rel = makeRelative absRoot f, rel `notElem` ignored ]
-      return    $ mkTest testName testCmd code absRoot <$> tests
+      return    $ mkTest testName testCmd code extraOpts absRoot <$> tests
 
 isTest   :: FilePath -> Bool
 isTest f = takeExtension f `elem` [".fq", ".smt2"]
@@ -150,9 +152,9 @@ instance IsOption FixpointOpts where
       )
 
 ---------------------------------------------------------------------------
-mkTest :: String -> TestCmd -> ExitCode -> FilePath -> FilePath -> TestTree
+mkTest :: String -> TestCmd -> ExitCode -> [String] -> FilePath -> FilePath -> TestTree
 ---------------------------------------------------------------------------
-mkTest testName testCmd code dir file
+mkTest testName testCmd code extraOpts dir file
   =
     askOption $ \opts ->
     testCase file $
@@ -163,7 +165,7 @@ mkTest testName testCmd code dir file
       else do
         createDirectoryIfMissing True $ takeDirectory log
         c <- withFile log WriteMode $ \h -> do
-          let cmd     = testCmd opts "fixpoint" dir file
+          let cmd     = testCmd (LO (unwords extraOpts) <> opts) "fixpoint" dir file
           (_,_,_,ph) <- createProcess $ (shell cmd) {std_out = UseHandle h, std_err = UseHandle h}
           waitForProcess ph
         when (code /= c) $


### PR DESCRIPTION
added a new flag `--savebfq` lag that saves the `.bfq` binary query file only when verification fails (i.e. when the result is `Unsafe`), as described in option 1 of issue [#2020](https://github.com/ucsd-progsys/liquidhaskell/issues/2020) in liquidhaskell.

this makes it possible to collect .bfq files in CI for flaky failures without saving them on every test run.