### PR TITLE
Support unicode syntax

### DIFF
--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -434,7 +434,7 @@ semi, comma, colon, dcolon, dot :: ParserV v String
 semi   = sym ";"
 comma  = sym ","
 colon  = sym ":" -- Note: not a reserved symbol; use with care
-dcolon = sym "::"<|> sym (unicodeAlias "::") -- Note: not a reserved symbol; use with care
+dcolon = sym "::"<|> maybe empty sym (unicodeAlias "::") -- Note: not a reserved symbol; use with care
 dot    = sym "." -- Note: not a reserved symbol; use with care
 
 -- | Parses a block via layout or explicit braces and semicolons.
@@ -602,22 +602,25 @@ locReserved x =
 -- NOTE: we currently don't double-check that the reserved operator is in the
 -- list of reserved operators.
 --
-
-unicodeAlias :: String -> String
-unicodeAlias "::" = "∷" -- U+2237
-unicodeAlias "=>" = "⇒" -- U+21D2
-unicodeAlias "->" = "→" -- U+2192
-unicodeAlias op   = op
-
 reservedOp :: String -> ParserV v ()
-reservedOp x =
-  void $ lexeme (try (string x <* notFollowedBy opLetter)
-    <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+reservedOp x = lexeme $ case unicodeAlias x of
+  Nothing -> reservedOpSingle x
+  Just y  -> reservedOpSingle x <|> reservedOpSingle y
+
+reservedOpSingle :: String -> ParserV v ()
+reservedOpSingle x = void $ try (string x <* notFollowedBy opLetter)
 
 reservedOp' :: Parser () -> String -> Parser ()
-reservedOp' spacesP x =
-  void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter)
-        <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+reservedOp' spacesP x = lexeme' spacesP $ case unicodeAlias x of
+  Nothing -> reservedOpSingle x
+  Just y  -> reservedOpSingle x <|> reservedOpSingle y
+
+{-# INLINE unicodeAlias #-}
+unicodeAlias :: String -> Maybe String
+unicodeAlias "::" = Just "∷" -- U+2237
+unicodeAlias "=>" = Just "⇒" -- U+21D2
+unicodeAlias "->" = Just "→" -- U+2192
+unicodeAlias _   = Nothing
 
 -- | Parser that consumes the given symbol.
 --

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -546,6 +546,8 @@ _reservedOpNames =
   , "|-"
   , "::"
   , "."
+  -- unicode aliases
+  , "∷", "⇒", "→"
   ]
 
 {-
@@ -602,12 +604,23 @@ locReserved x =
 --
 reservedOp :: String -> ParserV v ()
 reservedOp x =
-  void $ lexeme (try (string x <* notFollowedBy opLetter))
+  void $ lexeme (try (string x <* notFollowedBy opLetter)
+    <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+  where
+    unicodeAlias "::"     = "∷"  -- U+2237
+    unicodeAlias "=>"     = "⇒" -- U+21D2
+    unicodeAlias "->"     = "→"  -- U+2192
+    unicodeAlias op = op
 
 reservedOp' :: Parser () -> String -> Parser ()
 reservedOp' spacesP x =
-  void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter))
-
+  void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter)
+        <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
+  where
+    unicodeAlias "::"     = "∷"  -- U+2237
+    unicodeAlias "=>"     = "⇒" -- U+21D2
+    unicodeAlias "->"     = "→"  -- U+2192
+    unicodeAlias op = op
 
 -- | Parser that consumes the given symbol.
 --

--- a/src/Language/Fixpoint/Parse.hs
+++ b/src/Language/Fixpoint/Parse.hs
@@ -434,7 +434,7 @@ semi, comma, colon, dcolon, dot :: ParserV v String
 semi   = sym ";"
 comma  = sym ","
 colon  = sym ":" -- Note: not a reserved symbol; use with care
-dcolon = sym "::" -- Note: not a reserved symbol; use with care
+dcolon = sym "::"<|> sym (unicodeAlias "::") -- Note: not a reserved symbol; use with care
 dot    = sym "." -- Note: not a reserved symbol; use with care
 
 -- | Parses a block via layout or explicit braces and semicolons.
@@ -602,25 +602,22 @@ locReserved x =
 -- NOTE: we currently don't double-check that the reserved operator is in the
 -- list of reserved operators.
 --
