### PR TITLE
Support unicode syntax

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -546,6 +546,8 @@ _reservedOpNames =
   , "|-"
   , "::"
   , "."
+  -- unicode aliases
+  , "∷", "⇒", "→"
   ]
 
 {-
@@ -602,12 +604,23 @@ locReserved x =
 --
 reservedOp :: String -> ParserV v ()
 reservedOp x =
-  void $ lexeme (try (string x <* notFollowedBy opLetter))
+  void $ lexeme (try (string x <* notFollowedBy opLetter)
+    <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+  where
+    unicodeAlias "::"     = "∷"  -- U+2237
+    unicodeAlias "=>"     = "⇒" -- U+21D2
+    unicodeAlias "->"     = "→"  -- U+2192
+    unicodeAlias op = op
 
 reservedOp' :: Parser () -> String -> Parser ()
 reservedOp' spacesP x =
-  void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter))
-
+  void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter)
+        <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+  where
+    unicodeAlias "::"     = "∷"  -- U+2237
+    unicodeAlias "=>"     = "⇒" -- U+21D2
+    unicodeAlias "->"     = "→"  -- U+2192
+    unicodeAlias op = op
 
 -- | Parser that consumes the given symbol.
 --


### PR DESCRIPTION
To help fix LH Issue - ucsd-progsys/liquidhaskell#2551 'Liquid Haskell should accept UnicodeSyntax'.

Adding the changes to parser from this repo, and those in LH tests in LH repo.

Currently only added aliasing for unicode representations of `::`, `->`, `=>` as I found only those in the project, unlike Haskell which has support for other unicode characters as well.

Please check.

Thank you.