### PR TITLE
Avoid coercions between types with the same representation

### DIFF
--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -270,11 +270,15 @@ smt2App e = do s0 <- traverse smt2 es
     (f, es) = splitEApp' e
 
 smt2Coerc :: Sort -> Sort -> Expr -> SymM Builder
-smt2Coerc t1 t2 e
-  | t1 == t2  = smt2 e
-  | otherwise = do coerceFn <- symbolAtName coerceName (FFunc t1 t2)
-                   s <- smt2 e
-                   pure $ parenSeqs [Builder.fromText coerceFn , s]
+smt2Coerc t1 t2 e = do
+  env <- get
+  let s1 = Thy.sortSmtSort False (seData env) t1
+      s2 = Thy.sortSmtSort False (seData env) t2
+  if s1 == s2 then smt2 e
+  else do
+    coerceFn <- symbolAtName coerceName (FFunc t1 t2)
+    s <- smt2 e
+    pure $ parenSeqs [Builder.fromText coerceFn , s]
 
 splitEApp' :: Expr -> (Expr, [Expr])
 splitEApp'            = go []


### PR DESCRIPTION
Before, applications of coerce would be inserted always. This hides from the SMT solver that the argument of coerce and the result represent the same "thing".

When the source and the target type have the same sort representation, the coercion is unnecessary.

This is one of the fixes needed for https://github.com/ucsd-progsys/liquidhaskell/issues/2499