### PR TITLE
Separate outputs of tests

### DIFF
--- a/src/Language/Fixpoint/Smt/Interface.hs
+++ b/src/Language/Fixpoint/Smt/Interface.hs
@@ -65,7 +65,7 @@ module Language.Fixpoint.Smt.Interface (
     ) where
 
 import           Language.Fixpoint.Types.Config ( SMTSolver (..), solverFlags
-                                                , Config (solver, smtTimeout, noStringTheory, save, allowHO))
+                                                , Config (solver, smtTimeout, noStringTheory, save, saveDir, allowHO))
 import qualified Language.Fixpoint.Misc          as Misc
 import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Utils.Files
@@ -278,7 +278,7 @@ makeContext cfg f
                LBS.hPutStr hLog "\n"
        return me
     where
-       smtFile = extFileName Smt2 f
+       smtFile = extFileNameR' (saveDir cfg) Smt2 f
 
 makeContextWithSEnv :: Config -> FilePath -> SymEnv -> DefinedFuns -> IO Context
 makeContextWithSEnv cfg f env defns = do

--- a/src/Language/Fixpoint/Types/Config.hs
+++ b/src/Language/Fixpoint/Types/Config.hs
@@ -118,6 +118,7 @@ data Config = Config
   , noStringTheory :: Bool             -- ^ disable interpretation of string theory by SMT
   , explicitKvars  :: Bool             -- ^ use explicitly declared kvars (horn style) which disables several "defensive simplifications"
   , sortedSolution :: Bool             -- ^ leave sorts in the solution
+  , saveDir        :: Maybe FilePath    -- ^ output directory for --save generated files (default: .liquid/ next to source)
   } deriving (Eq,Data,Typeable,Show,Generic)
 
 instance Default Config where