+
+unicodeAlias :: String -> String
+unicodeAlias "::" = "∷" -- U+2237
+unicodeAlias "=>" = "⇒" -- U+21D2
+unicodeAlias "->" = "→" -- U+2192
+unicodeAlias op   = op
+
 reservedOp :: String -> ParserV v ()
 reservedOp x =
   void $ lexeme (try (string x <* notFollowedBy opLetter)
     <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
-  where
-    unicodeAlias "::"     = "∷"  -- U+2237
-    unicodeAlias "=>"     = "⇒" -- U+21D2
-    unicodeAlias "->"     = "→"  -- U+2192
-    unicodeAlias op = op
 
 reservedOp' :: Parser () -> String -> Parser ()
 reservedOp' spacesP x =
   void $ lexeme' spacesP (try (string x <* notFollowedBy opLetter)
         <|> try (string (unicodeAlias x) <* notFollowedBy opLetter))
-  where
-    unicodeAlias "::"     = "∷"  -- U+2237
-    unicodeAlias "=>"     = "⇒" -- U+21D2
-    unicodeAlias "->"     = "→"  -- U+2192
-    unicodeAlias op = op
 
 -- | Parser that consumes the given symbol.
 --

--- a/tests/pos/unicode.fq
+++ b/tests/pos/unicode.fq
@@ -1,0 +1,16 @@
+// Tests unicode operators
+
+fixpoint "--rewrite"
+fixpoint "--extensionality"
+fixpoint "--allowho"
+
+constant f : (func(0 , [int; int]))
+define f (x : int) : int = {(13)}
+
+expand [1 : True]
+
+constraint:
+  env []
+  lhs {VV1 : Tuple | true ⇒ true }
+  rhs {VV2 : Tuple | (f = \y : int → (13 ∷ int)) }
+  id 1 tag []

--- a/tests/tasty/ParserTests.hs
+++ b/tests/tasty/ParserTests.hs
@@ -180,11 +180,23 @@ testExpr0P =
     , testCase "ELam" $
         show (doParse' expr0P "test" "\\ foo : Int -> true") @?= "ELam (\"foo\",FInt) (PAnd [])"
 
+    , testCase "ELam unicode arrow" $
+        show (doParse' expr0P "test" "\\ foo : Int → true") @?= "ELam (\"foo\",FInt) (PAnd [])"
+
+    , testCase "arrow unicode == ASCII" $
+        show (doParse' expr0P "test" "\\ foo : Int → true") @?= show (doParse' expr0P "test" "\\ foo : Int -> true")
+
     , testCase "Expr" $
         show (doParse' expr0P "test" "(1)") @?= "ECon (I 1)"
 
     , testCase "ECst dcolon" $
         show (doParse' expr0P "test" "(1 :: Int)") @?= "ECst (ECon (I 1)) FInt"
+
+    , testCase "ECst unicode dcolon" $
+        show (doParse' expr0P "test" "(1 ∷ Int)") @?= "ECst (ECon (I 1)) FInt"
+
+    , testCase "dcolon unicode == ASCII" $
+        show (doParse' expr0P "test" "(1 ∷ Int)") @?= show (doParse' expr0P "test" "(1 :: Int)")
 
     , testCase "ECst colon" $
         show (doParse' expr0P "test" "(1 : Int)") @?= "ECst (ECon (I 1)) FInt"
@@ -270,6 +282,16 @@ testPredP =
 
     , testCase "|| 2" $
         show (doParse' predP "test" "|| [x;y]") @?= "POr [EVar \"x\",EVar \"y\"]"
+
+    , testCase "=>" $
+        show (doParse' exprP "test" "true => false") @?= "PImp (PAnd []) (POr [])"
+
+    , testCase "=> unicode" $
+        show (doParse' exprP "test" "true ⇒ false") @?= "PImp (PAnd []) (POr [])"
+
+    , testCase "=> unicode == ASCII" $
+        show (doParse' exprP "test" "true ⇒ false") @?= show (doParse' exprP "test" "true => false")
+
     ]
 
 


### PR DESCRIPTION
I've added the tests and modified the instance at `dcolon`.
Also checked for other places where the unicode usage of `::, ->, =>` might matter. I think these are all of them.
Please check and give me your feedback.

Thank you.