### PR TITLE
Show wf constraints in prettified fixpoint queries

### DIFF
--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -11,7 +11,7 @@ import           Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import           Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
-import           Data.List (intersperse, sortOn)
+import           Data.List (group, intersperse, sortOn)
 import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -40,7 +40,9 @@ import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Refinements
   ( ExprBV(..)
   , pattern PFalse
+  , pattern PKVar
   , Reft
+  , ReftBV(..)
   , SortedReft(..)
   , conjuncts
   , expr
@@ -72,6 +74,10 @@ prettyConstraints info =
   map
     (prettyConstraint (bs info) . snd)
     (sortOn fst $ HashMap.toList (cm info))
+  ++
+  map
+    (prettyWfConstraint (bs info) . snd)
+    (sortOn fst $ HashMap.toList (ws info))
 
 prettyConstraint
   :: Fixpoint a
@@ -130,6 +136,29 @@ prettyConstraint bindEnv c =
       , sr_sort sr
       , reftPred $ sr_reft sr
       )
+
+prettyWfConstraint
+  :: Fixpoint a
+  => BindEnv a
+  -> WfC a
+  -> Doc
+prettyWfConstraint bindEnv wfc =
+  let prettyEnv =
+        concatMap (take 1) $
+        group $   -- eliminate duplicates
+        sortOn fst
+          [ (s, sr_sort sr)
+          | bId <- elemsIBindEnv $ wenv wfc
+          , let (s, sr, _a) = lookupBindEnv bId bindEnv
+          ]
+      (v, t, k) = wrft wfc
+   in hang (text "\n\nwf:") 2 $
+          hang (text "env:") 2
+            (vcat $ map prettyBind prettyEnv)
+      $+$ text "reft" <+> toFix (RR t (Reft (v, PKVar k mempty)))
+      $+$ toFixMeta (text "wf") (toFix (winfo wfc))
+  where
+    prettyBind (s, srt) = toFix s <+> ":" <+> toFix srt
 
 pprId :: Show a => Maybe a -> Doc
 pprId (Just i)  = "id" <+> text (show i)


### PR DESCRIPTION
Now .fq.prettified files show wf constraints as

```
wf:
  env:
    fix$36$$36$dEq_a148 : (GHC.Internal.Classes.Eq a##a147)
    GHC.Internal.Types.$58$ : func(1 , [@(0); [@(0)]; [@(0)]])
    GHC.Internal.Types.EQ : GHC.Internal.Types.Ordering
    GHC.Internal.Types.False : bool
    GHC.Internal.Types.GT : GHC.Internal.Types.Ordering
    GHC.Internal.Types.LT : GHC.Internal.Types.Ordering
    GHC.Internal.Types.True : bool
    GHC.Internal.Types.$91$$93$ : func(1 , [[@(0)]])
    lq_tmp$x##771 : (GHC.Internal.Classes.Eq a##a14o)
    lq_tmp$x##772 : [a##a14o]
    lq_tmp$x##773 : [a##a14o]
    xs##aS9 : [a##a147]
  reft {VV##46 : [a##a14o] | [$k_##47]}
  // META wf : tests/names/pos/Uniques.hs:18:5-6
```