### PR TITLE
Change the syms method so it returns a HashSet

### DIFF
--- a/src/Language/Fixpoint/Horn/Info.hs
+++ b/src/Language/Fixpoint/Horn/Info.hs
@@ -215,7 +215,7 @@ maxQualifierParams = 3
 qualParams :: BindEnv -> F.Expr -> [(F.Symbol, F.Sort)]
 qualParams env e = [ (x, t) | (_, x, t) <- L.sortBy (comparing Down) ixts ]
   where
-    xs = Misc.nubOrd (F.syms e)
+    xs = S.toList (F.syms e)
     ixts = [ (i, x, t) | x <- xs, (t, i) <- Mb.maybeToList (lookupBindEnv x env) ]
 
 -------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Horn/Transformations.hs
+++ b/src/Language/Fixpoint/Horn/Transformations.hs
@@ -641,7 +641,7 @@ rewriteWithEqualities cfg measures n args equalities = preds
     thySyms = F.theorySymbols (F.solver cfg)
 
     isWellFormed :: F.Expr -> Bool
-    isWellFormed e = S.fromList (F.syms e) `S.isSubsetOf` argsAndPrims
+    isWellFormed e = S.fromList (HS.toList $ F.syms e) `S.isSubsetOf` argsAndPrims
 
     makeWellFormed :: Int -> [F.Expr] -> [F.Expr]
     makeWellFormed 0 exprs = filter isWellFormed exprs -- We solved it. Maybe.
@@ -649,7 +649,7 @@ rewriteWithEqualities cfg measures n args equalities = preds
       where
         go expr = if isWellFormed expr then [expr] else rewrite rewrites [expr]
           where
