### PR TITLE
unelab kvar solutions before applying them in PLE

### DIFF
--- a/src/Language/Fixpoint/Solver.hs
+++ b/src/Language/Fixpoint/Solver.hs
@@ -290,7 +290,7 @@ solveNative' !cfg !fi0 = do
   -- rnf soln `seq` donePhase Loud "Solve2"
   --let stat = resStatus res
   -- saveSolution cfg res
-  when (save cfg) $ saveSolution cfg res
+  when (save cfg) $ Sol.saveSolution cfg "" res
   -- writeLoud $ "\nSolution:\n"  ++ showpp (resSolution res)
   -- colorStrLn (colorResult stat) (show stat)
   return res
@@ -309,28 +309,6 @@ parseFI f = do
   return $ mempty { Types.quals = Types.quals  fi
                   , Types.gLits = Types.gLits  fi
                   , Types.dLits = Types.dLits  fi }
-
-saveSolution :: Config -> Result a -> IO ()
-saveSolution cfg res = when (save cfg) $ do
-  let f = queryFile Out cfg
-  putStrLn $ "Saving Solution: " ++ f ++ "\n"
-  ensurePath f
-  writeFile f $ unlines $
-    [ ""
-    , "Solution:"
-    , scopedRender (resSolution  res)
-    ] ++
-    [ ""
-    , ""
-    , "Non-cut kvars:"
-    , ""
-    , scopedRender (HashMap.map forceDelayed $ resNonCutsSolution res)
-    ]
-    where
-      scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
-      scoped sol = [ (k, scope k, e) | (k, e) <- HashMap.toList sol]
-      scope k = HashMap.lookupDefault [] k $ resSorts res
-      ncDoc (k, xts, e) = PJ.hsep [ pprint k PJ.<> pprint xts, ":=", pprint e ]
 
 simplifyResult :: Config -> Result a -> Result a
 simplifyResult cfg res =

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -31,7 +31,7 @@ module Language.Fixpoint.Solver.PLE
 
 import           Language.Fixpoint.Types hiding (simplify)
 import           Language.Fixpoint.Types.Config  as FC
-import           Language.Fixpoint.Types.Solutions (CMap, Solution)
+import           Language.Fixpoint.Types.Solutions (CMap, EQual(..), QBind(..), Sol(..), Solution)
 import qualified Language.Fixpoint.Types.Visitor as Vis
 import qualified Language.Fixpoint.Misc          as Misc
 import qualified Language.Fixpoint.Smt.Interface as SMT
@@ -84,11 +84,14 @@ instantiate cfg fi' mSol subcIds = do
     let cs = M.filterWithKey
                (\i c -> isPleCstr aEnv i c && maybe True (i `L.elem`) subcIds)
                (cm info)
+        -- To motivate unelaborating the solution here,
+        -- see https://github.com/ucsd-progsys/liquidhaskell/issues/2649
+        mSol' = unElabSolution <$> mSol
     let t  = mkCTrie (M.toList cs)                                          -- 1. BUILD the Trie
     res   <- withRESTSolver $ \solver -> do
                ctx <- get
                (res, ctx') <- liftIO $ withProgressM (`runStateT` ctx) (1 + M.size cs) $ do
-                 env <- instEnv cfg info mSol cs solver
+                 env <- instEnv cfg info mSol' cs solver
                  pleTrie t env                                              -- 2. TRAVERSE Trie to compute InstRes
                put ctx'
                return res
@@ -127,6 +130,18 @@ savePLEEqualities cfg info sEnv res = when (save cfg) $ do
             concatMap conjuncts eqs
            )
       $+$ ""
+
+-- | unElab instantiated qualifiers in the given solution
+unElabSolution :: Solution -> Solution
+unElabSolution s = s
+    { sMap = M.map unElabQBind (sMap s)
+    }
+  where
+    unElabQBind :: QBind -> QBind
+    unElabQBind (QB eqs) = QB (map unElabEQual eqs)
+
+    unElabEQual :: EQual -> EQual
+    unElabEQual eq = eq { eqPred = unElab $ eqPred eq }
 
 -------------------------------------------------------------------------------
 -- | Step 1a: @instEnv@ sets up the incremental-PLE environment

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -20,23 +20,29 @@ module Language.Fixpoint.Solver.Solution
 
   , nonCutsResult
 
