### PR TITLE
Add sort-compatibility check for measure application in PLE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,23 @@
 ---
-version: 2.0
+version: 2.1
 
+# This CircleCI job is the only one testing liquid-fixpoint with the
+# --interpreter flag.
 jobs:
-  build:
+  test-interpreter-flag:
     machine:
       image: default
     steps:
       - run: sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -yq curl git ssh unzip wget libtinfo-dev gcc make
       - add_ssh_keys
       - run:
-          name: Install z3
+          name: Install z3-4.10.2
           command: |
-            wget https://github.com/Z3Prover/z3/releases/download/z3-4.8.7/z3-4.8.7-x64-ubuntu-16.04.zip
-            unzip z3-4.8.7-x64-ubuntu-16.04.zip
-            rm -f z3-4.8.7-x64-ubuntu-16.04.zip
-            sudo cp z3-4.8.7-x64-ubuntu-16.04/bin/libz3.a /usr/local/lib
-            sudo cp z3-4.8.7-x64-ubuntu-16.04/bin/z3 /usr/local/bin
-            sudo cp z3-4.8.7-x64-ubuntu-16.04/include/* /usr/local/include
-            rm -rf z3-4.8.7-x64-ubuntu-16.04
+            wget https://github.com/Z3Prover/z3/releases/download/z3-4.10.2/z3-4.10.2-x64-glibc-2.31.zip
+            unzip z3-4.10.2-x64-glibc-2.31.zip
+            rm -f z3-4.10.2-x64-glibc-2.31.zip
+            sudo cp z3-4.10.2-x64-glibc-2.31/bin/z3 /usr/local/bin
+            rm -rf z3-4.10.2-x64-glibc-2.31
             z3 --version
       - run:
           name: Install cvc5
@@ -29,18 +29,23 @@ jobs:
             rm -rf cvc5-Linux-x86_64-static
             cvc5 --version
       - checkout
+
+      - run:
+          name: List dependencies
+          command: |
+            wget -qO- https://get.haskellstack.org/ | sudo sh
+            stack ls dependencies json | jq > stack-deps.json
+
       - restore_cache:
           keys:
-            - stack-cache-v1-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
-            - stack-cache-v1-{{ checksum "stack.yaml" }}
+            - stack-cache-v1-{{ checksum "stack-deps.json" }}
       - run:
           name: Dependencies
           command: |
-            wget -qO- https://get.haskellstack.org/ | sudo sh
             stack --no-terminal setup
             stack --no-terminal build -j2 liquid-fixpoint --only-dependencies --test --no-run-tests
       - save_cache:
-          key: stack-cache-v1-{{ checksum "stack.yaml" }}-{{ checksum "liquid-fixpoint.cabal" }}
+          key: stack-cache-v1-{{ checksum "stack-deps.json" }}
           paths:
             - ~/.stack
             - ./.stack-work
@@ -60,3 +65,8 @@ jobs:
       - run:
           name: Dist
           command: stack --no-terminal sdist
+
+workflows:
+   build:
+     jobs:
+      - test-interpreter-flag

--- a/src/Language/Fixpoint/Solver/Interpreter.hs
+++ b/src/Language/Fixpoint/Solver/Interpreter.hs
@@ -136,7 +136,8 @@ evalCandsLoop ie ictx0 γ env = go ictx0
   where
     withRewrites exprs =
       let
-        rws = [rewrite e rw | rw <- snd <$> M.toList (knSims γ)
+        sortEnv = seSort (evEnv env)
+        rws = [rewrite sortEnv e rw | rw <- snd <$> M.toList (knSims γ)
                             ,  e <- S.toList (snd `S.map` exprs)]
       in
         exprs <> S.fromList (concat rws)
@@ -162,8 +163,8 @@ evalOneCandStep env γ env' (ictx, acc) e = do
   res <- evalOne env γ env' ictx e
   return (ictx, res : acc)
 
-rewrite :: Expr -> Rewrite -> [(Expr,Expr)]
-rewrite e rw = Mb.mapMaybe (`rewriteTop` rw) (notGuardedApps e)
+rewrite :: SEnv Sort -> Expr -> Rewrite -> [(Expr,Expr)]
+rewrite env e rw = filter (wellSorted env . fst) $ Mb.mapMaybe (`rewriteTop` rw) (notGuardedApps e)
 
 rewriteTop :: Expr -> Rewrite -> Maybe (Expr,Expr)
 rewriteTop e rw
@@ -173,6 +174,10 @@ rewriteTop e rw
   = Just (EApp (EVar $ smName rw) e, subst (mkSubst $ zip (smArgs rw) es) (smBody rw))
   | otherwise
   = Nothing
+
+-- | Check that an expression is well-sorted
+wellSorted :: SEnv Sort -> Expr -> Bool
+wellSorted env = Mb.isJust . checkSortExpr dummySpan env
 
 ----------------------------------------------------------------------------------------------
 -- | Step 3: @resSInfo@ uses incremental PLE result @InstRes@ to produce the strengthened SInfo
@@ -262,8 +267,9 @@ updCtx InstEnv{..} ctx delta cidMb
           , icSubcId = cidMb -- fst <$> L.find (\(_, b) -> (head delta) `memberIBindEnv` (_cenv b)) ieCstrs
           }                  -- eliminate above if nothing broken
   where
-    initEqs   = S.fromList $ concat [rewrite e rw | e  <- cands ++ (snd <$> S.toList (icEquals ctx))
+    initEqs   = S.fromList $ concat [rewrite sortEnv e rw | e  <- cands ++ (snd <$> S.toList (icEquals ctx))
                                                   , rw <- snd <$> M.toList (knSims ieKnowl)]
+    sortEnv   = seSort (evEnv ieEvEnv)
     cands     = concatMap (makeCandidates ieKnowl ctx) (rhs:es)
     sims      = S.filter (isSimplification (knDCs ieKnowl)) (initEqs <> icEquals ctx)
     econsts   = M.fromList $ findConstants ieKnowl es

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -1144,10 +1144,17 @@ evalApp γ ctx e0 args@(e:es) _
 evalApp γ ctx e0 es _et
   | eqs@(_:_) <- noUserDataMeasureEqs γ (eApps e0 es)
   = do
-       let eqs' = map (second $ simplify γ ctx) eqs
-       modify $ \st ->
-         st { evNewEqualities = foldr S.insert (evNewEqualities st) eqs' }
-       return Nothing
+       env <- gets (seSort . evEnv)
+       -- Only well-sorted LHSs should be considered. For instance, a measure
+       -- expecting an argument of type [[Int]] should not be applied to a value
+       -- of type [Int].
+       let eqs' = map (second $ simplify γ ctx) $
+                    filter (wellSorted env . fst) eqs
+       if null eqs' then return Nothing
+       else do
+         modify $ \st ->
+           st { evNewEqualities = foldr S.insert (evNewEqualities st) eqs' }
+         return Nothing
 
 evalApp γ ctx e0 es et
   | ELam (argName, _) body <- dropECst e0
@@ -1258,6 +1265,10 @@ noUserDataMeasureEqs γ e =
   , (rw, NoUserDataSMeasure) <- rws
   , length es == length (smArgs rw)
   ]
+
+-- | Check that an expression is well-sorted
+wellSorted :: SEnv Sort -> Expr -> Bool
+wellSorted env = Mb.isJust . checkSortExpr dummySpan env
 
 --------------------------------------------------------------------------------
 -- | 'substEq' unfolds or instantiates an equation at a particular list of

--- a/tests/proof/ple_measure_sort_compat.fq
+++ b/tests/proof/ple_measure_sort_compat.fq
@@ -1,0 +1,35 @@
+fixpoint "--rewrite"
+
+// Regression test: PLE should not apply a measure defined on [int]
+// to a [[int]] constructor application. Both share the (:) constructor
+// but have incompatible sorts.
+
+data List 1 = [
+  | Nil  { }
+  | Cons { hd : @(0), tl : List @(0) }
+]
+
+// measure m works on List int (i.e., [int])
+constant m : (func(0, [(List int); int]))
+
+// measure ms works on List (List int) (i.e., [[int]])
+constant ms : (func(0, [(List (List int)); int]))
+
+match m Nil       { 0 }
+match m Cons x xs { 1 + m xs }
+
+match ms Nil       { 0 }
+match ms Cons x xs { 1 + m x + ms xs }
+
+bind 0 a : {v : (List int) | true }
+bind 1 b : {v : (List (List int)) | true }
+
+// This constraint requires PLE to unfold ms on a [[int]] expression
+// without spuriously applying m to it.
+constraint:
+  env [0; 1]
+  lhs {v : int | true }
+  rhs {v : int | ms (Cons a (Cons a Nil)) = (1 + m a) + (1 + m a) + 0 }
+  id 1 tag []
+
+expand [1 : True]


### PR DESCRIPTION
PLE's evalApp and noUserDataMeasureEqs would apply all measures keyed by a data constructor (e.g., (:)) to any constructor application, regardless of whether the expression's sort matched the measure's expected argument sort. This caused elaboration crashes when e.g. a measure on [Int] was applied to a [[Int]] expression.

Add well-sortness checks that use checkSortExpr to verify sort compatibility before generating measure equations.