-            needSolving = S.fromList (F.syms expr) `S.difference` argsAndPrims
+            needSolving = S.fromList (HS.toList $ F.syms expr) `S.difference` argsAndPrims
             rewrites = (\x -> (x, filter (/= F.EVar x) $ sols x)) <$> S.toList needSolving
             rewrite [] es = es
             rewrite ((x, rewriteExprs):rewriteExprs') es = rewrite rewriteExprs' $ [F.subst (F.mkSubst [(x, e')]) e | e' <- rewriteExprs, e <- es]

--- a/src/Language/Fixpoint/Horn/Types.hs
+++ b/src/Language/Fixpoint/Horn/Types.hs
@@ -43,10 +43,10 @@ import           Control.DeepSeq ( NFData )
 import qualified Data.Text               as T
 import           Data.Maybe (fromMaybe)
 import qualified Data.List               as L
-import qualified Language.Fixpoint.Misc  as Misc
 import qualified Language.Fixpoint.Types as F
 import qualified Text.PrettyPrint.HughesPJ.Compat as P
 import qualified Data.HashMap.Strict as M
+import qualified Data.HashSet as S
 import           Data.Aeson
 import           Data.Aeson.Types
 
@@ -80,8 +80,8 @@ instance F.ToHornSMT Pred where
 
 instance F.Subable Pred where
   syms (Reft e)   = F.syms e
-  syms (Var _ xs) = concatMap F.syms xs
-  syms (PAnd ps)  = concatMap F.syms ps
+  syms (Var _ xs) = F.syms xs
+  syms (PAnd ps)  = F.syms ps
 
   substa f (Reft e)   = Reft  (F.substa f      e)
   substa f (Var k xs) = Var k (F.substa f <$> xs)
@@ -131,7 +131,7 @@ mkQual env v p = case envSort env <$> (v:xs) of
                    (_,so):xts -> F.mkQ "Auto" ((v, so) : xts) p junk
                    _          -> F.panic "impossible"
   where
-    xs         = L.delete v $ Misc.setNub (F.syms p)
+    xs         = S.toList $ S.delete v $ F.syms p
     junk       = F.dummyPos "mkQual"
 
 envSort :: F.SEnv F.Sort -> F.Symbol -> (F.Symbol, F.Sort)
@@ -163,7 +163,7 @@ instance F.ToHornSMT (Bind a) where
   toHornSMT (Bind x t p _) = P.parens (F.toHornSMT (x, t) P.<+> F.toHornSMT p)
 
 instance F.Subable (Bind a) where
-    syms     (Bind x _ p _) = x : F.syms p
+    syms     (Bind x _ p _) = S.insert x $ F.syms p
     substa f (Bind v t p a) = Bind (f v) t (F.substa f p) a
     substf f (Bind v t p a) = Bind v t (F.substf (F.substfExcept f [v]) p) a
     subst su (Bind v t p a)  = Bind v t (F.subst (F.substExcept su [v]) p) a

--- a/src/Language/Fixpoint/Misc.hs
+++ b/src/Language/Fixpoint/Misc.hs
@@ -18,7 +18,6 @@ import           Control.Arrow                    (second)
 import           Control.Monad                    (when, forM_, filterM)
 import qualified Data.HashMap.Strict              as M
 import qualified Data.List                        as L
-import qualified Data.HashSet                     as S
 import qualified Data.Map                         as Map
 import qualified Data.Set                         as Set
 import           Data.Tuple                       (swap)
@@ -395,14 +394,6 @@ allCombinations xs = assert (all ((length xs == ) . length)) $ go xs
 
 powerset :: [a] -> [[a]]
 powerset xs = filterM (const [False, True]) xs
-
--- Null if first is a subset of second
-nubDiff :: (Eq a, Hashable a) => [a] -> [a] -> S.HashSet a
-nubDiff a b = a' `S.difference` b'
-  where
-    a' = S.fromList a
-    b' = S.fromList b
-
 
 fold1M :: (Monad m) => (a -> a -> m a) -> [a] -> m a
 fold1M _ []         = errorstar "fold1M with empty list"

--- a/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
+++ b/src/Language/Fixpoint/Solver/EnvironmentReduction.hs
@@ -91,9 +91,9 @@ import           Language.Fixpoint.Types.Refinements
   , reftBind
   , reftPred
   , sortedReftSymbols
-  , subst1
   , fromKVarSubst
   )
+import           Language.Fixpoint.Types.Substitutions (subst1)
 import           Language.Fixpoint.Types.Sorts (boolSort, sortSymbols)
 import           Language.Fixpoint.Types.Visitor (mapExprOnExpr)
 import Language.Fixpoint.Misc (snd3)

--- a/src/Language/Fixpoint/Solver/Interpreter.hs
+++ b/src/Language/Fixpoint/Solver/Interpreter.hs
@@ -598,7 +598,7 @@ knowledge info = KN
     aenv = ae info
 
     makeCons rw
-      | null (syms $ smBody rw)
+      | S.null (syms $ smBody rw)
       = Just (smName rw, (smDC rw, smBody rw))
       | otherwise
       = Nothing
@@ -731,7 +731,7 @@ normalizeBody :: Symbol -> Expr -> Expr
 normalizeBody f = go
   where
     go e
-      | elem f (syms e)
+      | S.member f (syms e)
       = go' e
     go e
       = e

--- a/src/Language/Fixpoint/Solver/PLE.hs
+++ b/src/Language/Fixpoint/Solver/PLE.hs
@@ -1437,7 +1437,7 @@ knowledge cfg si = KN
 
 
     makeCons rw
-      | null (syms $ smBody rw)
+      | S.null (syms $ smBody rw)
       = Just (smName rw, (smDC rw, smBody rw))
       | otherwise
       = Nothing
@@ -1564,7 +1564,7 @@ instance Normalizable Equation where
 
 -- | Normalize the given named expression if it is recursive.
 normalizeBody :: Symbol -> Expr -> Expr
-normalizeBody f exprs | f `elem` syms exprs = go exprs
+normalizeBody f exprs | f `S.member` syms exprs = go exprs
   where
     -- @go@ performs this simplification:
     --     (c => e1) /\ ((not c) => e2) --> if c then e1 else e2

--- a/src/Language/Fixpoint/Solver/Prettify.hs
+++ b/src/Language/Fixpoint/Solver/Prettify.hs
@@ -51,11 +51,10 @@ import           Language.Fixpoint.Types.Refinements
   , reftBind
   , reftPred
   , sortedReftSymbols
-  , substf
   , substSortInExpr
   )
 import           Language.Fixpoint.Types.Sorts (Sort(..), substSort)
-import           Language.Fixpoint.Types.Substitutions (exprSymbolsSet)
+import           Language.Fixpoint.Types.Substitutions (exprSymbolsSet, substf)
 import qualified Language.Fixpoint.Utils.Files as Files
 import           System.FilePath (addExtension)
 import           Text.PrettyPrint.HughesPJ.Compat

--- a/src/Language/Fixpoint/Solver/Sanitize.hs
+++ b/src/Language/Fixpoint/Solver/Sanitize.hs
@@ -300,10 +300,10 @@ cNoFreeVars fi knownSym c = if S.null fv then Nothing else Just (S.toList fv)
   where
     be   = F.bs fi
     ids  = F.elemsIBindEnv $ F.senv c
-    cDom = [Misc.fst3 $ F.lookupBindEnv i be | i <- ids]
-    cRng = concat [S.toList . F.reftFreeVars . F.sr_reft . Misc.snd3 $ F.lookupBindEnv i be | i <- ids]
-        ++ F.syms (F.crhs c)
-    fv   = (`Misc.nubDiff` cDom) . filter (not . knownSym) $ cRng
+    cDom = S.fromList [Misc.fst3 $ F.lookupBindEnv i be | i <- ids]
+    cRng = S.unions [F.syms . F.sr_reft . Misc.snd3 $ F.lookupBindEnv i be | i <- ids]
+        `S.union` F.syms (F.crhs c)
+    fv   = S.filter (not . knownSym) $ cRng `S.difference` cDom
 
 badCs :: Misc.ListNE (F.SimpC a, [F.Symbol]) -> E.Error
 badCs = E.catErrors . map (E.errFreeVarInConstraint . Bifunctor.first F.subcId)
@@ -326,12 +326,12 @@ banQualifFreeVars :: Config -> F.SInfo a -> SanitizeM (F.SInfo a)
 --------------------------------------------------------------------------------
 banQualifFreeVars cfg fi = Misc.applyNonNull (Right fi) (Left . badQuals) bads
   where
-    bads    = [ (q, xs) | q <- F.quals fi, let xs = free q, not (null xs) ]
-    free q  = filter (not . isGlobal) (F.syms q)
+    bads    = [ (q, xs) | q <- F.quals fi, let xs = free q, not (S.null xs) ]
+    free q  = S.filter (not . isGlobal) (F.syms q)
     isGlobal x = F.memberSEnv x (SortCheck.globalEnv cfg fi)
 
-badQuals     :: Misc.ListNE (F.Qualifier, Misc.ListNE F.Symbol) -> E.Error
-badQuals bqs = E.catErrors [ E.errFreeVarInQual q xs | (q, xs) <- bqs]
+badQuals     :: Misc.ListNE (F.Qualifier, S.HashSet F.Symbol) -> E.Error
+badQuals bqs = E.catErrors [ E.errFreeVarInQual q (S.toList xs) | (q, xs) <- bqs]
 
 
 --------------------------------------------------------------------------------

--- a/src/Language/Fixpoint/Solver/UniqifyBinds.hs
+++ b/src/Language/Fixpoint/Solver/UniqifyBinds.hs
@@ -81,14 +81,14 @@ updateIdMap be m scId s = M.insertWith S.union (RI scId) refSet m'
     ids                 = elemsIBindEnv (senv s)
     nameMap             = M.fromList [(fst3 $ lookupBindEnv i be, i) | i <- ids]
     m'                  = foldl' (insertIdIdLinks be nameMap) m ids
-    symSet              = S.fromList $ syms $ crhs s
+    symSet              = syms $ crhs s
     refSet              = namesToIds symSet nameMap
 
 insertIdIdLinks :: BindEnv a -> M.HashMap Symbol BindId -> IdMap -> BindId -> IdMap
 insertIdIdLinks be nameMap m i = M.insertWith S.union (RB i) refSet m
   where
     sr     = snd3 $ lookupBindEnv i be
-    symSet = reftFreeVars $ sr_reft sr
+    symSet = syms $ sr_reft sr
     refSet = namesToIds symSet nameMap
 
 namesToIds :: S.HashSet Symbol -> M.HashMap Symbol BindId -> S.HashSet BindId

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -24,7 +24,6 @@ module Language.Fixpoint.SortCheck  (
 
   -- * Checking Well-Formedness
   , checkSorted
-  , checkSortedReft
   , checkSortedReftFull
   , checkSortFull
   , pruneUnsortedReft
@@ -539,7 +538,7 @@ checkSortExpr sp γ e = case runCM0 sp Nothing (checkExpr f e) of
 subEnv :: (Subable e, Variable e ~ Symbol) => SEnv a -> e -> SEnv a
 subEnv g e = intersectWithSEnv const g g'
   where
-    g' = fromListSEnv $ (, ()) <$> syms e
+    g' = fromSetSEnv (syms e)
 
 
 --------------------------------------------------------------------------------
@@ -605,13 +604,6 @@ fresh = do
 --------------------------------------------------------------------------------
 -- | Checking Refinements ------------------------------------------------------
 --------------------------------------------------------------------------------
-checkSortedReft :: SEnv SortedReft -> [Symbol] -> SortedReft -> Maybe Doc
-checkSortedReft env xs sr = applyNonNull Nothing oops unknowns
-  where
-    oops                  = Just . (text "Unknown symbols:" <+>) . toFix
-    unknowns              = [ x | x <- syms sr, x `notElem` v : xs, not (x `memberSEnv` env)]
-    Reft (v,_)            = sr_reft sr
-
 checkSortedReftFull :: Checkable a => SrcSpan -> SEnv SortedReft -> a -> ElabM (Maybe Doc)
 checkSortedReftFull sp γ t =
   do ef <- ask

--- a/src/Language/Fixpoint/SortCheck.hs
+++ b/src/Language/Fixpoint/SortCheck.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PatternGuards         #-}
 {-# LANGUAGE BangPatterns          #-}

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -553,10 +553,10 @@ instance Subable Qualifier where
 mapQualBody :: (Expr -> Expr) -> Qualifier -> Qualifier
 mapQualBody f q = q { qBody = f (qBody q) }
 
-qualFreeSymbols :: Qualifier -> [Symbol]
-qualFreeSymbols q = filter (not . isPrim) xs
+qualFreeSymbols :: Qualifier -> S.HashSet Symbol
+qualFreeSymbols q = S.filter (not . isPrim) xs
   where
-    xs            = syms (qBody q) L.\\ syms (qpSym <$> qParams q)
+    xs            = syms (qBody q) `S.difference` S.fromList (qpSym <$> qParams q)
 
 instance Fixpoint QualParam where
   toFix (QP x _ t) = toFix (x, t)
@@ -589,8 +589,8 @@ pprQual (Q n xts p l) = text "qualif" <+> text (symbolString n) <-> parens args 
 qualifier :: SEnv Sort -> SourcePos -> SEnv Sort -> Symbol -> Sort -> Expr -> Qualifier
 qualifier lEnv l γ v so p   = mkQ "Auto" ((v, so) : xts) p l
   where
-    xs  = L.delete v $ L.nub $ syms p
-    xts = catMaybes $ zipWith (envSort l lEnv γ) xs [0..]
+    xs  = S.delete v $ syms p
+    xts = catMaybes $ zipWith (envSort l lEnv γ) (S.toList xs) [0..]
 
 mkQ :: Symbol -> [(Symbol, Sort)] -> Expr -> SourcePos -> Qualifier
 mkQ n = Q n . qualParams
@@ -1037,7 +1037,7 @@ eqnToHornSMT keyword (Equ f xs e s _) = parens (keyword <+> pprint f <+> toHornS
 
 
 mkEquation :: Symbol -> [(Symbol, Sort)] -> Expr -> Sort -> Equation
-mkEquation f xts e out = Equ f xts e out (f `elem` syms e)
+mkEquation f xts e out = Equ f xts e out (f `S.member` syms e)
 
 instance Subable Equation where
   syms   a = syms (eqBody a) -- ++ F.syms (axiomEq a)

--- a/src/Language/Fixpoint/Types/Constraints.hs
+++ b/src/Language/Fixpoint/Types/Constraints.hs
@@ -122,7 +122,7 @@ import           Language.Fixpoint.Types.Errors
 import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Sorts
 import           Language.Fixpoint.Types.Refinements
-import           Language.Fixpoint.Types.Substitutions()
+import           Language.Fixpoint.Types.Substitutions
 import           Language.Fixpoint.Types.Environments
 import qualified Language.Fixpoint.Utils.Files as Files
 import qualified Language.Fixpoint.Solver.Stats as Solver

--- a/src/Language/Fixpoint/Types/Environments.hs
+++ b/src/Language/Fixpoint/Types/Environments.hs
@@ -18,7 +18,7 @@ module Language.Fixpoint.Types.Environments (
   , SEnvB(..)
   , SESearch
   , SESearchB(..)
-  , emptySEnv, toListSEnv, fromListSEnv, fromMapSEnv
+  , emptySEnv, toListSEnv, fromListSEnv, fromMapSEnv, fromSetSEnv
   , mapSEnvWithKey, mapSEnv, mapMSEnv
   , insertSEnv, deleteSEnv, memberSEnv, lookupSEnv, unionSEnv, unionSEnv'
   , intersectWithSEnv
@@ -128,6 +128,9 @@ fromListSEnv            = SE . M.fromList
 
 fromMapSEnv             ::  M.HashMap b a -> SEnvB b a
 fromMapSEnv             = SE
+
+fromSetSEnv             ::  S.HashSet b -> SEnvB b ()
+fromSetSEnv             = SE . S.toMap
 
 mapSEnv                 :: (a₁ -> a₂) -> SEnvB b a₁ -> SEnvB b a₂
 mapSEnv f (SE env)      = SE (fmap f env)

--- a/src/Language/Fixpoint/Types/Refinements.hs
+++ b/src/Language/Fixpoint/Types/Refinements.hs
@@ -58,8 +58,6 @@ module Language.Fixpoint.Types.Refinements (
   -- * Generalizing Embedding with Typeclasses
   , Expression (..)
   , Predicate (..)
-  , Subable (..)
-
   -- * Constructors
   , reft                    -- "smart
   , trueSortedReft          -- trivial reft
@@ -128,7 +126,7 @@ import qualified Data.HashMap.Strict       as HashMap
 import           Data.HashSet              (HashSet)
 import qualified Data.HashSet              as HashSet
 import           GHC.Generics              (Generic)
-import           GHC.Stack                 (HasCallStack)
+
 #if MIN_VERSION_base(4,20,0)
 import           Data.List                 (partition)
 #else
@@ -1096,29 +1094,6 @@ instance Falseable (ExprBV b v) where
 instance Falseable (ReftBV b v) where
   isFalse (Reft (_, ra)) = isFalse ra
 
--------------------------------------------------------------------------
--- | Class Predicates for Valid Refinements -----------------------------
--------------------------------------------------------------------------
-
-class (Eq (Variable a), Hashable (Variable a)) => Subable a where
-  type Variable a
-  type Variable a = Symbol
-
-  syms   :: a -> [Variable a]                   -- ^ free symbols of a
-  substa :: (Variable a -> Variable a) -> a -> a
-  -- substa f  = substf (EVar . f)
-
-  substf :: (Variable a -> ExprBV (Variable a) (Variable a)) -> a -> a
-  subst  :: HasCallStack => SubstV (Variable a) -> a -> a
-  subst1 :: a -> (Variable a, ExprBV (Variable a) (Variable a)) -> a
-  subst1 y (x, e) = subst (Su $ M.fromList [(x,e)]) y
-
-instance Subable a => Subable (Located a) where
-  type Variable (Located a) = Variable a
-  syms (Loc _ _ x)   = syms x
-  substa f (Loc l l' x) = Loc l l' (substa f x)
-  substf f (Loc l l' x) = Loc l l' (substf f x)
-  subst su (Loc l l' x) = Loc l l' (subst su x)
 
 instance Fixpoint Doc where
   toFix = id

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE CPP               #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}
 
@@ -21,8 +24,8 @@ module Language.Fixpoint.Types.Substitutions (
   , subst1Except
   , substSymbolsSet
   , Refreshable(..)
+  , Subable(..)
   , rapierSubstExpr
-  , targetSubstSyms
   , filterSubst
   , catSubst
   , exprSymbolsSet
@@ -36,10 +39,12 @@ import           Data.Maybe
 import           Data.Hashable             (Hashable)
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
+import           GHC.Stack                 (HasCallStack)
 import           Language.Fixpoint.Types.Binders
 import           Language.Fixpoint.Types.PrettyPrint
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Sorts
+import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Refinements
 import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ.Compat
@@ -91,11 +96,28 @@ mkKVarSubst = kSubstFromSubst . mkSubst
 isEmptySubst :: SubstV v -> Bool
 isEmptySubst (Su xes) = M.null xes
 
-targetSubstSyms :: (Eq v, Hashable v) => SubstV v -> [v]
-targetSubstSyms (Su ms) = syms $ M.elems ms
-
 substSymbolsSet :: (Eq v, Hashable v) => SubstV v -> S.HashSet v
 substSymbolsSet (Su m) = S.unions $ map exprSymbolsSet (M.elems m)
+
+class (Eq (Variable a), Hashable (Variable a)) => Subable a where
+  type Variable a
+  type Variable a = Symbol
+
+  syms   :: a -> [Variable a]                   -- ^ free symbols of a
+  substa :: (Variable a -> Variable a) -> a -> a
+  -- substa f  = substf (EVar . f)
+
+  substf :: (Variable a -> ExprBV (Variable a) (Variable a)) -> a -> a
+  subst  :: HasCallStack => SubstV (Variable a) -> a -> a
+  subst1 :: a -> (Variable a, ExprBV (Variable a) (Variable a)) -> a
+  subst1 y (x, e) = subst (Su $ M.fromList [(x,e)]) y
+
+instance Subable a => Subable (Located a) where
+  type Variable (Located a) = Variable a
+  syms (Loc _ _ x)   = syms x
+  substa f (Loc l l' x) = Loc l l' (substa f x)
+  substf f (Loc l l' x) = Loc l l' (substf f x)
+  subst su (Loc l l' x) = Loc l l' (subst su x)
 
 instance Subable () where
   syms _      = []

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -163,19 +163,8 @@ substExcept  :: Eq v => SubstV v -> [v] -> SubstV v
 -- substExcept  (Su m) xs = Su (foldr M.delete m xs)
 substExcept (Su xes) xs = Su $ M.filterWithKey (const . not . (`elem` xs)) xes
 
-instance Subable Symbol where
-  substa f                 = f
-  substf f x               = subSymbol (Just (f x)) x
-  subst su x               = subSymbol (Just $ appSubst su x) x -- subSymbol (M.lookup x s) x
-  syms x                   = S.singleton x
-
 appSubst :: (Eq v, Hashable v) => SubstV v -> v -> ExprBV v v
 appSubst (Su s) x = M.findWithDefault (EVar x) x s
-
-subSymbol :: (Ord v, Hashable v, Fixpoint v) => Maybe (ExprBV v v) -> v -> v
-subSymbol (Just (EVar y)) _ = y
-subSymbol Nothing         x = x
-subSymbol _               x = x
 
 captureAvoiding :: Eq v => v -> (v -> ExprBV b v) -> v -> ExprBV b v
 captureAvoiding x f y = if y == x then EVar x else f y

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies      #-}
 {-# LANGUAGE TypeOperators     #-}

--- a/src/Language/Fixpoint/Types/Substitutions.hs
+++ b/src/Language/Fixpoint/Types/Substitutions.hs
@@ -35,7 +35,6 @@ module Language.Fixpoint.Types.Substitutions (
   ) where
 
 import           Data.List                 as List
-import           Data.Maybe
 import           Data.Hashable             (Hashable)
 import qualified Data.HashMap.Strict       as M
 import qualified Data.HashSet              as S
@@ -48,7 +47,6 @@ import           Language.Fixpoint.Types.Spans
 import           Language.Fixpoint.Types.Refinements
 import           Language.Fixpoint.Misc
 import           Text.PrettyPrint.HughesPJ.Compat
-import           Text.Printf               (printf)
 
 instance (Eq v, Hashable v) => Semigroup (SubstV v) where
   (<>) = catSubst
@@ -103,7 +101,7 @@ class (Eq (Variable a), Hashable (Variable a)) => Subable a where
   type Variable a
   type Variable a = Symbol
 
-  syms   :: a -> [Variable a]                   -- ^ free symbols of a
+  syms   :: a -> S.HashSet (Variable a)           -- ^ free symbols of a
   substa :: (Variable a -> Variable a) -> a -> a
   -- substa f  = substf (EVar . f)
 
@@ -120,28 +118,28 @@ instance Subable a => Subable (Located a) where
   subst su (Loc l l' x) = Loc l l' (subst su x)
 
 instance Subable () where
-  syms _      = []
+  syms _      = S.empty
   subst _ ()  = ()
   substf _ () = ()
   substa _ () = ()
 
 instance (Subable a, Subable b, Variable a ~ Variable b) => Subable (a,b) where
   type Variable (a, b) = Variable a
-  syms  (x, y)   = syms x ++ syms y
+  syms  (x, y)   = S.union (syms x) (syms y)
   subst su (x,y) = (subst su x, subst su y)
   substf f (x,y) = (substf f x, substf f y)
   substa f (x,y) = (substa f x, substa f y)
 
 instance Subable a => Subable [a] where
   type Variable [a] = Variable a
-  syms   = concatMap syms
+  syms   = S.unions . map syms
   subst  = fmap . subst
   substf = fmap . substf
   substa = fmap . substa
 
 instance Subable a => Subable (Maybe a) where
   type Variable (Maybe a) = Variable a
-  syms   = concatMap syms . maybeToList
+  syms = maybe S.empty syms
   subst  = fmap . subst
   substf = fmap . substf
   substa = fmap . substa
@@ -170,22 +168,22 @@ instance Subable Symbol where
   substa f                 = f
   substf f x               = subSymbol (Just (f x)) x
   subst su x               = subSymbol (Just $ appSubst su x) x -- subSymbol (M.lookup x s) x
-  syms x                   = [x]
+  syms x                   = S.singleton x
 
 appSubst :: (Eq v, Hashable v) => SubstV v -> v -> ExprBV v v
-appSubst (Su s) x = fromMaybe (EVar x) (M.lookup x s)
+appSubst (Su s) x = M.findWithDefault (EVar x) x s
 
 subSymbol :: (Ord v, Hashable v, Fixpoint v) => Maybe (ExprBV v v) -> v -> v
 subSymbol (Just (EVar y)) _ = y
 subSymbol Nothing         x = x
-subSymbol a               b = errorstar (printf "Cannot substitute symbol %s with expression %s" (showFix b) (showFix a))
+subSymbol _               x = x
 
 captureAvoiding :: Eq v => v -> (v -> ExprBV b v) -> v -> ExprBV b v
 captureAvoiding x f y = if y == x then EVar x else f y
 
 instance (Eq v, Hashable v) => Subable (ExprBV v v) where
   type Variable (ExprBV v v) = v
-  syms                     = exprSymbols
+  syms                     = exprSymbolsSet
   substa f                 = substf (EVar . f)
   substf :: (v -> ExprBV v v) -> ExprBV v v -> ExprBV v v
   substf f (EApp s e)      = EApp (substf f s) (substf f e)
@@ -352,7 +350,7 @@ extendSubst (Su m) x e = Su $ M.insert x e m
 disjointRange :: (Eq v, Hashable v) => SubstV v -> [(v, Sort)] -> Bool
 disjointRange (Su su) bs = S.null $ suSyms `S.intersection` bsSyms
   where
-    suSyms = S.fromList $ syms (M.elems su)
+    suSyms = syms (M.elems su)
     bsSyms = S.fromList $ fst <$> bs
 
 meetReft :: Binder v => ReftBV v v -> ReftBV v v -> ReftBV v v
@@ -363,7 +361,7 @@ meetReft (Reft (v, ra)) (Reft (v', ra'))
 
 instance (Eq v, Hashable v, Refreshable v) => Subable (ReftBV v v) where
   type Variable (ReftBV v v) = v
-  syms (Reft (v, ras))      = v : syms ras
+  syms = reftSymbolsSet
   substa f (Reft (v, ras))  = Reft (f v, substa f ras)
   subst su (Reft (v, ras))  =
     let su' = substExcept su [v]
@@ -371,6 +369,9 @@ instance (Eq v, Hashable v, Refreshable v) => Subable (ReftBV v v) where
      in Reft (v, rapierSubstExpr s su' ras)
   substf f (Reft (v, ras))  = Reft (v, substf (substfExcept f [v]) ras)
   subst1 (Reft (v, ras)) su = Reft (v, subst1Except [v] ras su)
+
+reftSymbolsSet :: (Eq v, Hashable v) => ReftBV v v -> S.HashSet v
+reftSymbolsSet (Reft (v, ras)) = S.delete v $ exprSymbolsSet ras
 
 instance Subable SortedReft where
   syms               = syms . sr_reft
@@ -420,34 +421,6 @@ pprReftPred (Reft (_, p))
 
 ppRas :: [Expr] -> Doc
 ppRas = cat . punctuate comma . map toFix . flattenRefas
-
---------------------------------------------------------------------------------
--- | TODO: Rewrite using visitor -----------------------------------------------
---------------------------------------------------------------------------------
--- exprSymbols :: Expr -> [Symbol]
--- exprSymbols = go
-  -- where
-    -- go (EVar x)           = [x]
-    -- go (EApp f e)         = go f ++ go e
-    -- go (ELam (x,_) e)     = filter (/= x) (go e)
-    -- go (ECoerc _ _ e)     = go e
-    -- go (ENeg e)           = go e
-    -- go (EBin _ e1 e2)     = go e1 ++ go e2
-    -- go (EIte p e1 e2)     = exprSymbols p ++ go e1 ++ go e2
-    -- go (ECst e _)         = go e
-    -- go (PAnd ps)          = concatMap go ps
-    -- go (POr ps)           = concatMap go ps
-    -- go (PNot p)           = go p
-    -- go (PIff p1 p2)       = go p1 ++ go p2
-    -- go (PImp p1 p2)       = go p1 ++ go p2
-    -- go (PAtom _ e1 e2)    = exprSymbols e1 ++ exprSymbols e2
-    -- go (PKVar _ (Su su))  = syms (M.elems su)
-    -- go (PAll xts p)       = (fst <$> xts) ++ go p
-    -- go _                  = []
-
-
-exprSymbols :: (Eq v, Hashable v) => ExprBV v v -> [v]
-exprSymbols = S.toList . exprSymbolsSet
 
 instance Expression (Symbol, SortedReft) where
   expr (x, RR _ (Reft (v, r))) = subst1 (expr r) (v, EVar x)

--- a/src/Language/Fixpoint/Types/Utils.hs
+++ b/src/Language/Fixpoint/Types/Utils.hs
@@ -23,6 +23,7 @@ import qualified Data.HashSet                         as S
 import           Language.Fixpoint.Misc
 import           Language.Fixpoint.Types.Names
 import           Language.Fixpoint.Types.Refinements
+import           Language.Fixpoint.Types.Substitutions
 import           Language.Fixpoint.Types.Environments
 import           Language.Fixpoint.Types.Constraints
 import           Language.Fixpoint.Types.Sorts

--- a/src/Language/Fixpoint/Types/Utils.hs
+++ b/src/Language/Fixpoint/Types/Utils.hs
@@ -5,9 +5,6 @@ module Language.Fixpoint.Types.Utils (
   -- * Domain of a kvar
     kvarDomain
 
-  -- * Free variables in a refinement
-  , reftFreeVars
-
   -- * Deconstruct a SortedReft
   , sortedReftConcKVars
 
@@ -41,13 +38,6 @@ domain be wfc = fst3 (wrft wfc) : map fst (envCs be $ wenv wfc)
 
 getWfC :: GInfo c a -> KVar -> WfC a
 getWfC si k = ws si M.! k
-
---------------------------------------------------------------------------------
--- | Free variables of a refinement
---------------------------------------------------------------------------------
---TODO deduplicate (also in Solver/UniqifyBinds)
-reftFreeVars :: Reft -> S.HashSet Symbol
-reftFreeVars r@(Reft (v, _)) = S.delete v $ S.fromList $ syms r
 
 --------------------------------------------------------------------------------
 -- | Split a SortedReft into its concrete and KVar conjuncts


### PR DESCRIPTION
syms was converting to list the result of computing the free symbols as a HashSet.

This PR has syms produce a HashSet instead.

This conversion was sometimes unnecessary. With the upcoming implementation of rapier substitution (https://github.com/ucsd-progsys/liquidhaskell/issues/2676), the interest to use a better representation than lists increases as well (rapier-style substitution requires providing a set with free variables as a parameter).


There is one other commit in this PR to put together the Subable class with the instances in the Substitutions module. For now, this is only to group related code together.