### PR TITLE
Change div/mod definition to match Haskell rounding semantics

### DIFF
--- a/src/Language/Fixpoint/Smt/Serialize.hs
+++ b/src/Language/Fixpoint/Smt/Serialize.hs
@@ -155,7 +155,7 @@ instance SMTLIB2 Bop where
   smt2 Div    = pure $ symbolBuilder divFuncName
   smt2 RTimes = pure "*"
   smt2 RDiv   = pure "/"
-  smt2 Mod    = pure "mod"
+  smt2 Mod    = pure $ symbolBuilder modFuncName
 
 instance SMTLIB2 Brel where
   smt2 Eq  = pure "="

--- a/src/Language/Fixpoint/Smt/Theories.hs
+++ b/src/Language/Fixpoint/Smt/Theories.hs
@@ -244,16 +244,19 @@ bFun' name ts out = key "declare-fun" (seqs [fromText name, args, out])
 bSort :: Raw -> Builder -> Builder
 bSort name def = key "define-sort" (fromText name <+> "()" <+> def)
 
-
+-- Generate division/modulo function that matches Haskell's rounding behavior
+-- Returns (ite (> y 0) (op x y) (- (op (- x) y)) where op can be 'div' or 'mod'
+mkHaskellDiv :: Builder -> Builder -> Builder -> Builder
+mkHaskellDiv op x y = key3 "ite" (key2 ">" y "0") (key2 op x y) (key "-" (key2 op (key "-" x) y))
 
 -- RJ: Am changing this to `Int` not `Real` as (1) we usually want `Int` and
 -- (2) have very different semantics. TODO: proper overloading, post genEApp
-uifDef :: Config -> Data.Text.Text -> Data.Text.Text -> Builder
+uifDef :: Config -> Data.Text.Text -> (Builder -> Builder -> Builder) -> Builder
 uifDef cfg f op
   | onlyLinearArith cfg -- linear cfg || Z3 /= solver cfg
   = bFun' f ["Int", "Int"] "Int"
   | otherwise
-  = bFun f [("x", "Int"), ("y", "Int")] "Int" (key2 (fromText op) "x" "y")
+  = bFun f [("x", "Int"), ("y", "Int")] "Int" (op "x" "y")
 
 onlyLinearArith :: Config -> Bool
 onlyLinearArith cfg = linear cfg || solver cfg `notElem` [Z3, Z3mem, Cvc5]
@@ -295,8 +298,9 @@ boolPreamble _
 
 arithPreamble :: Config -> [Preamble]
 arithPreamble cfg = (SAll,) <$>
- [ uifDef cfg (symbolText mulFuncName) "*"
- , uifDef cfg (symbolText divFuncName) "div"
+ [ uifDef cfg (symbolText mulFuncName) (key2 "*")
+ , uifDef cfg (symbolText divFuncName) (mkHaskellDiv "div")
+ , bFun (symbolText modFuncName) [("x", "Int"), ("y", "Int")] "Int" (mkHaskellDiv "mod" "x" "y")
  ]
 
 stringPreamble :: Config -> [Preamble]

--- a/src/Language/Fixpoint/Types/Names.hs
+++ b/src/Language/Fixpoint/Types/Names.hs
@@ -120,6 +120,7 @@ module Language.Fixpoint.Types.Names (
   , prims
   , mulFuncName
   , divFuncName
+  , modFuncName
 
   -- * Casting function names
   , setToIntName, bitVecToIntName, mapToIntName, bagToIntName, boolToIntName, realToIntName, toIntName, tyCastName
@@ -702,9 +703,10 @@ sizeName      = "Size"
 bitVecName    = "BitVec"
 
 
-mulFuncName, divFuncName :: Symbol
+mulFuncName, divFuncName, modFuncName :: Symbol
 mulFuncName  = "SMTLIB_OP_MUL"
-divFuncName  = "SMTLIB_OP_DIV"
+divFuncName  = "HASKELL_DIV"
+modFuncName  = "HASKELL_MOD"
 
 isPrim :: Symbol -> Bool
 isPrim x = S.member x prims


### PR DESCRIPTION
This is a follow-up to ucsd-progsys/liquidhaskell#2733

I changed the `/` and `mod` operators to generate `HASKELL_DIV` and `HASKELL_MOD` respectively, which are defined as:

```z3
(define-fun HASKELL_DIV ((x Int) (y Int)) Int (ite (> y 0) (div x y) (- (div (- x) y)))
(define-fun HASKELL_MOD ((x Int) (y Int)) Int (ite (> y 0) (mod x y) (- (mod (- x) y)))
```

On the liquid-haskell side, once this is merged, `/` `mod` becomes the correct definitions for `div` and `mod`:
```haskell
define div x y        = (x / y)
define mod x y        = (x mod y)
```
On the other hand, definitions for `quot` and `rem` needs to be updated to e.g.
```haskell
define quot x y       = if (x >= 0) == (y >= 0) then abs x / abs y else -(abs x / abs y)
define rem x y        = if x >= 0 then (abs x) mod (abs y) else -((abs x) mod (abs y))
```