+    -- * Save Solution
+  , saveSolution
+
     -- * Exported for Testing
   , simplifyKVar
   , alphaEq
   ) where
 
 import           Control.Arrow (second, (***))
-import           Control.Monad                  (guard, mplus)
+import           Control.Monad                  (guard, mplus, when)
 import           Control.Monad.Reader
 import qualified Data.HashSet                   as S
 import qualified Data.HashMap.Strict            as M
 import qualified Data.List                      as List
 import           Data.Maybe                     (maybeToList, isJust, isNothing)
+import qualified Text.PrettyPrint.HughesPJ      as PJ
 import           Language.Fixpoint.Types.PrettyPrint ()
 import           Language.Fixpoint.Types.Visitor      as V
 import           Language.Fixpoint.SortCheck          (ElabM)
 import qualified Language.Fixpoint.SortCheck          as So
+import           Language.Fixpoint.Misc               (ensurePath)
 import qualified Language.Fixpoint.Misc               as Misc
+import qualified Language.Fixpoint.Utils.Files        as Files
 import           Language.Fixpoint.Types.Config
 import qualified Language.Fixpoint.Types              as F
 import qualified Language.Fixpoint.Types.Solutions    as Sol
@@ -644,3 +650,29 @@ isVarEq fvs ei0 = case ei0 of
     isVarIn (F.EVar s) vs
       | elem s vs = Just s
     isVarIn _ _vs = Nothing
+
+--------------------------------------------------------------------------------
+-- | Save Solution to File -----------------------------------------------------
+--------------------------------------------------------------------------------
+
+saveSolution :: Config -> String -> Result a -> IO ()
+saveSolution cfg sfx res = when (save cfg) $ do
+  let f = Files.tempFileName (srcFile cfg ++ sfx ++ ".fqout")
+  putStrLn $ "Saving Solution: " ++ f ++ "\n"
+  ensurePath f
+  writeFile f $ unlines $
+    [ ""
+    , "Solution:"
+    , scopedRender (resSolution  res)
+    ] ++
+    [ ""
+    , ""
+    , "Non-cut kvars:"
+    , ""
+    , scopedRender (M.map forceDelayed $ resNonCutsSolution res)
+    ]
+    where
+      scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
+      scoped sol = [ (k, scope k, e) | (k, e) <- M.toList sol]
+      scope k = M.lookupDefault [] k $ resSorts res
+      ncDoc (k, xts, e) = PJ.hsep [ F.pprint k PJ.<> F.pprint xts, PJ.text ":=", F.pprint e ]

--- a/src/Language/Fixpoint/Solver/Solution.hs
+++ b/src/Language/Fixpoint/Solver/Solution.hs
@@ -673,6 +673,6 @@ saveSolution cfg sfx res = when (save cfg) $ do
     ]
     where
       scopedRender = PJ.render . PJ.vcat . map ncDoc . scoped
-      scoped sol = [ (k, scope k, e) | (k, e) <- M.toList sol]
+      scoped sol = [ (k, scope k, So.unApply e) | (k, e) <- M.toList sol]
       scope k = M.lookupDefault [] k $ resSorts res
       ncDoc (k, xts, e) = PJ.hsep [ F.pprint k PJ.<> F.pprint xts, PJ.text ":=", F.pprint e ]

--- a/src/Language/Fixpoint/Solver/Solve.hs
+++ b/src/Language/Fixpoint/Solver/Solve.hs
@@ -153,6 +153,8 @@ solve_ cfg fi s2 wkl = do
 
   res2  <- case resStatus res1 of  {- then run normal PLE on remaining unsolved constraints -}
     Unsafe _ bads2 | rewriteAxioms cfg -> do
+      when (save cfg) $
+        liftIO $ S.saveSolution cfg ".pre-ple" res1
       liftSMT $ smtComment "solve: ple"
       bs <- liftSMT $ PLE.instantiate cfg fi1 (Just s3) (Just $ map fst bads2)
       -- Check the constraints one last time after PLE


### PR DESCRIPTION
Fixes https://github.com/ucsd-progsys/liquidhaskell/issues/2649.

It doesn't get verification of Uniques.hs to pass with --ple, but that is another bug to figure out.

Additionally, this PR improves saves a new fqout file before PLE, for debugging. 