### PR TITLE
Fix polymorphic sort encoding

### DIFF
--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -336,6 +336,8 @@ fappSmtSort poly m env = go
   where
 -- HKT    go t@(FVar _) ts            = SApp (sortSmtSort poly env <$> (t:ts))
 
+    -- See https://github.com/ucsd-progsys/liquid-fixpoint/pull/839 for why
+    -- @FAbs m@ is re-added.
     go (FTC c) [a]
       | setConName == symbol c   = SSet (sortSmtSort poly env (FAbs m a))
     go (FTC c) [a]

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -315,9 +315,13 @@ instance S.Store SmtSort
 --   'smtSort True  msg t' serializes a sort 't' using type variables,
 --   'smtSort False msg t' serializes a sort 't' using 'Int' instead of tyvars.
 sortSmtSort :: Bool -> SEnv DataDecl -> Sort -> SmtSort
-sortSmtSort poly env t = {- tracepp ("sortSmtSort: " ++ showpp t) $ -} go . unAbs $ t
+sortSmtSort poly env t = sortSmtSort' poly env m t
   where
     m = sortAbs t
+
+sortSmtSort' :: Bool -> SEnv DataDecl -> Int -> Sort -> SmtSort
+sortSmtSort' poly env m t = go . unAbs $ t
+  where
     go (FFunc _ _)    = SInt
     go FInt           = SInt
     go FReal          = SReal
@@ -337,13 +341,13 @@ fappSmtSort poly m env = go
     -- See https://github.com/ucsd-progsys/liquid-fixpoint/pull/839 for why
     -- @FAbs m@ is re-added.
     go (FTC c) [a]
-      | setConName == symbol c   = SSet (sortSmtSort poly env (FAbs m a))
+      | setConName == symbol c   = SSet (sortSmtSort' poly env m a)
     go (FTC c) [a]
-      | bagConName == symbol c   = SBag (sortSmtSort poly env (FAbs m a))
+      | bagConName == symbol c   = SBag (sortSmtSort' poly env m a)
     go (FTC c) [FNatNum n]
       | ffldConName == symbol c  = SFFld n
     go (FTC c) [a, b]
-      | arrayConName == symbol c = SArray (sortSmtSort poly env (FAbs m a)) (sortSmtSort poly env (FAbs m b))
+      | arrayConName == symbol c = SArray (sortSmtSort' poly env m a) (sortSmtSort' poly env m b)
     go (FTC bv) [FTC s]
       | bitVecName == symbol bv
       , Just n <- sizeBv s      = SBitVec n
@@ -351,7 +355,7 @@ fappSmtSort poly m env = go
       | isString s              = SString
     go (FTC c) ts
       | Just n <- tyArgs c env
-      , let i = n - length ts   = SData c ((sortSmtSort poly env . FAbs m <$> ts) ++ pad i)
+      , let i = n - length ts   = SData c ((sortSmtSort' poly env m <$> ts) ++ pad i)
     go _ _                      = SInt
 
     pad i | poly                = []

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -337,13 +337,13 @@ fappSmtSort poly m env = go
 -- HKT    go t@(FVar _) ts            = SApp (sortSmtSort poly env <$> (t:ts))
 
     go (FTC c) [a]
-      | setConName == symbol c   = SSet (sortSmtSort poly env a)
+      | setConName == symbol c   = SSet (sortSmtSort poly env (FAbs m a))
     go (FTC c) [a]
-      | bagConName == symbol c   = SBag (sortSmtSort poly env a)
+      | bagConName == symbol c   = SBag (sortSmtSort poly env (FAbs m a))
     go (FTC c) [FNatNum n]
       | ffldConName == symbol c  = SFFld n
     go (FTC c) [a, b]
-      | arrayConName == symbol c = SArray (sortSmtSort poly env a) (sortSmtSort poly env b)
+      | arrayConName == symbol c = SArray (sortSmtSort poly env (FAbs m a)) (sortSmtSort poly env (FAbs m b))
     go (FTC bv) [FTC s]
       | bitVecName == symbol bv
       , Just n <- sizeBv s      = SBitVec n

--- a/src/Language/Fixpoint/Types/Theories.hs
+++ b/src/Language/Fixpoint/Types/Theories.hs
@@ -334,8 +334,6 @@ sortSmtSort poly env t = {- tracepp ("sortSmtSort: " ++ showpp t) $ -} go . unAb
 fappSmtSort :: Bool -> Int -> SEnv DataDecl -> Sort -> [Sort] -> SmtSort
 fappSmtSort poly m env = go
   where
--- HKT    go t@(FVar _) ts            = SApp (sortSmtSort poly env <$> (t:ts))
-
     -- See https://github.com/ucsd-progsys/liquid-fixpoint/pull/839 for why
     -- @FAbs m@ is re-added.
     go (FTC c) [a]


### PR DESCRIPTION

`fappSmtSort` receives `m` (the number of type parameters in scope) from `sortSmtSort`, but the `Array`, `Set`, and `Bag` cases were recursively calling `sortSmtSort` on sub-sorts without re-wrapping them in `FAbs m`. Each recursive call recomputes `m = sortAbs t` on the unwrapped sub-sort, so a bare `FVar 0` gives `m = -1`, the guard `i < m` fails, and the type variable silently becomes `Int`.

This caused a parametric datatype like:

```
(datatype (Adt 1) ((mk ((fld0 int) (fld1 (Array_t int @(0)))))))
```

to be emitted as `(Array Int Int)` instead of `(Array Int T0)`, producing Z3 sort mismatches when instantiated with non-Int types.

The fix wraps sub-sorts with `FAbs m` before recursing, matching what the `SData` case already did correctly.