@@ -252,6 +253,12 @@ defConfig = Config {
   , saveBfqOnError           = False   &= help "Save Query as .bfq file only when verification fails"
                                        &= name "save-bfq-on-error"
                                        &= explicit
+  , saveDir                  = Nothing
+      &= name "save-dir"
+      &= help "Output directory for --save generated files (default: .liquid/ next to source)"
+      &= opt (Nothing :: Maybe FilePath)
+      &= explicit
+      &= typDir
   , metadata                 = False   &= help "Print meta-data associated with constraints"
   , stats                    = False   &= help "Compute constraint statistics"
   , etaElim                  = False   &= help "Eta elimination in function definition"
@@ -326,4 +333,4 @@ multicore :: Config -> Bool
 multicore cfg = cores cfg /= Just 1
 
 queryFile :: Ext -> Config -> FilePath
-queryFile e = extFileName e . srcFile
+queryFile e cfg = extFileNameR' (saveDir cfg) e (srcFile cfg)

--- a/src/Language/Fixpoint/Utils/Files.hs
+++ b/src/Language/Fixpoint/Utils/Files.hs
@@ -13,6 +13,7 @@ module Language.Fixpoint.Utils.Files (
     Ext (..)
   , extFileName
   , extFileNameR
+  , extFileNameR'
   , tempDirectory
   , tempFileName
   , extModuleName
@@ -158,6 +159,12 @@ tmpDirName      = ".liquid"
 
 extFileNameR     :: Ext -> FilePath -> FilePath
 extFileNameR ext = (`addExtension` extMap ext)
+
+-- | Like 'extFileName' but uses a custom output directory when provided.
+-- When 'Nothing', falls back to the default @.liquid/@ directory behavior.
+extFileNameR' :: Maybe FilePath -> Ext -> FilePath -> FilePath
+extFileNameR' Nothing  e f = extFileName e f
+extFileNameR' (Just d) e f = d </> takeFileName (addExtension f (extMap e))
 
 isExtFile ::  Ext -> FilePath -> Bool
 isExtFile ext = (extMap ext ==) . takeExtension

--- a/tests/horn/pos/ple_list01_adt.smt2
+++ b/tests/horn/pos/ple_list01_adt.smt2
@@ -1,5 +1,4 @@
 (fixpoint "--rewrite")
-(fixpoint "--save")
 
 (constant len (func 1 ((Vec @(0))) Int))
 

--- a/tests/horn/pos/ple_sum.smt2
+++ b/tests/horn/pos/ple_sum.smt2
@@ -1,5 +1,4 @@
 (fixpoint "--rewrite")
-(fixpoint "--save")
  
  
  

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -102,10 +102,10 @@ unitTests lfDir
     , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         posOptions []             ExitSuccess
     , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []         []            (ExitFailure 1)
     , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []         []            (ExitFailure 1)
-    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/horn/pos/.liquid" []         []             ExitSuccess
-    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/horn/neg/.liquid" []         []            (ExitFailure 1)
-    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/horn/pos/.liquid" []         []             ExitSuccess
-    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/horn/neg/.liquid" []         []            (ExitFailure 1)
+    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
+    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
+    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
+    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
     , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         posOptions []             ExitSuccess
     , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []         []            (ExitFailure 1)
    ]
@@ -121,7 +121,8 @@ unitTests lfDir
       let absRoot = lfDir </> root
       files    <- walkDirectory absRoot
       let tests = [ rel | f <- files, isT f, let rel = makeRelative absRoot f, rel `notElem` ignored ]
-      return    $ mkTest testName testCmd code extraOpts absRoot <$> tests
+          saveDir = "--save-dir=" ++ lfDir </> "tests" </> "logs" </> "cur" </> testName
+      return $ mkTest testName testCmd code (saveDir : extraOpts) absRoot <$> tests
 
 isTest   :: FilePath -> Bool
 isTest f = takeExtension f `elem` [".fq", ".smt2"]
@@ -198,10 +199,6 @@ elimSaveCmd (LO opts) bin dir file =
 cvc5Cmd :: TestCmd
 cvc5Cmd (LO opts) bin dir file =
   printf "cd %s && %s --solver=cvc5 %s %s" dir bin opts file
-
-cvc5SaveCmd :: TestCmd
-cvc5SaveCmd (LO opts) bin dir file =
-  printf "cd %s && %s --save --solver=cvc5 %s %s" dir bin opts file
 
 ----------------------------------------------------------------------------------------
 -- Generic Helpers

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -85,31 +85,35 @@ combineReporters (TestReporter opts1 run1) (TestReporter opts2 run2)
 combineReporters _ _ = error "combineReporters needs TestReporters"
 
 unitTests :: FilePath -> IO TestTree
-unitTests lfDir
-  = group "Unit" [
-      dirTests "native-pos"           nativeCmd   "tests/pos"              posOptions skipNativePos  ExitSuccess
-    , dirTests "native-neg"           nativeCmd   "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
-    , dirTests "elim-crash"           nativeCmd   "tests/crash"            posOptions []            (ExitFailure 1)
-    , dirTests "elim-pos1"            elimCmd     "tests/pos"              posOptions []             ExitSuccess
-    , dirTests "elim-pos2"            elimCmd     "tests/elim"             posOptions []             ExitSuccess
-    , dirTests "elim-neg"             elimCmd     "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
-    , dirTests "elim-crash"           elimCmd     "tests/crash"            []                      []            (ExitFailure 1)
-    , dirTests "cvc5-pos"             cvc5Cmd     "tests/pos"              posOptions skipNativePos  ExitSuccess
-    , dirTests "cvc5-spec"            cvc5Cmd     "tests/cvc5"             posOptions skipNativePos  ExitSuccess
-    , dirTests "proof"                elimCmd     "tests/proof"            posOptions []             ExitSuccess
-    , dirTests "rankN"                elimCmd     "tests/rankNTypes"       posOptions []             ExitSuccess
-    , dirTests "horn-pos-el"          elimSaveCmd "tests/horn/pos"         posOptions []             ExitSuccess
-    , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         posOptions []             ExitSuccess
-    , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []         []            (ExitFailure 1)
-    , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []         []            (ExitFailure 1)
-    , dirJsonTests "horn-json-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
-    , dirJsonTests "horn-json-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
-    , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
-    , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
-    , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         posOptions []             ExitSuccess
-    , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []         []            (ExitFailure 1)
-   ]
-   where
+unitTests lfDir =
+    group "All"
+      [ group "original"
+        [ dirTests "native-pos"           nativeCmd   "tests/pos"              posOptions skipNativePos  ExitSuccess
+        , dirTests "native-neg"           nativeCmd   "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
+        , dirTests "elim-crash"           nativeCmd   "tests/crash"            posOptions []            (ExitFailure 1)
+        , dirTests "elim-pos1"            elimCmd     "tests/pos"              posOptions []             ExitSuccess
+        , dirTests "elim-pos2"            elimCmd     "tests/elim"             posOptions []             ExitSuccess
+        , dirTests "elim-neg"             elimCmd     "tests/neg"              [] ["float.fq"]  (ExitFailure 1)
+        , dirTests "elim-crash"           elimCmd     "tests/crash"            []                      []            (ExitFailure 1)
+        , dirTests "cvc5-pos"             cvc5Cmd     "tests/pos"              posOptions skipNativePos  ExitSuccess
+        , dirTests "cvc5-spec"            cvc5Cmd     "tests/cvc5"             posOptions skipNativePos  ExitSuccess
+        , dirTests "proof"                elimCmd     "tests/proof"            posOptions []             ExitSuccess
+        , dirTests "rankN"                elimCmd     "tests/rankNTypes"       posOptions []             ExitSuccess
+        , dirTests "horn-pos-el"          elimSaveCmd "tests/horn/pos"         posOptions []             ExitSuccess
+        , dirTests "horn-pos-cvc5"        cvc5Cmd     "tests/horn/pos"         posOptions []             ExitSuccess
+        , dirTests "horn-neg-el"          elimSaveCmd "tests/horn/neg"         []         []            (ExitFailure 1)
+        , dirTests "horn-neg-cvc5"        cvc5Cmd     "tests/horn/neg"         []         []            (ExitFailure 1)
+        , dirTests "horn-pos-na"          nativeCmd   "tests/horn/pos"         posOptions []             ExitSuccess
+        , dirTests "horn-neg-na"          nativeCmd   "tests/horn/neg"         []         []            (ExitFailure 1)
+        ]
+      , after AllSucceed "original" <$> group "saved"
+        [ dirJsonTests "horn-json-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
+        , dirJsonTests "horn-json-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
+        , dirHornTests "horn-smt2-pos-el" elimCmd     "tests/logs/cur/horn-pos-el" []         []             ExitSuccess
+        , dirHornTests "horn-smt2-neg-el" elimCmd     "tests/logs/cur/horn-neg-el" []         []            (ExitFailure 1)
+        ]
+      ]
+  where
     posOptions = ["--save-bfq-on-error"]
 
     dirTests     n a b c d e = testGroup n <$> dirTests' n isTest a b c d e


### PR DESCRIPTION
The `test` testsuite runs `fixpoint` more than once over the same queries with different parameters. Sometimes these executions would output files to the same locations, potentially overriding each other outputs.

In addition, some tests depend on the outputs of others.

This PR arranges outputs of different executions to go to different folders, and declares the dependencies between tests to the testing framework, so they are run in the appropriate order.